### PR TITLE
Made quantity_cast more versatile

### DIFF
--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -135,10 +135,20 @@ namespace units {
     return cast::cast(q);
   }
 
-  template<Unit ToU, Scalar ToRep = double, typename U, typename Rep>
+  template<Unit ToU, Scalar ToRep, typename U, typename Rep>
   constexpr quantity<ToU, ToRep> quantity_cast(const quantity<U, Rep>& q)
   {
     return quantity_cast<quantity<ToU, ToRep>>(q);
+  }
+  template<Unit ToU, typename U, typename Rep>
+  constexpr quantity<ToU, Rep> quantity_cast(const quantity<U, Rep>& q)
+  {
+    return quantity_cast<quantity<ToU, Rep>>(q);
+  }
+  template<Scalar ToRep, typename U, typename Rep>
+  constexpr quantity<U, ToRep> quantity_cast(const quantity<U, Rep>& q)
+  {
+    return quantity_cast<quantity<U, ToRep>>(q);
   }
 
 

--- a/test/unit_test/test_quantity.cpp
+++ b/test/unit_test/test_quantity.cpp
@@ -63,6 +63,10 @@ namespace units {
 namespace std {
 
   template<typename T, typename U>
+  struct common_type<my_value<T>, my_value<U>> : common_type<T, U> {
+  };
+
+  template<typename T, typename U>
   struct common_type<my_value<T>, U> : common_type<T, U> {
   };
 


### PR DESCRIPTION
- The standard cast no longer changes the representation type.
- One can change the unit type without changing the representation type.
- One can change the representation type without changing the unit type.