### PR TITLE
extending the range of operator* for incoherent units with large num/den

### DIFF
--- a/doc/DESIGN.md
+++ b/doc/DESIGN.md
@@ -78,7 +78,7 @@ where:
 
 ```cpp
 template<typename R>
-concept UnitRatio = Ratio<R> && (R::num * R::den > 0);
+concept UnitRatio = Ratio<R> && R::num > 0 && R::den > 0; // double negatives not allowed
 ```
 
 and `Ratio` is satisfied by any instantiation of `units::ratio<Num, Den, Exp>`.

--- a/src/include/units/bits/external/text_tools.h
+++ b/src/include/units/bits/external/text_tools.h
@@ -26,7 +26,7 @@
 
 namespace units::detail {
 
-template<int Value>
+template<std::intmax_t Value>
   requires (0 <= Value) && (Value < 10)
 inline constexpr basic_fixed_string superscript_number = "";
 
@@ -43,7 +43,7 @@ template<> inline constexpr basic_fixed_string superscript_number<9> = "\u2079";
 
 inline constexpr basic_fixed_string superscript_minus = "\u207b";
 
-template<int Value>
+template<std::intmax_t Value>
 constexpr auto superscript()
 {
   if constexpr(Value < 0)
@@ -54,12 +54,12 @@ constexpr auto superscript()
     return superscript<Value / 10>() + superscript<Value % 10>();
 }
 
-template<int Value>
+template<std::intmax_t Value>
 constexpr auto regular()
 {
-  if constexpr(Value < 0)
+  if constexpr (Value < 0)
     return basic_fixed_string("-") + superscript<-Value>();
-  else if constexpr(Value < 10)
+  else if constexpr (Value < 10)
     return basic_fixed_string(static_cast<char>('0' + Value));
   else
     return regular<Value / 10>() + regular<Value % 10>();

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -79,7 +79,7 @@ concept Ratio = detail::is_ratio<T>;
 
 // UnitRatio
 template<typename R>
-concept UnitRatio = Ratio<R> && (R::num * R::den > 0);
+concept UnitRatio = Ratio<R> && R::num > 0 && R::den > 0; // double negatives not allowed
 
 // Unit
 template<UnitRatio R, typename U>

--- a/test/unit_test/runtime/fmt_units_test.cpp
+++ b/test/unit_test/runtime/fmt_units_test.cpp
@@ -175,4 +175,10 @@ TEST_CASE("fmt::format on synthesized unit symbols", "[text][fmt]")
   {
     CHECK(fmt::format("{}", 1q_in + 1q_yd) == "37 in");
   }
+
+  SECTION("incoherent units with powers")
+  {
+    CHECK(fmt::format("{}", 1q_mi * 1q_mi * 1q_mi) == "1 [15900351812136/3814697265625 × 10⁹] m³");
+    CHECK(fmt::format("{}", 1q_au * 1q_au) == "1 [2237952291797391849 × 10⁴] m²");
+  }
 }


### PR DESCRIPTION
this improves the situation for #55 (doesn't solve it outright)
motivating examples which now work are:
1q_mi * 1q_mi * 1q_mi
1q_au * 1q_au
tests added and docs updated