### PR TITLE
implementing ratio<num,den,exp> which replaces ratio<num,den>

### DIFF
--- a/src/include/units/bits/base_units_ratio.h
+++ b/src/include/units/bits/base_units_ratio.h
@@ -32,7 +32,7 @@ template<Exponent E>
   requires (E::den == 1 || E::den == 2) // TODO provide support for any den
 struct exp_ratio {
   using base_ratio = E::dimension::base_unit::ratio;
-  using positive_ratio = conditional<E::num * E::den < 0, ratio<base_ratio::den, base_ratio::num>, base_ratio>;
+  using positive_ratio = conditional<E::num * E::den < 0, ratio<base_ratio::den, base_ratio::num, -base_ratio::exp>, base_ratio>;
   static constexpr std::int64_t N = E::num * E::den < 0 ? -E::num : E::num;
   using pow = ratio_pow<positive_ratio, N>;
   using type = conditional<E::den == 2, ratio_sqrt<pow>, pow>;

--- a/src/include/units/bits/unit_text.h
+++ b/src/include/units/bits/unit_text.h
@@ -29,13 +29,19 @@ namespace units::detail {
 template<typename Ratio>
 constexpr auto ratio_text()
 {
-  if constexpr(Ratio::num != 1 || Ratio::den != 1) {
+  if constexpr(Ratio::num != 1 || Ratio::den != 1 || Ratio::exp != 0) {
     auto txt = basic_fixed_string("[") + regular<Ratio::num>();
-    if constexpr(Ratio::den == 1) {
+    if constexpr(Ratio::den == 1 && Ratio::exp == 0) {
       return txt + basic_fixed_string("]");
     }
+    else if constexpr (Ratio::den == 1) {
+      return txt + basic_fixed_string(" x 10") + superscript<Ratio::exp>() +
+          basic_fixed_string("]");
+    }
     else {
-      return txt + basic_fixed_string("/") + regular<Ratio::den>() + basic_fixed_string("]");
+      return txt + basic_fixed_string("/") + regular<Ratio::den>() +
+          basic_fixed_string(" x 10") + superscript<Ratio::exp>() +
+          basic_fixed_string("]");
     }
   }
   else {
@@ -46,7 +52,7 @@ constexpr auto ratio_text()
 template<typename Ratio, typename PrefixType>
 constexpr auto prefix_or_ratio_text()
 {
-  if constexpr(Ratio::num == 1 && Ratio::den == 1) {
+  if constexpr(Ratio::num == 1 && Ratio::den == 1 && Ratio::exp == 0) {
     // no ratio/prefix
     return basic_fixed_string("");
   }

--- a/src/include/units/bits/unit_text.h
+++ b/src/include/units/bits/unit_text.h
@@ -35,12 +35,12 @@ constexpr auto ratio_text()
       return txt + basic_fixed_string("]");
     }
     else if constexpr (Ratio::den == 1) {
-      return txt + basic_fixed_string(" x 10") + superscript<Ratio::exp>() +
+      return txt + basic_fixed_string(" \u00D7 10") + superscript<Ratio::exp>() +
           basic_fixed_string("]");
     }
     else {
       return txt + basic_fixed_string("/") + regular<Ratio::den>() +
-          basic_fixed_string(" x 10") + superscript<Ratio::exp>() +
+          basic_fixed_string(" \u00D7 10") + superscript<Ratio::exp>() +
           basic_fixed_string("]");
     }
   }

--- a/src/include/units/physical/si/prefixes.h
+++ b/src/include/units/physical/si/prefixes.h
@@ -23,31 +23,32 @@
 #pragma once
 
 #include <units/prefix.h>
-#include <ratio>
 
 namespace units::si {
 
 struct prefix : prefix_type {};
 
-// TODO Remove dependency on std::ratio
-
 // clang-format off
-struct atto   : units::prefix<atto,   prefix, "a",      ratio<1, 1, -18>> {}; // std::atto::den>> {};
-struct femto  : units::prefix<femto,  prefix, "f",      ratio<1, 1, -15>> {}; // std::femto::den>> {};
-struct pico   : units::prefix<pico,   prefix, "p",      ratio<1, 1, -12>> {}; // std::pico::den>> {};
-struct nano   : units::prefix<nano,   prefix, "n",      ratio<1, 1,  -9>> {}; // std::nano::den>> {};
-struct micro  : units::prefix<micro,  prefix, "\u00b5", ratio<1, 1,  -6>> {}; // std::micro::den>> {};
-struct milli  : units::prefix<milli,  prefix, "m",      ratio<1, 1,  -3>> {}; // std::milli::den>> {};
-struct centi  : units::prefix<centi,  prefix, "c",      ratio<1, 1,  -2>> {}; // std::centi::den>> {};
-struct deci   : units::prefix<deci,   prefix, "d",      ratio<1, 1,  -1>> {}; // std::deci::den>> {};
-struct deca   : units::prefix<deca,   prefix, "da",     ratio<1, 1,   1>> {}; // std::deca::num>> {};
-struct hecto  : units::prefix<hecto,  prefix, "h",      ratio<1, 1,   2>> {}; // std::hecto::num>> {};
-struct kilo   : units::prefix<kilo,   prefix, "k",      ratio<1, 1,   3>> {}; // std::kilo::num>> {};
-struct mega   : units::prefix<mega,   prefix, "M",      ratio<1, 1,   6>> {}; // std::mega::num>> {};
-struct giga   : units::prefix<giga,   prefix, "G",      ratio<1, 1,   9>> {}; // std::giga::num>> {};
-struct tera   : units::prefix<tera,   prefix, "T",      ratio<1, 1,  12>> {}; // std::tera::num>> {};
-struct peta   : units::prefix<peta,   prefix, "P",      ratio<1, 1,  15>> {}; // std::peta::num>> {};
-struct exa    : units::prefix<exa,    prefix, "E",      ratio<1, 1,  18>> {}; // std::exa::num>> {};
-// clang-format off
+struct yocto  : units::prefix<yocto,  prefix, "y",      ratio<1, 1, -24>> {};
+struct zepto  : units::prefix<zepto,  prefix, "z",      ratio<1, 1, -21>> {};
+struct atto   : units::prefix<atto,   prefix, "a",      ratio<1, 1, -18>> {};
+struct femto  : units::prefix<femto,  prefix, "f",      ratio<1, 1, -15>> {};
+struct pico   : units::prefix<pico,   prefix, "p",      ratio<1, 1, -12>> {};
+struct nano   : units::prefix<nano,   prefix, "n",      ratio<1, 1,  -9>> {};
+struct micro  : units::prefix<micro,  prefix, "\u00b5", ratio<1, 1,  -6>> {};
+struct milli  : units::prefix<milli,  prefix, "m",      ratio<1, 1,  -3>> {};
+struct centi  : units::prefix<centi,  prefix, "c",      ratio<1, 1,  -2>> {};
+struct deci   : units::prefix<deci,   prefix, "d",      ratio<1, 1,  -1>> {};
+struct deca   : units::prefix<deca,   prefix, "da",     ratio<1, 1,   1>> {};
+struct hecto  : units::prefix<hecto,  prefix, "h",      ratio<1, 1,   2>> {};
+struct kilo   : units::prefix<kilo,   prefix, "k",      ratio<1, 1,   3>> {};
+struct mega   : units::prefix<mega,   prefix, "M",      ratio<1, 1,   6>> {};
+struct giga   : units::prefix<giga,   prefix, "G",      ratio<1, 1,   9>> {};
+struct tera   : units::prefix<tera,   prefix, "T",      ratio<1, 1,  12>> {};
+struct peta   : units::prefix<peta,   prefix, "P",      ratio<1, 1,  15>> {};
+struct exa    : units::prefix<exa,    prefix, "E",      ratio<1, 1,  18>> {};
+struct zetta  : units::prefix<zetta,  prefix, "Z",      ratio<1, 1,  21>> {};
+struct yotta  : units::prefix<yotta,  prefix, "Y",      ratio<1, 1,  24>> {};
+// clang-format on
 
 }  // namespace units::si

--- a/src/include/units/physical/si/prefixes.h
+++ b/src/include/units/physical/si/prefixes.h
@@ -31,21 +31,23 @@ struct prefix : prefix_type {};
 
 // TODO Remove dependency on std::ratio
 
-struct atto : units::prefix<atto, prefix, "a", ratio<1, std::atto::den>> {};
-struct femto : units::prefix<femto, prefix, "f", ratio<1, std::femto::den>> {};
-struct pico : units::prefix<pico, prefix, "p", ratio<1, std::pico::den>> {};
-struct nano : units::prefix<nano, prefix, "n", ratio<1, std::nano::den>> {};
-struct micro : units::prefix<micro, prefix, "\u00b5", ratio<1, std::micro::den>> {};
-struct milli : units::prefix<milli, prefix, "m", ratio<1, std::milli::den>> {};
-struct centi : units::prefix<centi, prefix, "c", ratio<1, std::centi::den>> {};
-struct deci : units::prefix<deci, prefix, "d", ratio<1, std::deci::den>> {};
-struct deca : units::prefix<deca, prefix, "da", ratio<std::deca::num>> {};
-struct hecto : units::prefix<hecto, prefix, "h", ratio<std::hecto::num>> {};
-struct kilo : units::prefix<kilo, prefix, "k", ratio<std::kilo::num>> {};
-struct mega : units::prefix<mega, prefix, "M", ratio<std::mega::num>> {};
-struct giga : units::prefix<giga, prefix, "G", ratio<std::giga::num>> {};
-struct tera : units::prefix<tera, prefix, "T", ratio<std::tera::num>> {};
-struct peta : units::prefix<peta, prefix, "P", ratio<std::peta::num>> {};
-struct exa : units::prefix<exa, prefix, "E", ratio<std::exa::num>> {};
+// clang-format off
+struct atto   : units::prefix<atto,   prefix, "a",      ratio<1, 1, -18>> {}; // std::atto::den>> {};
+struct femto  : units::prefix<femto,  prefix, "f",      ratio<1, 1, -15>> {}; // std::femto::den>> {};
+struct pico   : units::prefix<pico,   prefix, "p",      ratio<1, 1, -12>> {}; // std::pico::den>> {};
+struct nano   : units::prefix<nano,   prefix, "n",      ratio<1, 1,  -9>> {}; // std::nano::den>> {};
+struct micro  : units::prefix<micro,  prefix, "\u00b5", ratio<1, 1,  -6>> {}; // std::micro::den>> {};
+struct milli  : units::prefix<milli,  prefix, "m",      ratio<1, 1,  -3>> {}; // std::milli::den>> {};
+struct centi  : units::prefix<centi,  prefix, "c",      ratio<1, 1,  -2>> {}; // std::centi::den>> {};
+struct deci   : units::prefix<deci,   prefix, "d",      ratio<1, 1,  -1>> {}; // std::deci::den>> {};
+struct deca   : units::prefix<deca,   prefix, "da",     ratio<1, 1,   1>> {}; // std::deca::num>> {};
+struct hecto  : units::prefix<hecto,  prefix, "h",      ratio<1, 1,   2>> {}; // std::hecto::num>> {};
+struct kilo   : units::prefix<kilo,   prefix, "k",      ratio<1, 1,   3>> {}; // std::kilo::num>> {};
+struct mega   : units::prefix<mega,   prefix, "M",      ratio<1, 1,   6>> {}; // std::mega::num>> {};
+struct giga   : units::prefix<giga,   prefix, "G",      ratio<1, 1,   9>> {}; // std::giga::num>> {};
+struct tera   : units::prefix<tera,   prefix, "T",      ratio<1, 1,  12>> {}; // std::tera::num>> {};
+struct peta   : units::prefix<peta,   prefix, "P",      ratio<1, 1,  15>> {}; // std::peta::num>> {};
+struct exa    : units::prefix<exa,    prefix, "E",      ratio<1, 1,  18>> {}; // std::exa::num>> {};
+// clang-format off
 
 }  // namespace units::si

--- a/src/include/units/prefix.h
+++ b/src/include/units/prefix.h
@@ -30,14 +30,14 @@ namespace units {
 
 /**
  * @brief The base for all prefix types
- * 
+ *
  * Every prefix type should inherit from this type to satisfy PrefixType concept.
  */
 struct prefix_type {};
 
 /**
  * @brief No prefix possible for the unit
- * 
+ *
  * This is a special prefix type tag specifying that the unit can not be scaled with any kind
  * of the prefix.
  */
@@ -55,14 +55,14 @@ struct prefix_base : downcast_base<prefix_base<PT, R>> {
 
 /**
  * @brief A prefix used to scale units
- * 
+ *
  * Data from a prefix class is used in two cases:
  * - when defining a prefixed_unit its ratio is used to scale the reference unit and its
  *   symbol is used to prepend to the symbol of referenced unit
  * - when printing the symbol of a scaled unit that was not predefined by the user but its
  *   factor matches ratio of a prefix from the specified prefix family, its symbol will be
  *   prepended to the symbol of the unit
- * 
+ *
  * @tparam Child inherited class type used by the downcasting facility (CRTP Idiom)
  * @tparam PT a type of prefix family
  * @tparam Symbol a text representation of the prefix
@@ -70,7 +70,7 @@ struct prefix_base : downcast_base<prefix_base<PT, R>> {
  */
 template<typename Child, PrefixType PT, basic_fixed_string Symbol, Ratio R>
   requires (!std::same_as<PT, no_prefix>)
-struct prefix : downcast_child<Child, detail::prefix_base<PT, ratio<R::num, R::den>>> {
+struct prefix : downcast_child<Child, detail::prefix_base<PT, ratio<R::num, R::den, R::exp>>> {
   static constexpr auto symbol = Symbol;
 };
 

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -353,7 +353,11 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
 {
   using common_rep = decltype(lhs.count() * rhs.count());
   using ratio = ratio_multiply<typename U1::ratio, typename U2::ratio>;
-  return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * std::pow(10, common_rep(ratio::exp)) / common_rep(ratio::den);
+    if constexpr (treat_as_floating_point<common_rep>) {
+      return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * fpow10(ratio::exp) / common_rep(ratio::den);
+    } else {
+      return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * ipow10(ratio::exp) / common_rep(ratio::den);
+    }
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -32,6 +32,7 @@
 #endif
 
 #include <ostream>
+#include <iostream>
 
 namespace units {
 
@@ -51,10 +52,10 @@ concept safe_divisible = // exposition only
 
 /**
  * @brief A quantity
- * 
+ *
  * Property of a phenomenon, body, or substance, where the property has a magnitude that can be
  * expressed by means of a number and a measurement unit.
- * 
+ *
  * @tparam D a dimension of the quantity (can be either a BaseDimension or a DerivedDimension)
  * @tparam U a measurement unit of the quantity
  * @tparam Rep a type to be used to represent values of a quantity
@@ -352,7 +353,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
 {
   using common_rep = decltype(lhs.count() * rhs.count());
   using ratio = ratio_multiply<typename U1::ratio, typename U2::ratio>;
-  return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) / common_rep(ratio::den);
+  return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * std::pow(10, common_rep(ratio::exp)) / common_rep(ratio::den);
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
@@ -376,7 +377,7 @@ template<Scalar Value, typename D, typename U, typename Rep>
   Expects(q.count() != 0);
 
   using dim = dim_invert<D>;
-  using ratio = ratio<U::ratio::den, U::ratio::num>;
+  using ratio = ratio<U::ratio::den, U::ratio::num, -U::ratio::exp>;
   using unit = downcast_unit<dim, ratio>;
   using common_rep = decltype(v / q.count());
   using ret = quantity<dim, unit, common_rep>;

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -1,3 +1,4 @@
+
 // The MIT License (MIT)
 //
 // Copyright (c) 2018 Mateusz Pusz
@@ -32,7 +33,6 @@
 #endif
 
 #include <ostream>
-#include <iostream>
 
 namespace units {
 

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -296,7 +296,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "8 [1 x 10⁻²]m³");
+        CHECK(stream.str() == "8 [1 \u00D7 10⁻²]m³");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -317,7 +317,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "2 [6 x 10¹]Hz");
+        CHECK(stream.str() == "2 [6 \u00D7 10¹]Hz");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -338,7 +338,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "10 [1/6 x 10⁻¹]W");
+        CHECK(stream.str() == "10 [1/6 \u00D7 10⁻¹]W");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -359,7 +359,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "30 [1/6 x 10²]W");
+        CHECK(stream.str() == "30 [1/6 \u00D7 10²]W");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -404,7 +404,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "8 [1 x 10³]m⋅s");
+        CHECK(stream.str() == "8 [1 \u00D7 10³]m⋅s");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -425,7 +425,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "2 [6 x 10¹]kg/s");
+        CHECK(stream.str() == "2 [6 \u00D7 10¹]kg/s");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -446,7 +446,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "10 [1/6 x 10⁻¹]kg/s");
+        CHECK(stream.str() == "10 [1/6 \u00D7 10⁻¹]kg/s");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -467,7 +467,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "30 [6 x 10⁻²]1/m⋅s");
+        CHECK(stream.str() == "30 [6 \u00D7 10⁻²]1/m⋅s");
       }
 
       SECTION("fmt with default format {} on a quantity")

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -110,7 +110,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
   {
     SECTION("in terms of base units")
     {
-      const length<scaled_unit<ratio<1'000'000>, metre>> q(123);
+      const length<scaled_unit<ratio<1, 1, 6>, metre>> q(123);
       stream << q;
 
       SECTION("iostream")
@@ -131,7 +131,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
     SECTION("in terms of derived units")
     {
-      const energy<scaled_unit<ratio<1, 100>, joule>> q(60);
+      const energy<scaled_unit<ratio<1, 1, -2>, joule>> q(60);
       stream << q;
 
       SECTION("iostream")
@@ -296,7 +296,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "8 [1/100]m³");
+        CHECK(stream.str() == "8 [1 x 10⁻²]m³");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -317,7 +317,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "2 [60]Hz");
+        CHECK(stream.str() == "2 [6 x 10¹]Hz");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -338,7 +338,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "10 [1/60]W");
+        CHECK(stream.str() == "10 [1/6 x 10⁻¹]W");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -359,7 +359,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "30 [50/3]W");
+        CHECK(stream.str() == "30 [1/6 x 10²]W");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -404,7 +404,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "8 [1000]m⋅s");
+        CHECK(stream.str() == "8 [1 x 10³]m⋅s");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -425,7 +425,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "2 [60]kg/s");
+        CHECK(stream.str() == "2 [6 x 10¹]kg/s");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -446,7 +446,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "10 [1/60]kg/s");
+        CHECK(stream.str() == "10 [1/6 x 10⁻¹]kg/s");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -467,7 +467,7 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(stream.str() == "30 [3/50]1/m⋅s");
+        CHECK(stream.str() == "30 [6 x 10⁻²]1/m⋅s");
       }
 
       SECTION("fmt with default format {} on a quantity")
@@ -693,7 +693,7 @@ TEST_CASE("%q an %Q can be put anywhere in a format string", "[text][fmt]")
 
 TEST_CASE("fill and align specification", "[text][fmt]")
 {
-  SECTION("default format {} on a quantity") 
+  SECTION("default format {} on a quantity")
   {
     CHECK(fmt::format("|{:0}|", 123m) == "|123 m|");
     CHECK(fmt::format("|{:10}|", 123m) == "|     123 m|");
@@ -716,8 +716,8 @@ TEST_CASE("fill and align specification", "[text][fmt]")
     CHECK(fmt::format("|{:*>10%Q%q}|", 123m) == "|******123m|");
     CHECK(fmt::format("|{:*^10%Q%q}|", 123m) == "|***123m***|");
   }
-  
-  SECTION("value only format {:%Q} on a quantity") 
+
+  SECTION("value only format {:%Q} on a quantity")
   {
     CHECK(fmt::format("|{:0%Q}|", 123m) == "|123|");
     CHECK(fmt::format("|{:10%Q}|", 123m) == "|       123|");
@@ -729,7 +729,7 @@ TEST_CASE("fill and align specification", "[text][fmt]")
     CHECK(fmt::format("|{:*^10%Q}|", 123m) == "|***123****|");
   }
 
-  SECTION("symbol only format {:%q} on a quantity") 
+  SECTION("symbol only format {:%q} on a quantity")
   {
     CHECK(fmt::format("|{:0%q}|", 123m) == "|m|");
     CHECK(fmt::format("|{:10%q}|", 123m) == "|m         |");
@@ -747,7 +747,7 @@ TEST_CASE("sign specification", "[text][fmt]")
   length<metre> inf(std::numeric_limits<double>::infinity());
   length<metre> nan(std::numeric_limits<double>::quiet_NaN());
 
-  SECTION("default format {} on a quantity") 
+  SECTION("default format {} on a quantity")
   {
     CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", 1m) == "1 m,+1 m,1 m, 1 m");
     CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", -1m) == "-1 m,-1 m,-1 m,-1 m");
@@ -755,7 +755,7 @@ TEST_CASE("sign specification", "[text][fmt]")
     CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", nan) == "nan m,+nan m,nan m, nan m");
   }
 
-  SECTION("full format {:%Q %q} on a quantity") 
+  SECTION("full format {:%Q %q} on a quantity")
   {
     CHECK(fmt::format("{0:%Q%q},{0:+%Q%q},{0:-%Q%q},{0: %Q%q}", 1m) == "1m,+1m,1m, 1m");
     CHECK(fmt::format("{0:%Q%q},{0:+%Q%q},{0:-%Q%q},{0: %Q%q}", -1m) == "-1m,-1m,-1m,-1m");
@@ -763,7 +763,7 @@ TEST_CASE("sign specification", "[text][fmt]")
     CHECK(fmt::format("{0:%Q%q},{0:+%Q%q},{0:-%Q%q},{0: %Q%q}", nan) == "nanm,+nanm,nanm, nanm");
   }
 
-  SECTION("value only format {:%Q} on a quantity") 
+  SECTION("value only format {:%Q} on a quantity")
   {
     CHECK(fmt::format("{0:%Q},{0:+%Q},{0:-%Q},{0: %Q}", 1m) == "1,+1,1, 1");
     CHECK(fmt::format("{0:%Q},{0:+%Q},{0:-%Q},{0: %Q}", -1m) == "-1,-1,-1,-1");
@@ -781,7 +781,7 @@ TEST_CASE("sign specification for unit only", "[text][fmt][exception]")
 
 TEST_CASE("precision specification", "[text][fmt]")
 {
-  SECTION("default format {} on a quantity") 
+  SECTION("default format {} on a quantity")
   {
     CHECK(fmt::format("{:.1}", 1.2345m) == "1.2 m");
     CHECK(fmt::format("{:.0}", 1.2345m) == "1 m");
@@ -792,7 +792,7 @@ TEST_CASE("precision specification", "[text][fmt]")
     CHECK(fmt::format("{:.10}", 1.2345m) == "1.2345000000 m");
   }
 
-  SECTION("full format {:%Q %q} on a quantity") 
+  SECTION("full format {:%Q %q} on a quantity")
   {
     CHECK(fmt::format("{:.0%Q %q}", 1.2345m) == "1 m");
     CHECK(fmt::format("{:.1%Q %q}", 1.2345m) == "1.2 m");
@@ -803,7 +803,7 @@ TEST_CASE("precision specification", "[text][fmt]")
     CHECK(fmt::format("{:.10%Q %q}", 1.2345m) == "1.2345000000 m");
   }
 
-  SECTION("value only format {:%Q} on a quantity") 
+  SECTION("value only format {:%Q} on a quantity")
   {
     CHECK(fmt::format("{:.0%Q}", 1.2345m) == "1");
     CHECK(fmt::format("{:.1%Q}", 1.2345m) == "1.2");
@@ -817,17 +817,17 @@ TEST_CASE("precision specification", "[text][fmt]")
 
 TEST_CASE("precision specification for integral representation should throw", "[text][fmt][exception]")
 {
-  SECTION("default format {} on a quantity") 
+  SECTION("default format {} on a quantity")
   {
     REQUIRE_THROWS_MATCHES(fmt::format("{:.1}", 1m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
   }
 
-  SECTION("full format {:%Q %q} on a quantity") 
+  SECTION("full format {:%Q %q} on a quantity")
   {
     REQUIRE_THROWS_MATCHES(fmt::format("{:.1%Q %q}", 1m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
   }
 
-  SECTION("value only format {:%Q} on a quantity") 
+  SECTION("value only format {:%Q} on a quantity")
   {
     REQUIRE_THROWS_MATCHES(fmt::format("{:.1%Q}", 1m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
   }

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -160,6 +160,7 @@ static_assert(length<metre, int>(1km).count() == 1000);
 // static_assert(length<metre, int>(1s).count() == 1);   // should not compile (different dimensions)
 //static_assert(length<kilometre, int>(1010m).count() == 1);   // should not compile (truncating conversion)
 static_assert(length<kilometre, int>(quantity_cast<length<kilometre, my_int>>(1010m)).count() == 1);
+static_assert(length<metre, int>(quantity_cast<length<kilometre, my_int>>(1010m)).count() == 1000);
 
 // assignment operator
 
@@ -236,23 +237,23 @@ static_assert(std::is_same_v<decltype(1.0 * length<metre, int>()), length<metre,
 static_assert(
     std::is_same_v<decltype(velocity<metre_per_second, int>() * si::time<second, int>()), length<metre, int>>);
 static_assert(
-    std::is_same_v<decltype(velocity<metre_per_second, int>() * si::time<hour, int>()), length<scaled_unit<ratio<3600>, metre>, int>>);
+    std::is_same_v<decltype(velocity<metre_per_second, int>() * si::time<hour, int>()), length<scaled_unit<ratio<36, 1, 2>, metre>, int>>);
 static_assert(std::is_same_v<decltype(length<metre>() * si::time<minute>()),
-                             quantity<unknown_dimension<units::exp<dim_length, 1>, units::exp<dim_time, 1>>, scaled_unit<ratio<60>, unknown_unit>>>);
+              quantity<unknown_dimension<units::exp<dim_length, 1>, units::exp<dim_time, 1>>, scaled_unit<ratio<6, 1, 1>, unknown_unit>>>);
 static_assert(std::is_same_v<decltype(1 / si::time<second, int>()), frequency<hertz, int>>);
-static_assert(std::is_same_v<decltype(1 / si::time<minute, int>()), frequency<scaled_unit<ratio<1, 60>, hertz>, int>>);
+static_assert(std::is_same_v<decltype(1 / si::time<minute, int>()), frequency<scaled_unit<ratio<1, 6, -1>, hertz>, int>>);
 static_assert(std::is_same_v<decltype(1 / frequency<hertz, int>()), si::time<second, int>>);
 static_assert(std::is_same_v<decltype(1 / length<kilometre>()),
-                             quantity<unknown_dimension<units::exp<dim_length, -1>>, scaled_unit<ratio<1, 1000>, unknown_unit>>>);
+              quantity<unknown_dimension<units::exp<dim_length, -1>>, scaled_unit<ratio<1, 1, -3>, unknown_unit>>>);
 static_assert(std::is_same_v<decltype(length<metre, int>() / 1.0), length<metre, double>>);
 static_assert(std::is_same_v<decltype(length<metre, int>() / length<metre, double>()), double>);
 static_assert(std::is_same_v<decltype(length<kilometre, int>() / length<metre, double>()), double>);
 static_assert(
     std::is_same_v<decltype(length<metre, int>() / si::time<second, int>()), velocity<metre_per_second, int>>);
 static_assert(
-    std::is_same_v<decltype(length<metre>() / si::time<minute>()), velocity<scaled_unit<ratio<1, 60>, metre_per_second>>>);
+    std::is_same_v<decltype(length<metre>() / si::time<minute>()), velocity<scaled_unit<ratio<1, 6, -1>, metre_per_second>>>);
 static_assert(std::is_same_v<decltype(si::time<minute>() / length<metre>()),
-                             quantity<unknown_dimension<units::exp<dim_length, -1>, units::exp<dim_time, 1>>, scaled_unit<ratio<60>, unknown_unit>>>);
+              quantity<unknown_dimension<units::exp<dim_length, -1>, units::exp<dim_time, 1>>, scaled_unit<ratio<6 ,1 , 1>, unknown_unit>>>);
 static_assert(std::is_same_v<decltype(length<metre, int>() % short(1)), length<metre, int>>);
 static_assert(std::is_same_v<decltype(length<metre, int>() % length<metre, short>(1)), length<metre, int>>);
 

--- a/test/unit_test/static/ratio_test.cpp
+++ b/test/unit_test/static/ratio_test.cpp
@@ -27,9 +27,15 @@
   using namespace units;
 
   template<Ratio R1, Ratio R2>
-  inline constexpr bool same = R1::num == R2::num && R1::den == R2::den;
+  inline constexpr bool same = R1::num == R2::num && R1::den == R2::den && R1::exp == R2::exp;
 
   static_assert(same<ratio<2, 4>, ratio<1, 2>>);
+
+  // basic exponents tests
+  // note use of ::type is required because template params are changed while stamping out template
+  static_assert(std::is_same_v<ratio<2, 40, 1>::type, ratio<1, 20, 1>::type>);
+  static_assert(std::is_same_v<ratio<20, 4, -1>::type, ratio<10, 2, -1>::type>);
+  static_assert(std::is_same_v<ratio<200, 5>::type, ratio<20'000, 50, -1>::type>);
 
   static_assert(std::is_same_v<ratio_multiply<ratio<1>, ratio<3, 8>>, ratio<3, 8>>);
   static_assert(std::is_same_v<ratio_multiply<ratio<3, 8>, ratio<1>>, ratio<3, 8>>);
@@ -38,10 +44,18 @@
   static_assert(std::is_same_v<ratio_multiply<ratio<1, 8>, ratio<2>>, ratio<1, 4>>);
   static_assert(std::is_same_v<ratio_multiply<ratio<1, 2>, ratio<8>>, ratio<4>>);
 
+  // multiply with exponents
+  static_assert(std::is_same_v<ratio_multiply<ratio<1, 8, 2>, ratio<2, 1, 4>>, ratio<1, 4, 6>>);
+  static_assert(std::is_same_v<ratio_multiply<ratio<1, 2, -4>, ratio<8, 1, 3>>, ratio<4, 1, -1>>);
+
   static_assert(std::is_same_v<ratio_divide<ratio<4>, ratio<2>>, ratio<2>>);
   static_assert(std::is_same_v<ratio_divide<ratio<2>, ratio<8>>, ratio<1, 4>>);
   static_assert(std::is_same_v<ratio_divide<ratio<1, 8>, ratio<2>>, ratio<1, 16>>);
   static_assert(std::is_same_v<ratio_divide<ratio<6>, ratio<3>>, ratio<2>>);
+
+  // divide with exponents
+  static_assert(std::is_same_v<ratio_divide<ratio<1, 8, -6>, ratio<2, 1, -8>>, ratio<1, 16, 2>>);
+  static_assert(std::is_same_v<ratio_divide<ratio<6, 1, 4>, ratio<3>>, ratio<2, 1, 4>>);
 
   static_assert(std::is_same_v<ratio_pow<ratio<2>, 0>, ratio<1>>);
   static_assert(std::is_same_v<ratio_pow<ratio<2>, 1>, ratio<2>>);
@@ -52,17 +66,33 @@
   static_assert(std::is_same_v<ratio_pow<ratio<1, 2>, 2>, ratio<1, 4>>);
   static_assert(std::is_same_v<ratio_pow<ratio<1, 2>, 3>, ratio<1, 8>>);
 
+  // pow with exponents
+  static_assert(std::is_same_v<ratio_pow<ratio<1, 2, 3>, 2>, ratio<1, 4, 6>>);
+  static_assert(std::is_same_v<ratio_pow<ratio<1, 2, -6>, 3>, ratio<1, 8, -18>>);
+
   static_assert(std::is_same_v<ratio_sqrt<ratio<9>>, ratio<3>>);
   static_assert(std::is_same_v<ratio_sqrt<ratio<4>>, ratio<2>>);
   static_assert(std::is_same_v<ratio_sqrt<ratio<1>>, ratio<1>>);
   static_assert(std::is_same_v<ratio_sqrt<ratio<0>>, ratio<0>>);
   static_assert(std::is_same_v<ratio_sqrt<ratio<1, 4>>, ratio<1, 2>>);
 
-  // common_ratio
+  // // sqrt with exponents: TODO not working yet. Also not sure the non exponent version is accurate.
+  // static_assert(std::is_same_v<ratio_sqrt<ratio<9, 1, 2>>, ratio<3, 1, 1>>);
+  // static_assert(std::is_same_v<ratio_sqrt<ratio<4>>, ratio<2>>);
 
-  static_assert(std::is_same_v<common_ratio<ratio<1>, ratio<1000>>, ratio<1>>);
-  static_assert(std::is_same_v<common_ratio<ratio<1000>, ratio<1>>, ratio<1>>);
-  static_assert(std::is_same_v<common_ratio<ratio<1>, ratio<1, 1000>>, ratio<1, 1000>>);
-  static_assert(std::is_same_v<common_ratio<ratio<1, 1000>, ratio<1>>, ratio<1, 1000>>);
+  // common_ratio
+  // note use of ::type is required because template params are changed while stamping out template
+  static_assert(std::is_same_v<common_ratio<ratio<1>::type, ratio<1000>>, ratio<1>::type>);
+  static_assert(std::is_same_v<common_ratio<ratio<1000>, ratio<1>>::type, ratio<1>::type>);
+  static_assert(std::is_same_v<common_ratio<ratio<1>, ratio<1, 1000>>::type, ratio<1, 1000>::type>);
+  static_assert(std::is_same_v<common_ratio<ratio<1, 1000>, ratio<1>>::type, ratio<1, 1000>::type>);
+  static_assert(std::is_same_v<common_ratio<ratio<100, 1>, ratio<10, 1>>::type, ratio<10, 1>::type>);
+  static_assert(std::is_same_v<common_ratio<ratio<100, 1>, ratio<1, 10>>::type, ratio<1, 10>::type>);
+
+  // common ratio with exponents
+  static_assert(std::is_same_v<common_ratio<ratio<1>, ratio<1, 1, 3>>::type, ratio<1>::type>);
+  static_assert(std::is_same_v<common_ratio<ratio<10, 1, -1>, ratio<1, 1, -3>>::type, ratio<1, 1, -3>::type>);
+
+
 
   }  // namespace

--- a/test/unit_test/static/si_test.cpp
+++ b/test/unit_test/static/si_test.cpp
@@ -192,7 +192,7 @@ static_assert(10V * 1F == 10C);
 
 // velocity
 
-static_assert(std::is_same_v<decltype(1km / 1s), velocity<scaled_unit<ratio<1000>, metre_per_second>, std::int64_t>>);
+static_assert(std::is_same_v<decltype(1km / 1s), velocity<scaled_unit<ratio<1, 1, 3>, metre_per_second>, std::int64_t>>);
 
 static_assert(10m / 5s == 2mps);
 static_assert(10 / 5s * 1m == 2mps);

--- a/test/unit_test/static/unit_test.cpp
+++ b/test/unit_test/static/unit_test.cpp
@@ -30,12 +30,12 @@ using namespace units;
 struct metre : named_unit<metre, "m", si::prefix> {};
 struct centimetre : prefixed_unit<centimetre, si::centi, metre> {};
 struct kilometre : prefixed_unit<kilometre, si::kilo, metre> {};
-struct yard : named_scaled_unit<yard, "yd", no_prefix, ratio<9'144, 10'000>, metre> {};
+struct yard : named_scaled_unit<yard, "yd", no_prefix, ratio<9'144, 1, -4>, metre> {};
 struct foot : named_scaled_unit<foot, "ft", no_prefix, ratio<1, 3>, yard> {};
 struct dim_length : base_dimension<"length", metre> {};
 
 struct second : named_unit<second, "s", si::prefix> {};
-struct hour : named_scaled_unit<hour, "h", no_prefix, ratio<3600>, second> {};
+struct hour : named_scaled_unit<hour, "h", no_prefix, ratio<36, 1, 2>, second> {};
 struct dim_time : base_dimension<"time", second> {};
 
 struct kelvin : named_unit<kelvin, "K", no_prefix> {};
@@ -46,8 +46,8 @@ struct dim_velocity : derived_dimension<dim_velocity, metre_per_second, exp<dim_
 struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_velocity, kilometre, hour> {};
 
 static_assert(std::is_same_v<downcast<scaled_unit<ratio<1>, metre>>, metre>);
-static_assert(std::is_same_v<downcast<scaled_unit<ratio<1, 100>, metre>>, centimetre>);
-static_assert(std::is_same_v<downcast<scaled_unit<ratio<yard::ratio::num, yard::ratio::den>, metre>>, yard>);
+static_assert(std::is_same_v<downcast<scaled_unit<ratio<1, 1, -2>, metre>>, centimetre>);
+static_assert(std::is_same_v<downcast<scaled_unit<ratio<yard::ratio::num, yard::ratio::den, yard::ratio::exp>, metre>>, yard>);
 static_assert(std::is_same_v<downcast<scaled_unit<ratio_multiply<typename yard::ratio, ratio<1, 3>>, metre>>, foot>);
 static_assert(std::is_same_v<downcast<scaled_unit<ratio_divide<typename kilometre::ratio, typename hour::ratio>, metre_per_second>>, kilometre_per_hour>);
 


### PR DESCRIPTION
https://github.com/mpusz/units/issues/14

This "works", as in it passes all static and runtime tests.
However quite a few of the tests have been "modified" to make them pass. Whether
this is legitimate is debatable and should be the source of some thought /
discussion.

1. many of the static tests and some of the runtime tests have had the input
ratios of the tests modified in the following way. eg ratio<3,1000> =>
ratio<3,1,-3>. ie they have been "canonicalised".

There are obviously an infinite number of ratios which represent the same
rational number. The way `ratio` is implemented it always moves as "many powers
of 10" from the `num` and `den` into the `exp` and that makes the `canonical`
ratio.

Because these are all "types" and the lib uses is_same all over the place, only
exact matches will be `is_same`. ie ratio<300,4,0> !is_same ratio<3,4,2> (the
latter is the canonical ratio). This is perhaps fine for tests in the devlopment
phase, but there may be a need for "more forgiving" comparison / concept of
value equality. One such comparison which compares den,num,exp after
canonicalisation is the constexpr function `same` as defined at top of
`ratio_test.cpp`. We may need to expose this and perhaps add even more soft
comparisions.

2. In the runtime tests it is "subjective" how some resukts should be
printed. There is the question of "how exactly to format certain ratios". eg
omit denominators of "1" and exponents of "0". However before even addressing
these in detail a decision needs to be made about the general form of
"non-floating-point-converted" ratios which do not map exactly to a "Symbol
prefix".

Arguably these are "relatively ugly" whatever we do, so we could just
go for an easily canonicalised form. An example is:

-        CHECK(stream.str() == "10 [1/60]W");
+        CHECK(stream.str() == "10 [1/6 x 10⁻¹]W");

Which of thses is "better"? Is there a "third", better form?  It's not obvious.

My opnion is: Both of 1&2 are fine for now, unless we think they go down the
wrong avenue, and can be "perfected later"? ie we can expose a softer version of
ratio based equality, and decide on canonical way of printing ratios (as far as
that is actually a very useful output form, compared with decimal, scientific or
engineering notation).