### PR TITLE
Fix conan-mpusz remote URL

### DIFF
--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -24,7 +24,7 @@ steps may be done:
 - add the following remotes to your local `conan` instance
 
   ```bash
-  $ conan remote add conan-mpusz https://bintray.com/mpusz/conan-mpusz
+  $ conan remote add conan-mpusz https://api.bintray.com/conan/mpusz/conan-mpusz
   $ conan remote add conan-nonstd https://api.bintray.com/conan/martinmoene/nonstd-lite
   ```
 


### PR DESCRIPTION
The previous remote URL did not work, so use the URL specified on the Bintray website.

 * doc/INSTALL.md: Fix conan-mpusz remote URL