### PR TITLE
New formatting grammar implemented

### DIFF
--- a/src/include/units/format.h
+++ b/src/include/units/format.h
@@ -50,24 +50,24 @@ namespace units {
     template <typename CharT>
     struct global_format_specs
     {
-        CharT fill  = '\0';
-        fmt::align_t align = fmt::align_t::none;
-        int width   = 0;
+      CharT fill  = '\0';
+      fmt::align_t align = fmt::align_t::none;
+      int width   = 0;
     };
 
     // Holds specs about the representation (%[specs]Q)
     struct rep_format_specs
     {
-        fmt::sign_t sign = fmt::sign_t::none;
-        bool alt = false;
-        int precision = -1;
-        char type = '\0';
+      fmt::sign_t sign = fmt::sign_t::none;
+      bool alt = false;
+      int precision = -1;
+      char type = '\0';
     };
 
     // Holds specs about the unit (%[specs]q)
     struct unit_format_specs
     {
-        char modifier = '\0';
+      char modifier = '\0';
     };
 
     // Parse a `units-rep-modifier`
@@ -94,8 +94,8 @@ namespace units {
 
       // parse #
       if (*begin == '#') {
-          handler.on_alt();
-          if (++begin == end) return begin;
+        handler.on_alt();
+        if (++begin == end) return begin;
       }
 
       // parse precision if a floating point
@@ -107,7 +107,7 @@ namespace units {
       }
 
       if(begin != end && *begin != '}' && *begin != '%') {
-          handler.on_type(*begin++);
+        handler.on_type(*begin++);
       }
       return begin;
     }
@@ -150,12 +150,12 @@ namespace units {
           constexpr auto Qq = std::string_view{"Qq"};
           auto const new_end = std::find_first_of(begin, end, Qq.begin(), Qq.end());
           if (new_end == end) {
-              throw fmt::format_error("invalid format");
+            throw fmt::format_error("invalid format");
           }
           if (*new_end == 'Q') {
-              handler.on_quantity_value(begin, new_end);
+            handler.on_quantity_value(begin, new_end);
           } else {
-              handler.on_quantity_unit(*begin);
+            handler.on_quantity_unit(*begin);
           }
           ptr = new_end + 1;
         }
@@ -175,31 +175,31 @@ namespace units {
 
       fmt::format_to(to_buffer, "{{:");
       switch(rep_specs.sign) {
-        case fmt::sign::none:
-          break;
-        case fmt::sign::plus:
-          format_to(to_buffer, "+");
-          break;
-        case fmt::sign::minus:
-          format_to(to_buffer, "-");
-          break;
-        case fmt::sign::space:
-          format_to(to_buffer, " ");
-          break;
+      case fmt::sign::none:
+        break;
+      case fmt::sign::plus:
+        format_to(to_buffer, "+");
+        break;
+      case fmt::sign::minus:
+        format_to(to_buffer, "-");
+        break;
+      case fmt::sign::space:
+        format_to(to_buffer, " ");
+        break;
       }
 
       if (rep_specs.alt) {
-          format_to(to_buffer, "#");
+        format_to(to_buffer, "#");
       }
       auto type = rep_specs.type;
       if (auto precision = rep_specs.precision; precision >= 0) {
-          format_to(to_buffer, ".{}{}", precision, type == '\0' ? 'f' : type);
+        format_to(to_buffer, ".{}{}", precision, type == '\0' ? 'f' : type);
       } else if constexpr (treat_as_floating_point<Rep>) {
-              format_to(to_buffer, "{}", type == '\0' ? 'g' : type);
+        format_to(to_buffer, "{}", type == '\0' ? 'g' : type);
       } else {
-          if (type != '\0') {
-              format_to(to_buffer, "{}", type);
-          }
+        if (type != '\0') {
+          format_to(to_buffer, "{}", type);
+        }
       }
       fmt::format_to(to_buffer, "}}");
       return format_to(out, fmt::to_string(buffer), val);
@@ -214,9 +214,9 @@ namespace units {
       unit_format_specs const & unit_specs;
 
       explicit units_formatter(
-          OutputIt o, quantity<Dimension, Unit, Rep> q,
-          global_format_specs<CharT> const & gspecs,
-          rep_format_specs const & rspecs, unit_format_specs const & uspecs
+        OutputIt o, quantity<Dimension, Unit, Rep> q,
+        global_format_specs<CharT> const & gspecs,
+        rep_format_specs const & rspecs, unit_format_specs const & uspecs
       ):
         out(o), val(q.count()), global_specs(gspecs), rep_specs(rspecs), unit_specs(uspecs)
       {
@@ -236,9 +236,9 @@ namespace units {
       void on_quantity_unit([[maybe_unused]] const CharT)
       {
         if (unit_specs.modifier != '\0') {
-            throw fmt::format_error(
-                fmt::format("Unit modifier '{}' is not implemented", unit_specs.modifier)
-            ); // TODO
+          throw fmt::format_error(
+            fmt::format("Unit modifier '{}' is not implemented", unit_specs.modifier)
+          ); // TODO
         }
         format_to(out, "{}", unit_text<Dimension, Unit>().c_str());
       }
@@ -298,12 +298,12 @@ private:
     constexpr void on_precision(int precision) { f.rep_specs.precision = precision; } // rep
     constexpr void on_type(char type)                                     // rep
     {
-        constexpr auto good_types = std::string_view{"aAbBdeEfFgGoxX"};
-        if (good_types.find(type) != std::string_view::npos) {
-            f.rep_specs.type = type;
-        } else {
-            on_error("invalid type specifier");
-        }
+      constexpr auto good_types = std::string_view{"aAbBdeEfFgGoxX"};
+      if (good_types.find(type) != std::string_view::npos) {
+        f.rep_specs.type = type;
+      } else {
+        on_error("invalid type specifier");
+      }
     }
     constexpr void on_modifier(char mod) { f.unit_specs.modifier = mod; } // unit
     constexpr void end_precision() {}
@@ -323,17 +323,17 @@ private:
     constexpr void on_text(const CharT*, const CharT*) {}
     constexpr void on_quantity_value(const CharT* begin, const CharT* end)
     {
-        if (begin != end) {
-            units::detail::parse_units_rep(begin, end, *this, units::treat_as_floating_point<Rep>);
-        }
-        f.quantity_value = true;
+      if (begin != end) {
+        units::detail::parse_units_rep(begin, end, *this, units::treat_as_floating_point<Rep>);
+      }
+      f.quantity_value = true;
     }
     constexpr void on_quantity_unit(const CharT mod)
     {
-        if (mod != 'q') {
-            f.unit_specs.modifier = mod;
-        }
-        f.quantity_unit = true;
+      if (mod != 'q') {
+        f.unit_specs.modifier = mod;
+      }
+      f.quantity_unit = true;
     }
   };
 
@@ -394,22 +394,22 @@ public:
     auto to_gfb = std::back_inserter(global_format_buffer);
     format_to(to_gfb, "{{:");
     if (auto fill = global_specs.fill; fill != '\0') {
-        format_to(to_gfb, "{}", fill);
+      format_to(to_gfb, "{}", fill);
     }
     if (auto align = global_specs.align; align != fmt::align_t::none) {
-        switch (align) {
-        case fmt::align_t::left:
-            format_to(to_gfb, "<");
-            break;
-        case fmt::align_t::right:
-            format_to(to_gfb, ">");
-            break;
-        case fmt::align_t::center:
-            format_to(to_gfb, "^");
-            break;
-        default:
-            break;
-        }
+      switch (align) {
+      case fmt::align_t::left:
+        format_to(to_gfb, "<");
+        break;
+      case fmt::align_t::right:
+        format_to(to_gfb, ">");
+        break;
+      case fmt::align_t::center:
+        format_to(to_gfb, "^");
+        break;
+      default:
+        break;
+      }
     }
     if (auto width = global_specs.width; width >= 1) {
       format_to(to_gfb, "{}", width);
@@ -437,7 +437,6 @@ public:
       // user provided format
       units::detail::units_formatter f(to_quantity_buffer, q, global_specs, rep_specs, unit_specs);
       parse_units_format(begin, end, f);
-
     }
     // Format the `quantity buffer` using specs from `global_format_buffer`
     // In the example, equivalent to fmt::format("{:*^10}", "1.2_m")

--- a/src/include/units/format.h
+++ b/src/include/units/format.h
@@ -298,14 +298,21 @@ private:
     constexpr void on_precision(int precision) { f.rep_specs.precision = precision; } // rep
     constexpr void on_type(char type)                                     // rep
     {
-      constexpr auto good_types = std::string_view{"aAbBdeEfFgGoxX"};
-      if (good_types.find(type) != std::string_view::npos) {
+      constexpr auto valid_types = std::string_view{"aAbBdeEfFgGoxX"};
+      if (valid_types.find(type) != std::string_view::npos) {
         f.rep_specs.type = type;
       } else {
-        on_error("invalid type specifier");
+        on_error("invalid quantity type specifier");
       }
     }
-    constexpr void on_modifier(char mod) { f.unit_specs.modifier = mod; } // unit
+    constexpr void on_modifier(char mod) {
+      constexpr auto valid_modifiers = std::string_view{"A"};
+      if (valid_modifiers.find(mod) != std::string_view::npos) {
+        f.unit_specs.modifier = mod;
+      } else {
+        on_error("invalid unit modifier specified");
+      }
+    } // unit
     constexpr void end_precision() {}
 
     template<typename Id>

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -883,24 +883,24 @@ TEST_CASE("precision specification", "[text][fmt]")
 
   SECTION("full format {:%Q %q} on a quantity")
   {
-    CHECK(fmt::format("{:.0%Q %q}", 1.2345q_m) == "1 m");
-    CHECK(fmt::format("{:.1%Q %q}", 1.2345q_m) == "1.2 m");
-    CHECK(fmt::format("{:.2%Q %q}", 1.2345q_m) == "1.23 m");
-    CHECK(fmt::format("{:.3%Q %q}", 1.2345q_m) == "1.235 m");
-    CHECK(fmt::format("{:.4%Q %q}", 1.2345q_m) == "1.2345 m");
-    CHECK(fmt::format("{:.5%Q %q}", 1.2345q_m) == "1.23450 m");
+    CHECK(fmt::format("{:%.0Q %q}", 1.2345q_m) == "1 m");
+    CHECK(fmt::format("{:%.1Q %q}", 1.2345q_m) == "1.2 m");
+    CHECK(fmt::format("{:%.2Q %q}", 1.2345q_m) == "1.23 m");
+    CHECK(fmt::format("{:%.3Q %q}", 1.2345q_m) == "1.235 m");
+    CHECK(fmt::format("{:%.4Q %q}", 1.2345q_m) == "1.2345 m");
+    CHECK(fmt::format("{:%.5Q %q}", 1.2345q_m) == "1.23450 m");
     CHECK(fmt::format("{:.10%Q %q}", 1.2345q_m) == "1.2345000000 m");
   }
 
   SECTION("value only format {:%Q} on a quantity")
   {
-    CHECK(fmt::format("{:.0%Q}", 1.2345q_m) == "1");
-    CHECK(fmt::format("{:.1%Q}", 1.2345q_m) == "1.2");
-    CHECK(fmt::format("{:.2%Q}", 1.2345q_m) == "1.23");
-    CHECK(fmt::format("{:.3%Q}", 1.2345q_m) == "1.235");
-    CHECK(fmt::format("{:.4%Q}", 1.2345q_m) == "1.2345");
-    CHECK(fmt::format("{:.5%Q}", 1.2345q_m) == "1.23450");
-    CHECK(fmt::format("{:.10%Q}", 1.2345q_m) == "1.2345000000");
+    CHECK(fmt::format("{:%.0Q}", 1.2345q_m) == "1");
+    CHECK(fmt::format("{:%.1Q}", 1.2345q_m) == "1.2");
+    CHECK(fmt::format("{:%.2Q}", 1.2345q_m) == "1.23");
+    CHECK(fmt::format("{:%.3Q}", 1.2345q_m) == "1.235");
+    CHECK(fmt::format("{:%.4Q}", 1.2345q_m) == "1.2345");
+    CHECK(fmt::format("{:%.5Q}", 1.2345q_m) == "1.23450");
+    CHECK(fmt::format("{:%.10Q}", 1.2345q_m) == "1.2345000000");
   }
 }
 
@@ -913,126 +913,90 @@ TEST_CASE("precision specification for integral representation should throw", "[
 
   SECTION("full format {:%Q %q} on a quantity")
   {
-    REQUIRE_THROWS_MATCHES(fmt::format("{:.1%Q %q}", 1q_m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
+    REQUIRE_THROWS_MATCHES(fmt::format("{:%.1Q %q}", 1q_m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
   }
 
   SECTION("value only format {:%Q} on a quantity")
   {
-    REQUIRE_THROWS_MATCHES(fmt::format("{:.1%Q}", 1q_m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
+    REQUIRE_THROWS_MATCHES(fmt::format("{:%.1Q}", 1q_m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
   }
 }
 
 TEST_CASE("type specification", "[text][fmt]")
 {
-  SECTION("default format {} on a quantity")
-  {
-    CHECK(fmt::format("{:b}", 42q_m) == "101010 m");
-    CHECK(fmt::format("{:B}", 42q_m) == "101010 m");
-    CHECK(fmt::format("{:d}", 42q_m) == "42 m");
-    CHECK(fmt::format("{:o}", 42q_m) == "52 m");
-    CHECK(fmt::format("{:x}", 42q_m) == "2a m");
-    CHECK(fmt::format("{:X}", 42q_m) == "2A m");
-
-    CHECK(fmt::format("{:a}",   1.2345678q_m) == "0x9.e065152d8eae841p-3 m");
-    CHECK(fmt::format("{:.3a}", 1.2345678q_m) == "0x9.e06p-3 m");
-    CHECK(fmt::format("{:A}",   1.2345678q_m) == "0X9.E065152D8EAE841P-3 m");
-    CHECK(fmt::format("{:.3A}", 1.2345678q_m) == "0X9.E06P-3 m");
-    CHECK(fmt::format("{:e}",   1.2345678q_m) == "1.234568e+00 m");
-    CHECK(fmt::format("{:.3e}", 1.2345678q_m) == "1.235e+00 m");
-    CHECK(fmt::format("{:E}",   1.2345678q_m) == "1.234568E+00 m");
-    CHECK(fmt::format("{:.3E}", 1.2345678q_m) == "1.235E+00 m");
-    CHECK(fmt::format("{:g}",   1.2345678q_m) == "1.23457 m");
-    CHECK(fmt::format("{:g}",   1.2345678e8q_m) == "1.23457e+08 m");
-    CHECK(fmt::format("{:.3g}", 1.2345678q_m) == "1.23 m");
-    CHECK(fmt::format("{:.3g}", 1.2345678e8q_m) == "1.23e+08 m");
-    CHECK(fmt::format("{:G}",   1.2345678q_m) == "1.23457 m");
-    CHECK(fmt::format("{:G}",   1.2345678e8q_m) == "1.23457E+08 m");
-    CHECK(fmt::format("{:.3G}", 1.2345678q_m) == "1.23 m");
-    CHECK(fmt::format("{:.3G}", 1.2345678e8q_m) == "1.23E+08 m");
-  }
-
   SECTION("full format {:%Q %q} on a quantity")
   {
-    CHECK(fmt::format("{:b%Q %q}", 42q_m) == "101010 m");
-    CHECK(fmt::format("{:B%Q %q}", 42q_m) == "101010 m");
-    CHECK(fmt::format("{:d%Q %q}", 42q_m) == "42 m");
-    CHECK(fmt::format("{:o%Q %q}", 42q_m) == "52 m");
-    CHECK(fmt::format("{:x%Q %q}", 42q_m) == "2a m");
-    CHECK(fmt::format("{:X%Q %q}", 42q_m) == "2A m");
+    CHECK(fmt::format("{:%bQ %q}", 42q_m) == "101010 m");
+    CHECK(fmt::format("{:%BQ %q}", 42q_m) == "101010 m");
+    CHECK(fmt::format("{:%dQ %q}", 42q_m) == "42 m");
+    CHECK(fmt::format("{:%oQ %q}", 42q_m) == "52 m");
+    CHECK(fmt::format("{:%xQ %q}", 42q_m) == "2a m");
+    CHECK(fmt::format("{:%XQ %q}", 42q_m) == "2A m");
 
-    CHECK(fmt::format("{:a%Q %q}",   1.2345678q_m) == "0x9.e065152d8eae841p-3 m");
-    CHECK(fmt::format("{:.3a%Q %q}", 1.2345678q_m) == "0x9.e06p-3 m");
-    CHECK(fmt::format("{:A%Q %q}",   1.2345678q_m) == "0X9.E065152D8EAE841P-3 m");
-    CHECK(fmt::format("{:.3A%Q %q}", 1.2345678q_m) == "0X9.E06P-3 m");
-    CHECK(fmt::format("{:e%Q %q}",   1.2345678q_m) == "1.234568e+00 m");
-    CHECK(fmt::format("{:.3e%Q %q}", 1.2345678q_m) == "1.235e+00 m");
-    CHECK(fmt::format("{:E%Q %q}",   1.2345678q_m) == "1.234568E+00 m");
-    CHECK(fmt::format("{:.3E%Q %q}", 1.2345678q_m) == "1.235E+00 m");
-    CHECK(fmt::format("{:g%Q %q}",   1.2345678q_m) == "1.23457 m");
-    CHECK(fmt::format("{:g%Q %q}",   1.2345678e8q_m) == "1.23457e+08 m");
-    CHECK(fmt::format("{:.3g%Q %q}", 1.2345678q_m) == "1.23 m");
-    CHECK(fmt::format("{:.3g%Q %q}", 1.2345678e8q_m) == "1.23e+08 m");
-    CHECK(fmt::format("{:G%Q %q}",   1.2345678q_m) == "1.23457 m");
-    CHECK(fmt::format("{:G%Q %q}",   1.2345678e8q_m) == "1.23457E+08 m");
-    CHECK(fmt::format("{:.3G%Q %q}", 1.2345678q_m) == "1.23 m");
-    CHECK(fmt::format("{:.3G%Q %q}", 1.2345678e8q_m) == "1.23E+08 m");
+    CHECK(fmt::format("{:%aQ %q}",   1.2345678q_m) == "0x9.e065152d8eae841p-3 m");
+    CHECK(fmt::format("{:%.3aQ %q}", 1.2345678q_m) == "0x9.e06p-3 m");
+    CHECK(fmt::format("{:%AQ %q}",   1.2345678q_m) == "0X9.E065152D8EAE841P-3 m");
+    CHECK(fmt::format("{:%.3AQ %q}", 1.2345678q_m) == "0X9.E06P-3 m");
+    CHECK(fmt::format("{:%eQ %q}",   1.2345678q_m) == "1.234568e+00 m");
+    CHECK(fmt::format("{:%.3eQ %q}", 1.2345678q_m) == "1.235e+00 m");
+    CHECK(fmt::format("{:%EQ %q}",   1.2345678q_m) == "1.234568E+00 m");
+    CHECK(fmt::format("{:%.3EQ %q}", 1.2345678q_m) == "1.235E+00 m");
+    CHECK(fmt::format("{:%gQ %q}",   1.2345678q_m) == "1.23457 m");
+    CHECK(fmt::format("{:%gQ %q}",   1.2345678e8q_m) == "1.23457e+08 m");
+    CHECK(fmt::format("{:%.3gQ %q}", 1.2345678q_m) == "1.23 m");
+    CHECK(fmt::format("{:%.3gQ %q}", 1.2345678e8q_m) == "1.23e+08 m");
+    CHECK(fmt::format("{:%GQ %q}",   1.2345678q_m) == "1.23457 m");
+    CHECK(fmt::format("{:%GQ %q}",   1.2345678e8q_m) == "1.23457E+08 m");
+    CHECK(fmt::format("{:%.3GQ %q}", 1.2345678q_m) == "1.23 m");
+    CHECK(fmt::format("{:%.3GQ %q}", 1.2345678e8q_m) == "1.23E+08 m");
   }
 
   SECTION("value only format {:%Q} on a quantity")
   {
-    CHECK(fmt::format("{:b%Q}", 42q_m) == "101010");
-    CHECK(fmt::format("{:B%Q}", 42q_m) == "101010");
-    CHECK(fmt::format("{:d%Q}", 42q_m) == "42");
-    CHECK(fmt::format("{:o%Q}", 42q_m) == "52");
-    CHECK(fmt::format("{:x%Q}", 42q_m) == "2a");
-    CHECK(fmt::format("{:X%Q}", 42q_m) == "2A");
+    CHECK(fmt::format("{:%bQ}", 42q_m) == "101010");
+    CHECK(fmt::format("{:%BQ}", 42q_m) == "101010");
+    CHECK(fmt::format("{:%dQ}", 42q_m) == "42");
+    CHECK(fmt::format("{:%oQ}", 42q_m) == "52");
+    CHECK(fmt::format("{:%xQ}", 42q_m) == "2a");
+    CHECK(fmt::format("{:%XQ}", 42q_m) == "2A");
 
-    CHECK(fmt::format("{:a%Q}",   1.2345678q_m) == "0x9.e065152d8eae841p-3");
-    CHECK(fmt::format("{:.3a%Q}", 1.2345678q_m) == "0x9.e06p-3");
-    CHECK(fmt::format("{:A%Q}",   1.2345678q_m) == "0X9.E065152D8EAE841P-3");
-    CHECK(fmt::format("{:.3A%Q}", 1.2345678q_m) == "0X9.E06P-3");
-    CHECK(fmt::format("{:e%Q}",   1.2345678q_m) == "1.234568e+00");
-    CHECK(fmt::format("{:.3e%Q}", 1.2345678q_m) == "1.235e+00");
-    CHECK(fmt::format("{:E%Q}",   1.2345678q_m) == "1.234568E+00");
-    CHECK(fmt::format("{:.3E%Q}", 1.2345678q_m) == "1.235E+00");
-    CHECK(fmt::format("{:g%Q}",   1.2345678q_m) == "1.23457");
-    CHECK(fmt::format("{:g%Q}",   1.2345678e8q_m) == "1.23457e+08");
-    CHECK(fmt::format("{:.3g%Q}", 1.2345678q_m) == "1.23");
-    CHECK(fmt::format("{:.3g%Q}", 1.2345678e8q_m) == "1.23e+08");
-    CHECK(fmt::format("{:G%Q}",   1.2345678q_m) == "1.23457");
-    CHECK(fmt::format("{:G%Q}",   1.2345678e8q_m) == "1.23457E+08");
-    CHECK(fmt::format("{:.3G%Q}", 1.2345678q_m) == "1.23");
-    CHECK(fmt::format("{:.3G%Q}", 1.2345678e8q_m) == "1.23E+08");
+    CHECK(fmt::format("{:%aQ}",   1.2345678q_m) == "0x9.e065152d8eae841p-3");
+    CHECK(fmt::format("{:%.3aQ}", 1.2345678q_m) == "0x9.e06p-3");
+    CHECK(fmt::format("{:%AQ}",   1.2345678q_m) == "0X9.E065152D8EAE841P-3");
+    CHECK(fmt::format("{:%.3AQ}", 1.2345678q_m) == "0X9.E06P-3");
+    CHECK(fmt::format("{:%eQ}",   1.2345678q_m) == "1.234568e+00");
+    CHECK(fmt::format("{:%.3eQ}", 1.2345678q_m) == "1.235e+00");
+    CHECK(fmt::format("{:%EQ}",   1.2345678q_m) == "1.234568E+00");
+    CHECK(fmt::format("{:%.3EQ}", 1.2345678q_m) == "1.235E+00");
+    CHECK(fmt::format("{:%gQ}",   1.2345678q_m) == "1.23457");
+    CHECK(fmt::format("{:%gQ}",   1.2345678e8q_m) == "1.23457e+08");
+    CHECK(fmt::format("{:%.3gQ}", 1.2345678q_m) == "1.23");
+    CHECK(fmt::format("{:%.3gQ}", 1.2345678e8q_m) == "1.23e+08");
+    CHECK(fmt::format("{:%GQ}",   1.2345678q_m) == "1.23457");
+    CHECK(fmt::format("{:%GQ}",   1.2345678e8q_m) == "1.23457E+08");
+    CHECK(fmt::format("{:%.3GQ}", 1.2345678q_m) == "1.23");
+    CHECK(fmt::format("{:%.3GQ}", 1.2345678e8q_m) == "1.23E+08");
   }
 }
 
 TEST_CASE("different base types with the # specifier")
 {
-  SECTION("default format {} on a quantity")
-  {
-    CHECK(fmt::format("{:#b}", 42q_m) == "0b101010 m");
-    CHECK(fmt::format("{:#B}", 42q_m) == "0B101010 m");
-    CHECK(fmt::format("{:#o}", 42q_m) == "052 m");
-    CHECK(fmt::format("{:#x}", 42q_m) == "0x2a m");
-    CHECK(fmt::format("{:#X}", 42q_m) == "0X2A m");
-  }
-
   SECTION("full format {:%Q %q} on a quantity")
   {
-    CHECK(fmt::format("{:#b%Q %q}", 42q_m) == "0b101010 m");
-    CHECK(fmt::format("{:#B%Q %q}", 42q_m) == "0B101010 m");
-    CHECK(fmt::format("{:#o%Q %q}", 42q_m) == "052 m");
-    CHECK(fmt::format("{:#x%Q %q}", 42q_m) == "0x2a m");
-    CHECK(fmt::format("{:#X%Q %q}", 42q_m) == "0X2A m");
+    CHECK(fmt::format("{:%#bQ %q}", 42q_m) == "0b101010 m");
+    CHECK(fmt::format("{:%#BQ %q}", 42q_m) == "0B101010 m");
+    CHECK(fmt::format("{:%#oQ %q}", 42q_m) == "052 m");
+    CHECK(fmt::format("{:%#xQ %q}", 42q_m) == "0x2a m");
+    CHECK(fmt::format("{:%#XQ %q}", 42q_m) == "0X2A m");
   }
 
   SECTION("value only format {:%Q} on a quantity")
   {
-    CHECK(fmt::format("{:#b%Q}", 42q_m) == "0b101010");
-    CHECK(fmt::format("{:#B%Q}", 42q_m) == "0B101010");
-    CHECK(fmt::format("{:#o%Q}", 42q_m) == "052");
-    CHECK(fmt::format("{:#x%Q}", 42q_m) == "0x2a");
-    CHECK(fmt::format("{:#X%Q}", 42q_m) == "0X2A");
+    CHECK(fmt::format("{:%#bQ}", 42q_m) == "0b101010");
+    CHECK(fmt::format("{:%#BQ}", 42q_m) == "0B101010");
+    CHECK(fmt::format("{:%#oQ}", 42q_m) == "052");
+    CHECK(fmt::format("{:%#xQ}", 42q_m) == "0x2a");
+    CHECK(fmt::format("{:%#XQ}", 42q_m) == "0X2A");
   }
 }
 

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -836,51 +836,33 @@ TEST_CASE("sign specification", "[text][fmt]")
   length<metre> inf(std::numeric_limits<double>::infinity());
   length<metre> nan(std::numeric_limits<double>::quiet_NaN());
 
-  SECTION("default format {} on a quantity")
-  {
-    CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", 1q_m) == "1 m,+1 m,1 m, 1 m");
-    CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", -1q_m) == "-1 m,-1 m,-1 m,-1 m");
-    CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", inf) == "inf m,+inf m,inf m, inf m");
-    CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", nan) == "nan m,+nan m,nan m, nan m");
-  }
+  /* SECTION("default format {} on a quantity") */
+  /* { */
+  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", 1q_m) == "1 m,+1 m,1 m, 1 m"); */
+  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", -1q_m) == "-1 m,-1 m,-1 m,-1 m"); */
+  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", inf) == "inf m,+inf m,inf m, inf m"); */
+  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", nan) == "nan m,+nan m,nan m, nan m"); */
+  /* } */
 
   SECTION("full format {:%Q %q} on a quantity")
   {
-    CHECK(fmt::format("{0:%Q%q},{0:+%Q%q},{0:-%Q%q},{0: %Q%q}", 1q_m) == "1m,+1m,1m, 1m");
-    CHECK(fmt::format("{0:%Q%q},{0:+%Q%q},{0:-%Q%q},{0: %Q%q}", -1q_m) == "-1m,-1m,-1m,-1m");
-    CHECK(fmt::format("{0:%Q%q},{0:+%Q%q},{0:-%Q%q},{0: %Q%q}", inf) == "infm,+infm,infm, infm");
-    CHECK(fmt::format("{0:%Q%q},{0:+%Q%q},{0:-%Q%q},{0: %Q%q}", nan) == "nanm,+nanm,nanm, nanm");
+    CHECK(fmt::format("{0:%Q%q},{0:%+Q%q},{0:%-Q%q},{0:% Q%q}", 1q_m) == "1m,+1m,1m, 1m");
+    CHECK(fmt::format("{0:%Q%q},{0:%+Q%q},{0:%-Q%q},{0:% Q%q}", -1q_m) == "-1m,-1m,-1m,-1m");
+    CHECK(fmt::format("{0:%Q%q},{0:%+Q%q},{0:%-Q%q},{0:% Q%q}", inf) == "infm,+infm,infm, infm");
+    CHECK(fmt::format("{0:%Q%q},{0:%+Q%q},{0:%-Q%q},{0:% Q%q}", nan) == "nanm,+nanm,nanm, nanm");
   }
 
   SECTION("value only format {:%Q} on a quantity")
   {
-    CHECK(fmt::format("{0:%Q},{0:+%Q},{0:-%Q},{0: %Q}", 1q_m) == "1,+1,1, 1");
-    CHECK(fmt::format("{0:%Q},{0:+%Q},{0:-%Q},{0: %Q}", -1q_m) == "-1,-1,-1,-1");
-    CHECK(fmt::format("{0:%Q},{0:+%Q},{0:-%Q},{0: %Q}", inf) == "inf,+inf,inf, inf");
-    CHECK(fmt::format("{0:%Q},{0:+%Q},{0:-%Q},{0: %Q}", nan) == "nan,+nan,nan, nan");
+    CHECK(fmt::format("{0:%Q},{0:%+Q},{0:%-Q},{0:% Q}", 1q_m) == "1,+1,1, 1");
+    CHECK(fmt::format("{0:%Q},{0:%+Q},{0:%-Q},{0:% Q}", -1q_m) == "-1,-1,-1,-1");
+    CHECK(fmt::format("{0:%Q},{0:%+Q},{0:%-Q},{0:% Q}", inf) == "inf,+inf,inf, inf");
+    CHECK(fmt::format("{0:%Q},{0:%+Q},{0:%-Q},{0:% Q}", nan) == "nan,+nan,nan, nan");
   }
 }
-
-TEST_CASE("sign specification for unit only", "[text][fmt][exception]")
-{
-  CHECK_THROWS_MATCHES(fmt::format("{:+%q}", 1q_m), fmt::format_error, Message("sign not allowed for a quantity unit"));
-  CHECK_THROWS_MATCHES(fmt::format("{:-%q}", 1q_m), fmt::format_error, Message("sign not allowed for a quantity unit"));
-}
-
 
 TEST_CASE("precision specification", "[text][fmt]")
 {
-  SECTION("default format {} on a quantity")
-  {
-    CHECK(fmt::format("{:.1}", 1.2345q_m) == "1.2 m");
-    CHECK(fmt::format("{:.0}", 1.2345q_m) == "1 m");
-    CHECK(fmt::format("{:.2}", 1.2345q_m) == "1.23 m");
-    CHECK(fmt::format("{:.3}", 1.2345q_m) == "1.235 m");
-    CHECK(fmt::format("{:.4}", 1.2345q_m) == "1.2345 m");
-    CHECK(fmt::format("{:.5}", 1.2345q_m) == "1.23450 m");
-    CHECK(fmt::format("{:.10}", 1.2345q_m) == "1.2345000000 m");
-  }
-
   SECTION("full format {:%Q %q} on a quantity")
   {
     CHECK(fmt::format("{:%.0Q %q}", 1.2345q_m) == "1 m");
@@ -889,7 +871,7 @@ TEST_CASE("precision specification", "[text][fmt]")
     CHECK(fmt::format("{:%.3Q %q}", 1.2345q_m) == "1.235 m");
     CHECK(fmt::format("{:%.4Q %q}", 1.2345q_m) == "1.2345 m");
     CHECK(fmt::format("{:%.5Q %q}", 1.2345q_m) == "1.23450 m");
-    CHECK(fmt::format("{:.10%Q %q}", 1.2345q_m) == "1.2345000000 m");
+    CHECK(fmt::format("{:%.10Q %q}", 1.2345q_m) == "1.2345000000 m");
   }
 
   SECTION("value only format {:%Q} on a quantity")
@@ -906,11 +888,6 @@ TEST_CASE("precision specification", "[text][fmt]")
 
 TEST_CASE("precision specification for integral representation should throw", "[text][fmt][exception]")
 {
-  SECTION("default format {} on a quantity")
-  {
-    REQUIRE_THROWS_MATCHES(fmt::format("{:.1}", 1q_m), fmt::format_error, Message("precision not allowed for integral quantity representation"));
-  }
-
   SECTION("full format {:%Q %q} on a quantity")
   {
     REQUIRE_THROWS_MATCHES(fmt::format("{:%.1Q %q}", 1q_m), fmt::format_error, Message("precision not allowed for integral quantity representation"));

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -836,14 +836,6 @@ TEST_CASE("sign specification", "[text][fmt]")
   length<metre> inf(std::numeric_limits<double>::infinity());
   length<metre> nan(std::numeric_limits<double>::quiet_NaN());
 
-  /* SECTION("default format {} on a quantity") */
-  /* { */
-  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", 1q_m) == "1 m,+1 m,1 m, 1 m"); */
-  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", -1q_m) == "-1 m,-1 m,-1 m,-1 m"); */
-  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", inf) == "inf m,+inf m,inf m, inf m"); */
-  /*   CHECK(fmt::format("{0:},{0:+},{0:-},{0: }", nan) == "nan m,+nan m,nan m, nan m"); */
-  /* } */
-
   SECTION("full format {:%Q %q} on a quantity")
   {
     CHECK(fmt::format("{0:%Q%q},{0:%+Q%q},{0:%-Q%q},{0:% Q%q}", 1q_m) == "1m,+1m,1m, 1m");


### PR DESCRIPTION
I've implemented the new grammar, as requested in #81 .
Talking about the `A` unit modifier from #78 , it's already in the list of the currently valid unit modifiers, but using it will result in an exception ("unit modifier 'A' is not implemented"). When the code for the modifier will be ready, we will have to remove exception (line 240) and change the code in the `units_formatter::on_quantity_unit` member function (line 236).

What do you think about it?