### PR TITLE
Added ASCII-only output support

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -156,13 +156,13 @@ struct centi : units::prefix<centi, prefix, "c", ratio<1, 1, -2>> {};
 struct kilo : units::prefix<kilo, prefix, "k", ratio<1, 1, 3>> {};
 
 // length
-struct metre : named_unit<metre, "m", prefix> {};
+struct metre : named_unit<metre, "m", "m", prefix> {};
 struct centimetre : prefixed_unit<centimetre, centi, metre> {};
 struct kilometre : prefixed_unit<kilometre, kilo, metre> {};
 
 // time
-struct second : named_unit<second, "s", prefix> {};
-struct hour : named_scaled_unit<hour, "h", no_prefix, ratio<3600>, second> {};
+struct second : named_unit<second, "s", "s", prefix> {};
+struct hour : named_scaled_unit<hour, "h", "h", no_prefix, ratio<3600>, second> {};
 
 // velocity
 struct metre_per_second : unit<metre_per_second> {};
@@ -173,8 +173,8 @@ struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_velocity, kilom
 namespace units::us {
 
 // length
-struct yard : named_scaled_unit<yard, "yd", no_prefix, ratio<9'144, 10'000>, si::metre> {};
-struct mile : named_scaled_unit<mile, "mi", no_prefix, ratio<1'760>, yard> {};
+struct yard : named_scaled_unit<yard, "yd", "yd", no_prefix, ratio<9'144, 10'000>, si::metre> {};
+struct mile : named_scaled_unit<mile, "mi", "mi", no_prefix, ratio<1'760>, yard> {};
 
 // velocity
 struct mile_per_hour : deduced_unit<mile_per_hour, si::dim_velocity, mile, si::hour> {};
@@ -794,10 +794,10 @@ adds support for digital information quantities. In summary it adds:
     ```cpp
     namespace units::data {
 
-    struct bit : named_unit<bit, "b", prefix> {};
+    struct bit : named_unit<bit, "b", "b", prefix> {};
     struct kibibit : prefixed_unit<kibibit, kibi, bit> {};
 
-    struct byte : named_scaled_unit<byte, "B", prefix, ratio<8>, bit> {};
+    struct byte : named_scaled_unit<byte, "B", "B", prefix, ratio<8>, bit> {};
     struct kibibyte : prefixed_unit<kibibyte, kibi, byte> {};
 
     }

--- a/docs/framework/units.rst
+++ b/docs/framework/units.rst
@@ -37,7 +37,7 @@ where `si::metre` is defined as::
 
     namespace si {
 
-    struct metre : named_unit<metre, "m", prefix> {};
+    struct metre : named_unit<metre, "m", "m", prefix> {};
 
     }
 
@@ -99,7 +99,7 @@ always have to be a named unit)::
 
     namespace si {
 
-    struct newton : named_unit<newton, "N", prefix> {};
+    struct newton : named_unit<newton, "N", "N", prefix> {};
 
     }
 

--- a/src/include/units/bits/deduced_symbol_text.h
+++ b/src/include/units/bits/deduced_symbol_text.h
@@ -85,10 +85,23 @@ constexpr auto deduced_symbol_text(exp_list<Es...>, std::index_sequence<Idxs...>
   return (exp_text<Es, Us::symbol, neg_exp, Idxs>() + ...);
 }
 
+template<typename... Us, typename... Es, std::size_t... Idxs>
+constexpr auto deduced_ascii_symbol_text(exp_list<Es...>, std::index_sequence<Idxs...>)
+{
+  constexpr auto neg_exp = negative_exp_count<Es...>;
+  return (exp_text<Es, Us::ascii_symbol, neg_exp, Idxs>() + ...);
+}
+
 template<DerivedDimension Dim, Unit... Us>
 constexpr auto deduced_symbol_text()
 {
   return deduced_symbol_text<Us...>(typename Dim::recipe(), std::index_sequence_for<Us...>());
+}
+
+template<DerivedDimension Dim, Unit... Us>
+constexpr auto deduced_ascii_symbol_text()
+{
+  return deduced_ascii_symbol_text<Us...>(typename Dim::recipe(), std::index_sequence_for<Us...>());
 }
 
 }  // namespace units::detail

--- a/src/include/units/bits/unit_text.h
+++ b/src/include/units/bits/unit_text.h
@@ -138,14 +138,9 @@ template<typename T>
 concept has_symbol = requires{ T::symbol; };
 
 template<Dimension Dim, Unit U>
-constexpr auto unit_text()
+constexpr auto unit_text_prefix_or_ratio()
 {
-  if constexpr(has_symbol<U>) {
-    // already has a symbol so print it
-    return U::symbol;
-  }
-  else {
-    // print as a prefix or ratio of a coherent unit
+  // print as a prefix or ratio of a coherent unit
     using coherent_unit = dimension_unit<Dim>;
     using ratio = ratio_divide<typename U::ratio, typename coherent_unit::ratio>;
     auto prefix_txt = prefix_or_ratio_text<ratio, typename U::reference::prefix_type>();
@@ -158,6 +153,29 @@ constexpr auto unit_text()
       // use derived dimension ingredients to create a unit symbol
       return prefix_txt + derived_dimension_unit_text<Dim>();
     }
+}
+
+template<Dimension Dim, Unit U>
+constexpr auto unit_text()
+{
+  if constexpr(has_symbol<U>) {
+    // already has a symbol so print it
+    return U::symbol;
+  }
+  else {
+    return unit_text_prefix_or_ratio<Dim, U>();
+  }
+}
+
+template<Dimension Dim, Unit U>
+constexpr auto unit_text_ascii()
+{
+  if constexpr(has_symbol<U>) {
+    // already has a symbol so print it
+    return U::ascii_symbol;
+  }
+  else {
+    return unit_text_prefix_or_ratio<Dim, U>();
   }
 }
 

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -29,14 +29,14 @@
 
 namespace units::data {
 
-struct bit : named_unit<bit, "b", prefix> {};
+struct bit : named_unit<bit, "b", "b", prefix> {};
 struct kibibit : prefixed_unit<kibibit, kibi, bit> {};
 struct mebibit : prefixed_unit<mebibit, mebi, bit> {};
 struct gibibit : prefixed_unit<gibibit, gibi, bit> {};
 struct tebibit : prefixed_unit<tebibit, tebi, bit> {};
 struct pebibit : prefixed_unit<pebibit, pebi, bit> {};
 
-struct byte : named_scaled_unit<byte, "B", prefix, ratio<8>, bit> {};
+struct byte : named_scaled_unit<byte, "B", "B", prefix, ratio<8>, bit> {};
 struct kibibyte : prefixed_unit<kibibyte, kibi, byte> {};
 struct mebibyte : prefixed_unit<mebibyte, mebi, byte> {};
 struct gibibyte : prefixed_unit<gibibyte, gibi, byte> {};

--- a/src/include/units/physical/cgs/acceleration.h
+++ b/src/include/units/physical/cgs/acceleration.h
@@ -28,7 +28,7 @@
 
 namespace units::cgs {
 
-struct gal : named_unit<gal, "Gal", si::prefix> {};
+struct gal : named_unit<gal, "Gal", "Gal", si::prefix> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gal, dim_length, dim_time> {};
 
 template<Unit U, Scalar Rep = double>

--- a/src/include/units/physical/cgs/energy.h
+++ b/src/include/units/physical/cgs/energy.h
@@ -29,7 +29,7 @@
 
 namespace units::cgs {
 
-struct erg : named_unit<erg, "erg", si::prefix> {};
+struct erg : named_unit<erg, "erg", "erg", si::prefix> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, erg, dim_force, dim_length> {};
 

--- a/src/include/units/physical/cgs/force.h
+++ b/src/include/units/physical/cgs/force.h
@@ -30,7 +30,7 @@
 
 namespace units::cgs {
 
-struct dyne : named_unit<dyne, "dyn", si::prefix> {};
+struct dyne : named_unit<dyne, "dyn", "dyn", si::prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, dyne, dim_mass, dim_acceleration> {};
 

--- a/src/include/units/physical/cgs/pressure.h
+++ b/src/include/units/physical/cgs/pressure.h
@@ -30,7 +30,7 @@
 
 namespace units::cgs {
 
-struct barye : named_unit<barye, "Ba", si::prefix> {};
+struct barye : named_unit<barye, "Ba", "Ba", si::prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, barye, dim_force, dim_area> {};
 

--- a/src/include/units/physical/iau/length.h
+++ b/src/include/units/physical/iau/length.h
@@ -28,13 +28,13 @@
 namespace units::iau {
 
 // https://en.wikipedia.org/wiki/Light-year
-struct light_year : named_scaled_unit<light_year, "ly", no_prefix, ratio<9460730472580800>, si::metre> {};
+struct light_year : named_scaled_unit<light_year, "ly", "ly", no_prefix, ratio<9460730472580800>, si::metre> {};
 
 // https://en.wikipedia.org/wiki/Parsec
-struct parsec : named_scaled_unit<parsec, "pc", si::prefix, ratio<30'856'775'814'913'673>, si::metre> {};
+struct parsec : named_scaled_unit<parsec, "pc", "pc", si::prefix, ratio<30'856'775'814'913'673>, si::metre> {};
 
 // https://en.wikipedia.org/wiki/Angstrom
-struct angstrom : named_scaled_unit<angstrom, "angstrom", no_prefix, ratio<1, 1, -10>, si::metre> {};
+struct angstrom : named_scaled_unit<angstrom, "angstrom", "angstrom", no_prefix, ratio<1, 1, -10>, si::metre> {};
 
 inline namespace literals {
 

--- a/src/include/units/physical/imperial/length.h
+++ b/src/include/units/physical/imperial/length.h
@@ -27,10 +27,10 @@
 namespace units::imperial {
 
 // https://en.wikipedia.org/wiki/Chain_(unit)
-struct chain : named_scaled_unit<chain, "ch", no_prefix, ratio<22, 1>, international::yard> {};
+struct chain : named_scaled_unit<chain, "ch", "ch", no_prefix, ratio<22, 1>, international::yard> {};
 
 // https://en.wikipedia.org/wiki/Rod_(unit)
-struct rod : named_scaled_unit<rod, "rd", no_prefix, ratio<1, 4>, chain> {};
+struct rod : named_scaled_unit<rod, "rd", "rd", no_prefix, ratio<1, 4>, chain> {};
 
 inline namespace literals {
 

--- a/src/include/units/physical/international/length.h
+++ b/src/include/units/physical/international/length.h
@@ -29,30 +29,30 @@ namespace units::international {
 
 // international yard
 // https://en.wikipedia.org/wiki/International_yard_and_pound
-struct yard : named_scaled_unit<yard, "yd", no_prefix, ratio<9'144, 1'000, -1>, si::metre> {};
+struct yard : named_scaled_unit<yard, "yd", "yd", no_prefix, ratio<9'144, 1'000, -1>, si::metre> {};
 
 // international foot
 // https://en.wikipedia.org/wiki/Foot_(unit)#International_foot
-struct foot : named_scaled_unit<foot, "ft", no_prefix, ratio<1, 3>, yard> {};
+struct foot : named_scaled_unit<foot, "ft", "ft", no_prefix, ratio<1, 3>, yard> {};
 
 // https://en.wikipedia.org/wiki/Fathom#International_fathom
-struct fathom : named_scaled_unit<fathom, "fathom", no_prefix, ratio<2>, yard> {};
+struct fathom : named_scaled_unit<fathom, "fathom", "fathom", no_prefix, ratio<2>, yard> {};
 
 // international inch
 // https://en.wikipedia.org/wiki/Inch#Equivalences
-struct inch : named_scaled_unit<inch, "in", no_prefix, ratio<1, 36>, yard> {};
+struct inch : named_scaled_unit<inch, "in", "in", no_prefix, ratio<1, 36>, yard> {};
 
 // intrnational mile
 // https://en.wikipedia.org/wiki/Mile#International_mile
-struct mile : named_scaled_unit<mile, "mi", no_prefix, ratio<25'146, 15'625>, si::kilometre> {};
+struct mile : named_scaled_unit<mile, "mi", "mi", no_prefix, ratio<25'146, 15'625>, si::kilometre> {};
 
 // international nautical mile
 // https://en.wikipedia.org/wiki/Nautical_mile
-struct nautical_mile : named_scaled_unit<nautical_mile, "mi(naut)", no_prefix, ratio<1852>, si::metre> {};
+struct nautical_mile : named_scaled_unit<nautical_mile, "mi(naut)", "mi(naut)", no_prefix, ratio<1852>, si::metre> {};
 
 // thou
 // https://en.wikipedia.org/wiki/Thousandth_of_an_inch
-struct thou : named_scaled_unit<thou, "thou", no_prefix, ratio<1, 1000>, inch> {};
+struct thou : named_scaled_unit<thou, "thou", "thou", no_prefix, ratio<1, 1000>, inch> {};
 
 // mil - different name for thou
 // https://en.wikipedia.org/wiki/Thousandth_of_an_inch

--- a/src/include/units/physical/natural/units.h
+++ b/src/include/units/physical/natural/units.h
@@ -27,11 +27,11 @@
 
 namespace units::natural {
 
-struct unitless : named_unit<unitless, "", no_prefix> {};
-struct electronvolt : named_unit<electronvolt, "eV", si::prefix> {};
+struct unitless : named_unit<unitless, "", "", no_prefix> {};
+struct electronvolt : named_unit<electronvolt, "eV", "eV", si::prefix> {};
 struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, si::giga, electronvolt> {};
-struct inverted_gigaelectronvolt : named_unit<inverted_gigaelectronvolt, "GeV⁻¹", no_prefix> {};
-struct square_gigaelectronvolt : named_unit<square_gigaelectronvolt, "GeV²", no_prefix> {};
+struct inverted_gigaelectronvolt : named_unit<inverted_gigaelectronvolt, "GeV⁻¹", "GeV^-1", no_prefix> {};
+struct square_gigaelectronvolt : named_unit<square_gigaelectronvolt, "GeV²", "GeV^2", no_prefix> {};
 
 // NOTE: eV as a base unit with no relation to joule prevents us from going back
 // from natural units to SI. Do we need such a support or should we treat

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -30,7 +30,7 @@
 
 namespace units::si {
 
-struct farad : named_unit<farad, "F", prefix> {};
+struct farad : named_unit<farad, "F", "F", prefix> {};
 
 struct millifarad : prefixed_unit<millifarad, milli, farad> {};
 struct microfarad : prefixed_unit<microfarad, micro, farad> {};

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -28,7 +28,7 @@
 
 namespace units::si {
 
-struct ampere : named_unit<ampere, "m", prefix> {};
+struct ampere : named_unit<ampere, "m", "m", prefix> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 

--- a/src/include/units/physical/si/electric_charge.h
+++ b/src/include/units/physical/si/electric_charge.h
@@ -29,7 +29,7 @@
 
 namespace units::si {
 
-struct coulomb : named_unit<coulomb, "C", prefix> {};
+struct coulomb : named_unit<coulomb, "C", "C", prefix> {};
 
 struct dim_electric_charge : physical::dim_electric_charge<dim_electric_charge, coulomb, dim_time, dim_electric_current> {};
 

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -29,13 +29,13 @@
 
 namespace units::si {
 
-struct joule : named_unit<joule, "J", prefix> {};
+struct joule : named_unit<joule, "J", "J", prefix> {};
 struct millijoule : prefixed_unit<millijoule, milli, joule> {};
 struct kilojoule : prefixed_unit<kilojoule, kilo, joule> {};
 struct megajoule : prefixed_unit<megajoule, mega, joule> {};
 struct gigajoule : prefixed_unit<gigajoule, giga, joule> {};
 
-struct electronvolt : named_scaled_unit<electronvolt, "eV", prefix, ratio<1'602'176'634, 1'000'000'000, -19>, joule> {};
+struct electronvolt : named_scaled_unit<electronvolt, "eV", "eV", prefix, ratio<1'602'176'634, 1'000'000'000, -19>, joule> {};
 struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, joule, dim_force, dim_length> {};

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -30,7 +30,7 @@
 
 namespace units::si {
 
-struct newton : named_unit<newton, "N", prefix> {};
+struct newton : named_unit<newton, "N", "N", prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -28,7 +28,7 @@
 
 namespace units::si {
 
-struct hertz : named_unit<hertz, "Hz", prefix> {};
+struct hertz : named_unit<hertz, "Hz", "Hz", prefix> {};
 struct millihertz : prefixed_unit<millihertz, milli, hertz> {};
 struct kilohertz : prefixed_unit<kilohertz, kilo, hertz> {};
 struct megahertz : prefixed_unit<megahertz, mega, hertz> {};

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -28,7 +28,7 @@
 
 namespace units::si {
 
-struct metre : named_unit<metre, "m", prefix> {};
+struct metre : named_unit<metre, "m", "m", prefix> {};
 struct millimetre : prefixed_unit<millimetre, milli, metre> {};
 struct centimetre : prefixed_unit<centimetre, centi, metre> {};
 struct decimetre : prefixed_unit<decimetre, deci, metre> {};
@@ -36,7 +36,7 @@ struct hectometre : prefixed_unit<hectometre, hecto, metre> {};
 struct kilometre : prefixed_unit<kilometre, kilo, metre> {};
 struct femtometre : prefixed_unit<femtometre, femto, metre> {};
 
-struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix, ratio<149'597'870'700>, metre> {};
+struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", "au", no_prefix, ratio<149'597'870'700>, metre> {};
 
 struct dim_length : physical::dim_length<metre> {};
 

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -28,7 +28,7 @@
 
 namespace units::si {
 
-struct candela : named_unit<candela, "cd", prefix> {};
+struct candela : named_unit<candela, "cd", "cd", prefix> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -28,11 +28,11 @@
 
 namespace units::si {
 
-struct gram : named_unit<gram, "g", prefix> {};
+struct gram : named_unit<gram, "g", "g", prefix> {};
 struct kilogram : prefixed_unit<kilogram, kilo, gram> {};
-struct tonne : named_scaled_unit<tonne, "t", prefix, ratio<1'000>, kilogram> {};
+struct tonne : named_scaled_unit<tonne, "t", "t", prefix, ratio<1'000>, kilogram> {};
 
-struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'050, 10'000'000'000'000, -27>, kilogram> {};
+struct dalton : named_scaled_unit<dalton, "Da", "Da", no_prefix, ratio<16'605'390'666'050, 10'000'000'000'000, -27>, kilogram> {};
 
 struct dim_mass : physical::dim_mass<kilogram> {};
 

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -29,7 +29,7 @@
 
 namespace units::si {
 
-struct watt : named_unit<watt, "W", prefix> {};
+struct watt : named_unit<watt, "W", "W", prefix> {};
 struct milliwatt : prefixed_unit<milliwatt, milli, watt> {};
 struct kilowatt : prefixed_unit<kilowatt, kilo, watt> {};
 struct megawatt : prefixed_unit<megawatt, mega, watt> {};

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -30,7 +30,7 @@
 
 namespace units::si {
 
-struct pascal : named_unit<pascal, "Pa", prefix> {};
+struct pascal : named_unit<pascal, "Pa", "Pa", prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -30,7 +30,7 @@
 
 namespace units::si {
 
-struct ohm : named_unit<ohm, "Ω", prefix> {};
+struct ohm : named_unit<ohm, "Ω", "ohm", prefix> {};
 struct milliohm : prefixed_unit<milliohm, milli, ohm> {};
 struct kiloohm : prefixed_unit<kiloohm, kilo, ohm> {};
 struct megaohm : prefixed_unit<megaohm, mega, ohm> {};

--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -28,7 +28,7 @@
 
 namespace units::si {
 
-struct mole : named_unit<metre, "mol", prefix> {};
+struct mole : named_unit<metre, "mol", "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 

--- a/src/include/units/physical/si/temperature.h
+++ b/src/include/units/physical/si/temperature.h
@@ -27,7 +27,7 @@
 
 namespace units::si {
 
-struct kelvin : named_unit<kelvin, "K", no_prefix> {};
+struct kelvin : named_unit<kelvin, "K", "K", no_prefix> {};
 
 struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<kelvin> {};
 

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -28,13 +28,13 @@
 
 namespace units::si {
 
-struct second : named_unit<second, "s", prefix> {};
+struct second : named_unit<second, "s", "s", prefix> {};
 struct nanosecond : prefixed_unit<nanosecond, nano, second> {};
 struct microsecond : prefixed_unit<microsecond, micro, second> {};
 struct millisecond : prefixed_unit<millisecond, milli, second> {};
-struct minute : named_scaled_unit<minute, "min", no_prefix, ratio<60>, second> {};
-struct hour : named_scaled_unit<hour, "h", no_prefix, ratio<60>, minute> {};
-struct day : named_scaled_unit<hour, "d", no_prefix, ratio<24>, hour> {};
+struct minute : named_scaled_unit<minute, "min", "min", no_prefix, ratio<60>, second> {};
+struct hour : named_scaled_unit<hour, "h", "h", no_prefix, ratio<60>, minute> {};
+struct day : named_scaled_unit<hour, "d", "d", no_prefix, ratio<24>, hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -30,7 +30,7 @@
 
 namespace units::si {
 
-struct volt : named_unit<volt, "V", prefix> {};
+struct volt : named_unit<volt, "V", "V", prefix> {};
 struct millivolt : prefixed_unit<millivolt, milli, volt> {};
 struct microvolt : prefixed_unit<microvolt, micro, volt> {};
 struct nanovolt : prefixed_unit<nanovolt, nano, volt> {};

--- a/src/include/units/physical/typographic/length.h
+++ b/src/include/units/physical/typographic/length.h
@@ -28,10 +28,10 @@
 namespace units::typographic {
 
 // TODO Conflicts with (https://en.wikipedia.org/wiki/Pica_(typography)), verify correctness of below conversion factors and provide hyperlinks to definitions
-struct pica_comp : named_scaled_unit<pica_comp, "pica(comp)", no_prefix, ratio<4233333, 1000000, -3>, si::metre> {};
-struct pica_prn : named_scaled_unit<pica_prn, "pica(prn)", no_prefix, ratio<2108759, 500000, -3>, si::metre> {};
-struct point_comp : named_scaled_unit<point_comp, "point(comp)", no_prefix, ratio<1763889, 500000, -4>, si::metre> {};
-struct point_prn : named_scaled_unit<point_prn, "point(prn)", no_prefix, ratio<1757299, 500000, -4>, si::metre> {};
+struct pica_comp : named_scaled_unit<pica_comp, "pica(comp)", "pica(comp)", no_prefix, ratio<4233333, 1000000, -3>, si::metre> {};
+struct pica_prn : named_scaled_unit<pica_prn, "pica(prn)", "pica(prn)", no_prefix, ratio<2108759, 500000, -3>, si::metre> {};
+struct point_comp : named_scaled_unit<point_comp, "point(comp)", "point(comp)", no_prefix, ratio<1763889, 500000, -4>, si::metre> {};
+struct point_prn : named_scaled_unit<point_prn, "point(prn)", "point(prn)", no_prefix, ratio<1757299, 500000, -4>, si::metre> {};
 
 inline namespace literals {
 

--- a/src/include/units/physical/us/length.h
+++ b/src/include/units/physical/us/length.h
@@ -28,14 +28,14 @@ namespace units::us {
 
 // https://en.wikipedia.org/wiki/Foot_(unit)#US_survey_foot
 // https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors#B6
-struct foot : named_scaled_unit<foot, "ft(us)", no_prefix, ratio<1'200, 3'937>, si::metre> {};
+struct foot : named_scaled_unit<foot, "ft(us)", "ft(us)", no_prefix, ratio<1'200, 3'937>, si::metre> {};
 
 // https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors#B6
-struct fathom : named_scaled_unit<fathom, "fathom(us)", no_prefix, ratio<6>, foot> {};
+struct fathom : named_scaled_unit<fathom, "fathom(us)", "fathom(us)", no_prefix, ratio<6>, foot> {};
 
 // https://en.wikipedia.org/wiki/Mile#U.S._survey_mile
 // https://www.nist.gov/pml/special-publication-811/nist-guide-si-appendix-b-conversion-factors#B6
-struct mile : named_scaled_unit<mile, "mi(us)", no_prefix, ratio<5280>, us::foot> {};
+struct mile : named_scaled_unit<mile, "mi(us)", "mi(us)", no_prefix, ratio<5280>, us::foot> {};
 
 inline namespace literals {
 

--- a/src/include/units/unit.h
+++ b/src/include/units/unit.h
@@ -94,10 +94,11 @@ struct unknown_coherent_unit : unit<unknown_coherent_unit> {};
  * @tparam Symbol a short text representation of the unit
  * @tparam PT no_prefix or a type of prefix family
  */
-template<typename Child, basic_fixed_string Symbol, PrefixType PT>
+template<typename Child, basic_fixed_string Symbol, basic_fixed_string ASCIISymbol, PrefixType PT>
 struct named_unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
+  static constexpr auto ascii_symbol = ASCIISymbol;
   using prefix_type = PT;
 };
 
@@ -115,10 +116,11 @@ struct named_unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
  * @tparam R a scale to apply to U
  * @tparam U a reference unit to scale
  */
-template<typename Child, basic_fixed_string Symbol, PrefixType PT, UnitRatio R, Unit U>
+template<typename Child, basic_fixed_string Symbol, basic_fixed_string ASCIISymbol, PrefixType PT, UnitRatio R, Unit U>
 struct named_scaled_unit : downcast_child<Child, scaled_unit<ratio_multiply<R, typename U::ratio>, typename U::reference>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
+  static constexpr auto ascii_symbol = ASCIISymbol;
   using prefix_type = PT;
 };
 
@@ -139,6 +141,7 @@ struct prefixed_unit :
     downcast_child<Child, scaled_unit<ratio_multiply<typename P::ratio, typename U::ratio>, typename U::reference>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = P::symbol + U::symbol;
+  static constexpr auto ascii_symbol = P::symbol + U::ascii_symbol;
   using prefix_type = no_prefix;
 };
 
@@ -161,6 +164,7 @@ template<typename Child, DerivedDimension Dim, Unit U, Unit... URest>
 struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest...>> {
   static constexpr bool is_named = false;
   static constexpr auto symbol = detail::deduced_symbol_text<Dim, U, URest...>();
+  static constexpr auto ascii_symbol = detail::deduced_ascii_symbol_text<Dim, U, URest...>();
   using prefix_type = no_prefix;
 };
 

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -29,6 +29,7 @@
 #include "units/physical/si/velocity.h"
 #include "units/physical/si/volume.h"
 #include "units/physical/si/surface_tension.h"
+#include "units/physical/si/resistance.h"
 #include "units/format.h"
 #include "units/math.h"
 #include <catch2/catch.hpp>
@@ -703,6 +704,16 @@ TEST_CASE("format string with only %Q should print quantity value only", "[text]
 TEST_CASE("format string with only %q should print quantity unit symbol only", "[text][fmt]")
 {
   CHECK(fmt::format("{:%q}", 123q_km_per_h) == "km/h");
+}
+
+TEST_CASE("format string with only %q should print Unicode quantity unit symbol only", "[text][fmt]")
+{
+  CHECK(fmt::format("{:%Q%q}", 123q_kR) == "123kΩ");
+}
+
+TEST_CASE("format string with only %a should print ASCII quantity unit symbol only", "[text][fmt]")
+{
+  CHECK(fmt::format("{:%Q%a}", 123q_kR) == "123kohm");
 }
 
 TEST_CASE("%q an %Q can be put anywhere in a format string", "[text][fmt]")

--- a/test/unit_test/static/dimension_op_test.cpp
+++ b/test/unit_test/static/dimension_op_test.cpp
@@ -28,13 +28,13 @@ using namespace units;
 
 namespace {
 
-struct u0 : named_unit<u0, "u0", no_prefix> {};
+struct u0 : named_unit<u0, "u0", "u0", no_prefix> {};
 struct d0 : base_dimension<"d0", u0> {};
-struct u1 : named_unit<u1, "u1", no_prefix> {};
+struct u1 : named_unit<u1, "u1", "u1", no_prefix> {};
 struct d1 : base_dimension<"d1", u1> {};
-struct u2 : named_unit<u2, "u2", no_prefix> {};
+struct u2 : named_unit<u2, "u2", "u2", no_prefix> {};
 struct d2 : base_dimension<"d2", u2> {};
-struct u3 : named_unit<u3, "u3", no_prefix> {};
+struct u3 : named_unit<u3, "u3", "u3", no_prefix> {};
 struct d3 : base_dimension<"d3", u3> {};
 
 // exp_invert

--- a/test/unit_test/static/type_list_test.cpp
+++ b/test/unit_test/static/type_list_test.cpp
@@ -93,9 +93,9 @@ static_assert(
     std::is_same_v<type_list_split_half<type_list<int, long, double, float>>::second_list, type_list<double, float>>);
 
 // type_list_merge_sorted
-struct u0 : named_unit<u0, "u0", no_prefix> {};
+struct u0 : named_unit<u0, "u0", "u0", no_prefix> {};
 struct d0 : base_dimension<"d0", u0> {};
-struct u1 : named_unit<u1, "u1", no_prefix> {};
+struct u1 : named_unit<u1, "u1", "u1", no_prefix> {};
 struct d1 : base_dimension<"d1", u1> {};
 
 static_assert(std::is_same_v<type_list_merge_sorted<type_list<units::exp<d0, 1>>, type_list<units::exp<d1, 1>>, exp_less>,

--- a/test/unit_test/static/unit_test.cpp
+++ b/test/unit_test/static/unit_test.cpp
@@ -27,18 +27,18 @@ namespace {
 
 using namespace units;
 
-struct metre : named_unit<metre, "m", si::prefix> {};
+struct metre : named_unit<metre, "m", "m", si::prefix> {};
 struct centimetre : prefixed_unit<centimetre, si::centi, metre> {};
 struct kilometre : prefixed_unit<kilometre, si::kilo, metre> {};
-struct yard : named_scaled_unit<yard, "yd", no_prefix, ratio<9'144, 1, -4>, metre> {};
-struct foot : named_scaled_unit<foot, "ft", no_prefix, ratio<1, 3>, yard> {};
+struct yard : named_scaled_unit<yard, "yd", "yd", no_prefix, ratio<9'144, 1, -4>, metre> {};
+struct foot : named_scaled_unit<foot, "ft", "ft", no_prefix, ratio<1, 3>, yard> {};
 struct dim_length : base_dimension<"length", metre> {};
 
-struct second : named_unit<second, "s", si::prefix> {};
-struct hour : named_scaled_unit<hour, "h", no_prefix, ratio<36, 1, 2>, second> {};
+struct second : named_unit<second, "s", "s", si::prefix> {};
+struct hour : named_scaled_unit<hour, "h", "h", no_prefix, ratio<36, 1, 2>, second> {};
 struct dim_time : base_dimension<"time", second> {};
 
-struct kelvin : named_unit<kelvin, "K", no_prefix> {};
+struct kelvin : named_unit<kelvin, "K", "K", no_prefix> {};
 // struct kilokelvin : prefixed_unit<kilokelvin, si::kilo, kelvin> {};  // should not compile (prefix not allowed for this reference unit)
 
 struct metre_per_second : unit<metre_per_second> {};


### PR DESCRIPTION
Dear Mr. Mateusz Pusz,

Much of C++ template programming with C++20 features is still a bit overwhelming for me at this point in time.

I do not fully understand how the library is written, but I can rely on what I already know about it and my intuition to understand certain parts. I think I get the gist of it.

I am using this library for SPICE circuit generation using custom templates. I have generator classes that are responsible for rendering the custom templates into SPICE circuit text.

Initializing my generator:
```RCCircuitGenerator generator {5ns, 2ms, 5V, 1ms, 10kR, 10nF};```

The formatting string for the line starting with "RLOAD" (see below) looks like this:
```RLOAD 1 2 {:%Q%q}```

The following SPICE RC circuit text would be generated:
```
RC_CIRCUIT
.TRAN 5ns 2ms
VSRC 1 0 PULSE 0 5V 0 0 0 1ms
RLOAD 1 2 10kΩ
CCHARGE 2 0 10nF
.END
```

However, the SPICE simulator library I am using, ```ngspice```, expect ASCII encoding. The simulation crashes when this circuit is passed to the library.

With the changes I have provided, when the formatting string for the line starting with "RLOAD" looks like this:
```RLOAD 1 2 {:%Q%a}```

Then the following SPICE RC circuit text would be generated:
```
RC_CIRCUIT
.TRAN 5ns 2ms
VSRC 1 0 PULSE 0 5V 0 0 0 1ms
RLOAD 1 2 10kohm
CCHARGE 2 0 10nF
.END
```

And the SPICE simulation then works.

I hope that my modifications adhere to the style and philosophy of this library as closely as possible.

Please let me know of any modifications you would like to me perform first if you would like to merge this pull request eventually.

Thank you very much.

Ramzi Sabra