### PR TITLE
alias_unit

### DIFF
--- a/src/include/units/physical/si/absorbed_dose.h
+++ b/src/include/units/physical/si/absorbed_dose.h
@@ -31,8 +31,26 @@
 namespace units::si {
 
 struct gray : named_unit<gray, "Gy", prefix> {};
+struct yoctogray : prefixed_unit<yoctogray, yocto, gray> {};
+struct zeptogray : prefixed_unit<zeptogray, zepto, gray> {};
+struct attogray : prefixed_unit<attogray, atto, gray> {};
+struct femtogray : prefixed_unit<femtogray, femto, gray> {};
+struct picogray : prefixed_unit<picogray, pico, gray> {};
+struct nanogray : prefixed_unit<nanogray, nano, gray> {};
+struct microgray : prefixed_unit<microgray, micro, gray> {};
 struct milligray : prefixed_unit<milligray, milli, gray> {};
+struct centigray : prefixed_unit<centigray, centi, gray> {};
+struct decigray : prefixed_unit<decigray, deci, gray> {};
+struct decagray : prefixed_unit<decagray, deca, gray> {};
+struct hectogray : prefixed_unit<hectogray, hecto, gray> {};
 struct kilogray : prefixed_unit<kilogray, kilo, gray> {};
+struct megagray : prefixed_unit<megagray, mega, gray> {};
+struct gigagray : prefixed_unit<gigagray, giga, gray> {};
+struct teragray : prefixed_unit<teragray, tera, gray> {};
+struct petagray : prefixed_unit<petagray, peta, gray> {};
+struct exagray : prefixed_unit<exagray, exa, gray> {};
+struct zettagray : prefixed_unit<zettagray, zetta, gray> {};
+struct yottagray : prefixed_unit<yottagray, yotta, gray> {};
 
 struct dim_absorbed_dose : physical::dim_absorbed_dose<dim_absorbed_dose, gray, dim_energy, dim_mass> {};
 
@@ -45,13 +63,85 @@ inline namespace literals {
 constexpr auto operator"" q_Gy(unsigned long long l) { return absorbed_dose<gray, std::int64_t>(l); }
 constexpr auto operator"" q_Gy(long double l) { return absorbed_dose<gray, long double>(l); }
 
+// yGy
+constexpr auto operator"" q_yGy(unsigned long long l) { return absorbed_dose<yoctogray, std::int64_t>(l); }
+constexpr auto operator"" q_yGy(long double l) { return absorbed_dose<yoctogray, long double>(l); }
+
+// zGy
+constexpr auto operator"" q_zGy(unsigned long long l) { return absorbed_dose<zeptogray, std::int64_t>(l); }
+constexpr auto operator"" q_zGy(long double l) { return absorbed_dose<zeptogray, long double>(l); }
+
+// aGy
+constexpr auto operator"" q_aGy(unsigned long long l) { return absorbed_dose<attogray, std::int64_t>(l); }
+constexpr auto operator"" q_aGy(long double l) { return absorbed_dose<attogray, long double>(l); }
+
+// fGy
+constexpr auto operator"" q_fGy(unsigned long long l) { return absorbed_dose<femtogray, std::int64_t>(l); }
+constexpr auto operator"" q_fGy(long double l) { return absorbed_dose<femtogray, long double>(l); }
+
+// pGy
+constexpr auto operator"" q_pGy(unsigned long long l) { return absorbed_dose<picogray, std::int64_t>(l); }
+constexpr auto operator"" q_pGy(long double l) { return absorbed_dose<picogray, long double>(l); }
+
+// nGy
+constexpr auto operator"" q_nGy(unsigned long long l) { return absorbed_dose<nanogray, std::int64_t>(l); }
+constexpr auto operator"" q_nGy(long double l) { return absorbed_dose<nanogray, long double>(l); }
+
+// uGy
+constexpr auto operator"" q_uGy(unsigned long long l) { return absorbed_dose<microgray, std::int64_t>(l); }
+constexpr auto operator"" q_uGy(long double l) { return absorbed_dose<microgray, long double>(l); }
+
 // mGy
 constexpr auto operator"" q_mGy(unsigned long long l) { return absorbed_dose<milligray, std::int64_t>(l); }
 constexpr auto operator"" q_mGy(long double l) { return absorbed_dose<milligray, long double>(l); }
 
+// cGy
+constexpr auto operator"" q_cGy(unsigned long long l) { return absorbed_dose<centigray, std::int64_t>(l); }
+constexpr auto operator"" q_cGy(long double l) { return absorbed_dose<centigray, long double>(l); }
+
+// dGy
+constexpr auto operator"" q_dGy(unsigned long long l) { return absorbed_dose<decigray, std::int64_t>(l); }
+constexpr auto operator"" q_dGy(long double l) { return absorbed_dose<decigray, long double>(l); }
+
+// daGy
+constexpr auto operator"" q_daGy(unsigned long long l) { return absorbed_dose<decagray, std::int64_t>(l); }
+constexpr auto operator"" q_daGy(long double l) { return absorbed_dose<decagray, long double>(l); }
+
+// hGy
+constexpr auto operator"" q_hGy(unsigned long long l) { return absorbed_dose<hectogray, std::int64_t>(l); }
+constexpr auto operator"" q_hGy(long double l) { return absorbed_dose<hectogray, long double>(l); }
+
 // kGy
 constexpr auto operator"" q_kGy(unsigned long long l) { return absorbed_dose<kilogray, std::int64_t>(l); }
 constexpr auto operator"" q_kGy(long double l) { return absorbed_dose<kilogray, long double>(l); }
+
+// MGy
+constexpr auto operator"" q_MGy(unsigned long long l) { return absorbed_dose<megagray, std::int64_t>(l); }
+constexpr auto operator"" q_MGy(long double l) { return absorbed_dose<megagray, long double>(l); }
+
+// GGy
+constexpr auto operator"" q_GGy(unsigned long long l) { return absorbed_dose<gigagray, std::int64_t>(l); }
+constexpr auto operator"" q_GGy(long double l) { return absorbed_dose<gigagray, long double>(l); }
+
+// TGy
+constexpr auto operator"" q_TGy(unsigned long long l) { return absorbed_dose<teragray, std::int64_t>(l); }
+constexpr auto operator"" q_TGy(long double l) { return absorbed_dose<teragray, long double>(l); }
+
+// PGy
+constexpr auto operator"" q_PGy(unsigned long long l) { return absorbed_dose<petagray, std::int64_t>(l); }
+constexpr auto operator"" q_PGy(long double l) { return absorbed_dose<petagray, long double>(l); }
+
+// EGy
+constexpr auto operator"" q_EGy(unsigned long long l) { return absorbed_dose<exagray, std::int64_t>(l); }
+constexpr auto operator"" q_EGy(long double l) { return absorbed_dose<exagray, long double>(l); }
+
+// ZGy
+constexpr auto operator"" q_ZGy(unsigned long long l) { return absorbed_dose<zettagray, std::int64_t>(l); }
+constexpr auto operator"" q_ZGy(long double l) { return absorbed_dose<zettagray, long double>(l); }
+
+// YGy
+constexpr auto operator"" q_YGy(unsigned long long l) { return absorbed_dose<yottagray, std::int64_t>(l); }
+constexpr auto operator"" q_YGy(long double l) { return absorbed_dose<yottagray, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -52,7 +52,7 @@ struct square_exametre : deduced_unit<square_exametre, dim_area, exametre> {};
 struct square_zettametre : deduced_unit<square_zettametre, dim_area, zettametre> {};
 struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre> {};
 
-using hectare = square_hectometre;
+struct hectare : alias_unit<square_hectometre, "ha"> {};
 
 template<Unit U, Scalar Rep = double>
 using area = quantity<dim_area, U, Rep>;

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -31,12 +31,28 @@ namespace units::si {
 struct square_metre : unit<square_metre> {};
 struct dim_area : physical::dim_area<dim_area, square_metre, dim_length> {};
 
+struct square_yoctometre : deduced_unit<square_yoctometre, dim_area, yoctometre> {};
+struct square_zeptometre : deduced_unit<square_zeptometre, dim_area, zeptometre> {};
+struct square_attometre : deduced_unit<square_attometre, dim_area, attometre> {};
+struct square_femtometre : deduced_unit<square_femtometre, dim_area, femtometre> {};
+struct square_picometre : deduced_unit<square_picometre, dim_area, picometre> {};
+struct square_nanometre : deduced_unit<square_nanometre, dim_area, nanometre> {};
+struct square_micrometre : deduced_unit<square_micrometre, dim_area, micrometre> {};
 struct square_millimetre : deduced_unit<square_millimetre, dim_area, millimetre> {};
 struct square_centimetre : deduced_unit<square_centimetre, dim_area, centimetre> {};
-struct square_femtometre : deduced_unit<square_femtometre, dim_area, femtometre> {};
+struct square_decimetre : deduced_unit<square_decimetre, dim_area, decimetre> {};
+struct square_decametre : deduced_unit<square_decametre, dim_area, decametre> {};
+struct square_hectometre : deduced_unit<square_hectometre, dim_area, hectometre> {};
 struct square_kilometre : deduced_unit<square_kilometre, dim_area, kilometre> {};
+struct square_megametre : deduced_unit<square_megametre, dim_area, megametre> {};
+struct square_gigametre : deduced_unit<square_gigametre, dim_area, gigametre> {};
+struct square_terametre : deduced_unit<square_terametre, dim_area, terametre> {};
+struct square_petametre : deduced_unit<square_petametre, dim_area, petametre> {};
+struct square_exametre : deduced_unit<square_exametre, dim_area, exametre> {};
+struct square_zettametre : deduced_unit<square_zettametre, dim_area, zettametre> {};
+struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre> {};
 
-struct hectare : deduced_unit<hectare, dim_area, hectometre> {};
+using hectare = square_hectometre;
 
 template<Unit U, Scalar Rep = double>
 using area = quantity<dim_area, U, Rep>;
@@ -47,6 +63,34 @@ inline namespace literals {
 constexpr auto operator"" q_m2(unsigned long long l) { return area<square_metre, std::int64_t>(l); }
 constexpr auto operator"" q_m2(long double l) { return area<square_metre, long double>(l); }
 
+// ym2
+constexpr auto operator"" q_ym2(unsigned long long l) { return area<square_yoctometre, std::int64_t>(l); }
+constexpr auto operator"" q_ym2(long double l) { return area<square_yoctometre, long double>(l); }
+
+// zm2
+constexpr auto operator"" q_zm2(unsigned long long l) { return area<square_zeptometre, std::int64_t>(l); }
+constexpr auto operator"" q_zm2(long double l) { return area<square_zeptometre, long double>(l); }
+
+// am2
+constexpr auto operator"" q_am2(unsigned long long l) { return area<square_attometre, std::int64_t>(l); }
+constexpr auto operator"" q_am2(long double l) { return area<square_attometre, long double>(l); }
+
+// fm2
+constexpr auto operator"" q_fm2(unsigned long long l) { return area<square_femtometre, std::int64_t>(l); }
+constexpr auto operator"" q_fm2(long double l) { return area<square_femtometre, long double>(l); }
+
+// pm2
+constexpr auto operator"" q_pm2(unsigned long long l) { return area<square_picometre, std::int64_t>(l); }
+constexpr auto operator"" q_pm2(long double l) { return area<square_picometre, long double>(l); }
+
+// nm2
+constexpr auto operator"" q_nm2(unsigned long long l) { return area<square_nanometre, std::int64_t>(l); }
+constexpr auto operator"" q_nm2(long double l) { return area<square_nanometre, long double>(l); }
+
+// um2
+constexpr auto operator"" q_um2(unsigned long long l) { return area<square_micrometre, std::int64_t>(l); }
+constexpr auto operator"" q_um2(long double l) { return area<square_micrometre, long double>(l); }
+
 // mm2
 constexpr auto operator"" q_mm2(unsigned long long l) { return area<square_millimetre, std::int64_t>(l); }
 constexpr auto operator"" q_mm2(long double l) { return area<square_millimetre, long double>(l); }
@@ -55,13 +99,49 @@ constexpr auto operator"" q_mm2(long double l) { return area<square_millimetre, 
 constexpr auto operator"" q_cm2(unsigned long long l) { return area<square_centimetre, std::int64_t>(l); }
 constexpr auto operator"" q_cm2(long double l) { return area<square_centimetre, long double>(l); }
 
-// fm2
-constexpr auto operator"" q_fm2(unsigned long long l) { return area<square_femtometre, std::int64_t>(l); }
-constexpr auto operator"" q_fm2(long double l) { return area<square_femtometre, long double>(l); }
+// dm2
+constexpr auto operator"" q_dm2(unsigned long long l) { return area<square_decimetre, std::int64_t>(l); }
+constexpr auto operator"" q_dm2(long double l) { return area<square_decimetre, long double>(l); }
+
+// dam2
+constexpr auto operator"" q_dam2(unsigned long long l) { return area<square_decametre, std::int64_t>(l); }
+constexpr auto operator"" q_dam2(long double l) { return area<square_decametre, long double>(l); }
+
+// hm2
+constexpr auto operator"" q_hm2(unsigned long long l) { return area<square_hectometre, std::int64_t>(l); }
+constexpr auto operator"" q_hm2(long double l) { return area<square_hectometre, long double>(l); }
 
 // km2
 constexpr auto operator"" q_km2(unsigned long long l) { return area<square_kilometre, std::int64_t>(l); }
 constexpr auto operator"" q_km2(long double l) { return area<square_kilometre, long double>(l); }
+
+// Mm2
+constexpr auto operator"" q_Mm2(unsigned long long l) { return area<square_megametre, std::int64_t>(l); }
+constexpr auto operator"" q_Mm2(long double l) { return area<square_megametre, long double>(l); }
+
+// Gm2
+constexpr auto operator"" q_Gm2(unsigned long long l) { return area<square_gigametre, std::int64_t>(l); }
+constexpr auto operator"" q_Gm2(long double l) { return area<square_gigametre, long double>(l); }
+
+// Tm2
+constexpr auto operator"" q_Tm2(unsigned long long l) { return area<square_terametre, std::int64_t>(l); }
+constexpr auto operator"" q_Tm2(long double l) { return area<square_terametre, long double>(l); }
+
+// Pm2
+constexpr auto operator"" q_Pm2(unsigned long long l) { return area<square_petametre, std::int64_t>(l); }
+constexpr auto operator"" q_Pm2(long double l) { return area<square_petametre, long double>(l); }
+
+// Em2
+constexpr auto operator"" q_Em2(unsigned long long l) { return area<square_exametre, std::int64_t>(l); }
+constexpr auto operator"" q_Em2(long double l) { return area<square_exametre, long double>(l); }
+
+// Zm2
+constexpr auto operator"" q_Zm2(unsigned long long l) { return area<square_zettametre, std::int64_t>(l); }
+constexpr auto operator"" q_Zm2(long double l) { return area<square_zettametre, long double>(l); }
+
+// Ym2
+constexpr auto operator"" q_Ym2(unsigned long long l) { return area<square_yottametre, std::int64_t>(l); }
+constexpr auto operator"" q_Ym2(long double l) { return area<square_yottametre, long double>(l); }
 
 // ha
 constexpr auto operator"" q_ha(unsigned long long l) { return area<hectare, std::int64_t>(l); }

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -52,7 +52,7 @@ struct square_exametre : deduced_unit<square_exametre, dim_area, exametre> {};
 struct square_zettametre : deduced_unit<square_zettametre, dim_area, zettametre> {};
 struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre> {};
 
-struct hectare : alias_unit<square_hectometre, "ha"> {};
+struct hectare : alias_unit<square_hectometre, "ha", no_prefix> {};
 
 template<Unit U, Scalar Rep = double>
 using area = quantity<dim_area, U, Rep>;

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -31,11 +31,26 @@
 namespace units::si {
 
 struct farad : named_unit<farad, "F", prefix> {};
-
-struct millifarad : prefixed_unit<millifarad, milli, farad> {};
-struct microfarad : prefixed_unit<microfarad, micro, farad> {};
-struct nanofarad : prefixed_unit<nanofarad, nano, farad> {};
+struct yoctofarad : prefixed_unit<yoctofarad, yocto, farad> {};
+struct zeptofarad : prefixed_unit<zeptofarad, zepto, farad> {};
+struct attofarad : prefixed_unit<attofarad, atto, farad> {};
+struct femtofarad : prefixed_unit<femtofarad, femto, farad> {};
 struct picofarad : prefixed_unit<picofarad, pico, farad> {};
+struct nanofarad : prefixed_unit<nanofarad, nano, farad> {};
+struct microfarad : prefixed_unit<microfarad, micro, farad> {};
+struct millifarad : prefixed_unit<millifarad, milli, farad> {};
+struct centifarad : prefixed_unit<centifarad, centi, farad> {};
+struct decifarad : prefixed_unit<decifarad, deci, farad> {};
+struct decafarad : prefixed_unit<decafarad, deca, farad> {};
+struct hectofarad : prefixed_unit<hectofarad, hecto, farad> {};
+struct kilofarad : prefixed_unit<kilofarad, kilo, farad> {};
+struct megafarad : prefixed_unit<megafarad, mega, farad> {};
+struct gigafarad : prefixed_unit<gigafarad, giga, farad> {};
+struct terafarad : prefixed_unit<terafarad, tera, farad> {};
+struct petafarad : prefixed_unit<petafarad, peta, farad> {};
+struct exafarad : prefixed_unit<exafarad, exa, farad> {};
+struct zettafarad : prefixed_unit<zettafarad, zetta, farad> {};
+struct yottafarad : prefixed_unit<yottafarad, yotta, farad> {};
 
 struct dim_capacitance : physical::dim_capacitance<dim_capacitance, farad, dim_electric_charge, dim_voltage> {};
 
@@ -48,17 +63,85 @@ inline namespace literals {
 constexpr auto operator"" q_F(unsigned long long l) { return capacitance<farad, std::int64_t>(l); }
 constexpr auto operator"" q_F(long double l) { return capacitance<farad, long double>(l); }
 
-constexpr auto operator"" q_mF(unsigned long long l) { return capacitance<millifarad, std::int64_t>(l); }
-constexpr auto operator"" q_mF(long double l) { return capacitance<millifarad, long double>(l); }
+// yF
+constexpr auto operator"" q_yF(unsigned long long l) { return capacitance<yoctofarad, std::int64_t>(l); }
+constexpr auto operator"" q_yF(long double l) { return capacitance<yoctofarad, long double>(l); }
 
-constexpr auto operator"" q_uF(unsigned long long l) { return capacitance<microfarad, std::int64_t>(l); }
-constexpr auto operator"" q_uF(long double l) { return capacitance<microfarad, long double>(l); }
+// zF
+constexpr auto operator"" q_zF(unsigned long long l) { return capacitance<zeptofarad, std::int64_t>(l); }
+constexpr auto operator"" q_zF(long double l) { return capacitance<zeptofarad, long double>(l); }
 
+// aF
+constexpr auto operator"" q_aF(unsigned long long l) { return capacitance<attofarad, std::int64_t>(l); }
+constexpr auto operator"" q_aF(long double l) { return capacitance<attofarad, long double>(l); }
+
+// fF
+constexpr auto operator"" q_fF(unsigned long long l) { return capacitance<femtofarad, std::int64_t>(l); }
+constexpr auto operator"" q_fF(long double l) { return capacitance<femtofarad, long double>(l); }
+
+// pF
+constexpr auto operator"" q_pF(unsigned long long l) { return capacitance<picofarad, std::int64_t>(l); }
+constexpr auto operator"" q_pF(long double l) { return capacitance<picofarad, long double>(l); }
+
+// nF
 constexpr auto operator"" q_nF(unsigned long long l) { return capacitance<nanofarad, std::int64_t>(l); }
 constexpr auto operator"" q_nF(long double l) { return capacitance<nanofarad, long double>(l); }
 
-constexpr auto operator"" q_pF(unsigned long long l) { return capacitance<picofarad, std::int64_t>(l); }
-constexpr auto operator"" q_pF(long double l) { return capacitance<picofarad, long double>(l); }
+// uF
+constexpr auto operator"" q_uF(unsigned long long l) { return capacitance<microfarad, std::int64_t>(l); }
+constexpr auto operator"" q_uF(long double l) { return capacitance<microfarad, long double>(l); }
+
+// mF
+constexpr auto operator"" q_mF(unsigned long long l) { return capacitance<millifarad, std::int64_t>(l); }
+constexpr auto operator"" q_mF(long double l) { return capacitance<millifarad, long double>(l); }
+
+// cF
+constexpr auto operator"" q_cF(unsigned long long l) { return capacitance<centifarad, std::int64_t>(l); }
+constexpr auto operator"" q_cF(long double l) { return capacitance<centifarad, long double>(l); }
+
+// dF
+constexpr auto operator"" q_dF(unsigned long long l) { return capacitance<decifarad, std::int64_t>(l); }
+constexpr auto operator"" q_dF(long double l) { return capacitance<decifarad, long double>(l); }
+
+// daF
+constexpr auto operator"" q_daF(unsigned long long l) { return capacitance<decafarad, std::int64_t>(l); }
+constexpr auto operator"" q_daF(long double l) { return capacitance<decafarad, long double>(l); }
+
+// hF
+constexpr auto operator"" q_hF(unsigned long long l) { return capacitance<hectofarad, std::int64_t>(l); }
+constexpr auto operator"" q_hF(long double l) { return capacitance<hectofarad, long double>(l); }
+
+// kF
+constexpr auto operator"" q_kF(unsigned long long l) { return capacitance<kilofarad, std::int64_t>(l); }
+constexpr auto operator"" q_kF(long double l) { return capacitance<kilofarad, long double>(l); }
+
+// MF
+constexpr auto operator"" q_MF(unsigned long long l) { return capacitance<megafarad, std::int64_t>(l); }
+constexpr auto operator"" q_MF(long double l) { return capacitance<megafarad, long double>(l); }
+
+// GF
+constexpr auto operator"" q_GF(unsigned long long l) { return capacitance<gigafarad, std::int64_t>(l); }
+constexpr auto operator"" q_GF(long double l) { return capacitance<gigafarad, long double>(l); }
+
+// TF
+constexpr auto operator"" q_TF(unsigned long long l) { return capacitance<terafarad, std::int64_t>(l); }
+constexpr auto operator"" q_TF(long double l) { return capacitance<terafarad, long double>(l); }
+
+// PF
+constexpr auto operator"" q_PF(unsigned long long l) { return capacitance<petafarad, std::int64_t>(l); }
+constexpr auto operator"" q_PF(long double l) { return capacitance<petafarad, long double>(l); }
+
+// EF
+constexpr auto operator"" q_EF(unsigned long long l) { return capacitance<exafarad, std::int64_t>(l); }
+constexpr auto operator"" q_EF(long double l) { return capacitance<exafarad, long double>(l); }
+
+// ZF
+constexpr auto operator"" q_ZF(unsigned long long l) { return capacitance<zettafarad, std::int64_t>(l); }
+constexpr auto operator"" q_ZF(long double l) { return capacitance<zettafarad, long double>(l); }
+
+// YF
+constexpr auto operator"" q_YF(unsigned long long l) { return capacitance<yottafarad, std::int64_t>(l); }
+constexpr auto operator"" q_YF(long double l) { return capacitance<yottafarad, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/catalytic_activity.h
+++ b/src/include/units/physical/si/catalytic_activity.h
@@ -31,7 +31,26 @@
 namespace units::si {
 
 struct katal : named_unit<katal, "kat", prefix> {};
+struct yoctokatal : prefixed_unit<yoctokatal, yocto, katal> {};
+struct zeptokatal : prefixed_unit<zeptokatal, zepto, katal> {};
+struct attokatal : prefixed_unit<attokatal, atto, katal> {};
+struct femtokatal : prefixed_unit<femtokatal, femto, katal> {};
+struct picokatal : prefixed_unit<picokatal, pico, katal> {};
 struct nanokatal : prefixed_unit<nanokatal, nano, katal> {};
+struct microkatal : prefixed_unit<microkatal, micro, katal> {};
+struct millikatal : prefixed_unit<millikatal, milli, katal> {};
+struct centikatal : prefixed_unit<centikatal, centi, katal> {};
+struct decikatal : prefixed_unit<decikatal, deci, katal> {};
+struct decakatal : prefixed_unit<decakatal, deca, katal> {};
+struct hectokatal : prefixed_unit<hectokatal, hecto, katal> {};
+struct kilokatal : prefixed_unit<kilokatal, kilo, katal> {};
+struct megakatal : prefixed_unit<megakatal, mega, katal> {};
+struct gigakatal : prefixed_unit<gigakatal, giga, katal> {};
+struct terakatal : prefixed_unit<terakatal, tera, katal> {};
+struct petakatal : prefixed_unit<petakatal, peta, katal> {};
+struct exakatal : prefixed_unit<exakatal, exa, katal> {};
+struct zettakatal : prefixed_unit<zettakatal, zetta, katal> {};
+struct yottakatal : prefixed_unit<yottakatal, yotta, katal> {};
 
 struct enzyme_unit : named_scaled_unit<enzyme_unit, "U", prefix, ratio<1, 60, -6>, katal> {};
 
@@ -46,9 +65,85 @@ inline namespace literals {
 constexpr auto operator"" q_kat(unsigned long long l) { return catalytic_activity<katal, std::int64_t>(l); }
 constexpr auto operator"" q_kat(long double l) { return catalytic_activity<katal, long double>(l); }
 
+// ykat
+constexpr auto operator"" q_ykat(unsigned long long l) { return catalytic_activity<yoctokatal, std::int64_t>(l); }
+constexpr auto operator"" q_ykat(long double l) { return catalytic_activity<yoctokatal, long double>(l); }
+
+// zkat
+constexpr auto operator"" q_zkat(unsigned long long l) { return catalytic_activity<zeptokatal, std::int64_t>(l); }
+constexpr auto operator"" q_zkat(long double l) { return catalytic_activity<zeptokatal, long double>(l); }
+
+// akat
+constexpr auto operator"" q_akat(unsigned long long l) { return catalytic_activity<attokatal, std::int64_t>(l); }
+constexpr auto operator"" q_akat(long double l) { return catalytic_activity<attokatal, long double>(l); }
+
+// fkat
+constexpr auto operator"" q_fkat(unsigned long long l) { return catalytic_activity<femtokatal, std::int64_t>(l); }
+constexpr auto operator"" q_fkat(long double l) { return catalytic_activity<femtokatal, long double>(l); }
+
+// pkat
+constexpr auto operator"" q_pkat(unsigned long long l) { return catalytic_activity<picokatal, std::int64_t>(l); }
+constexpr auto operator"" q_pkat(long double l) { return catalytic_activity<picokatal, long double>(l); }
+
 // nkat
 constexpr auto operator"" q_nkat(unsigned long long l) { return catalytic_activity<nanokatal, std::int64_t>(l); }
 constexpr auto operator"" q_nkat(long double l) { return catalytic_activity<nanokatal, long double>(l); }
+
+// ukat
+constexpr auto operator"" q_ukat(unsigned long long l) { return catalytic_activity<microkatal, std::int64_t>(l); }
+constexpr auto operator"" q_ukat(long double l) { return catalytic_activity<microkatal, long double>(l); }
+
+// mkat
+constexpr auto operator"" q_mkat(unsigned long long l) { return catalytic_activity<millikatal, std::int64_t>(l); }
+constexpr auto operator"" q_mkat(long double l) { return catalytic_activity<millikatal, long double>(l); }
+
+// ckat
+constexpr auto operator"" q_ckat(unsigned long long l) { return catalytic_activity<centikatal, std::int64_t>(l); }
+constexpr auto operator"" q_ckat(long double l) { return catalytic_activity<centikatal, long double>(l); }
+
+// dkat
+constexpr auto operator"" q_dkat(unsigned long long l) { return catalytic_activity<decikatal, std::int64_t>(l); }
+constexpr auto operator"" q_dkat(long double l) { return catalytic_activity<decikatal, long double>(l); }
+
+// dakat
+constexpr auto operator"" q_dakat(unsigned long long l) { return catalytic_activity<decakatal, std::int64_t>(l); }
+constexpr auto operator"" q_dakat(long double l) { return catalytic_activity<decakatal, long double>(l); }
+
+// hkat
+constexpr auto operator"" q_hkat(unsigned long long l) { return catalytic_activity<hectokatal, std::int64_t>(l); }
+constexpr auto operator"" q_hkat(long double l) { return catalytic_activity<hectokatal, long double>(l); }
+
+// kkat
+constexpr auto operator"" q_kkat(unsigned long long l) { return catalytic_activity<kilokatal, std::int64_t>(l); }
+constexpr auto operator"" q_kkat(long double l) { return catalytic_activity<kilokatal, long double>(l); }
+
+// Mkat
+constexpr auto operator"" q_Mkat(unsigned long long l) { return catalytic_activity<megakatal, std::int64_t>(l); }
+constexpr auto operator"" q_Mkat(long double l) { return catalytic_activity<megakatal, long double>(l); }
+
+// Gkat
+constexpr auto operator"" q_Gkat(unsigned long long l) { return catalytic_activity<gigakatal, std::int64_t>(l); }
+constexpr auto operator"" q_Gkat(long double l) { return catalytic_activity<gigakatal, long double>(l); }
+
+// Tkat
+constexpr auto operator"" q_Tkat(unsigned long long l) { return catalytic_activity<terakatal, std::int64_t>(l); }
+constexpr auto operator"" q_Tkat(long double l) { return catalytic_activity<terakatal, long double>(l); }
+
+// Pkat
+constexpr auto operator"" q_Pkat(unsigned long long l) { return catalytic_activity<petakatal, std::int64_t>(l); }
+constexpr auto operator"" q_Pkat(long double l) { return catalytic_activity<petakatal, long double>(l); }
+
+// Ekat
+constexpr auto operator"" q_Ekat(unsigned long long l) { return catalytic_activity<exakatal, std::int64_t>(l); }
+constexpr auto operator"" q_Ekat(long double l) { return catalytic_activity<exakatal, long double>(l); }
+
+// Zkat
+constexpr auto operator"" q_Zkat(unsigned long long l) { return catalytic_activity<zettakatal, std::int64_t>(l); }
+constexpr auto operator"" q_Zkat(long double l) { return catalytic_activity<zettakatal, long double>(l); }
+
+// Ykat
+constexpr auto operator"" q_Ykat(unsigned long long l) { return catalytic_activity<yottakatal, std::int64_t>(l); }
+constexpr auto operator"" q_Ykat(long double l) { return catalytic_activity<yottakatal, long double>(l); }
 
 // U
 constexpr auto operator"" q_U(unsigned long long l) { return catalytic_activity<enzyme_unit, std::int64_t>(l); }

--- a/src/include/units/physical/si/conductance.h
+++ b/src/include/units/physical/si/conductance.h
@@ -30,9 +30,22 @@
 namespace units::si {
 
 struct siemens : named_unit<siemens, "S", prefix> {};
-struct millisiemens : prefixed_unit<millisiemens, milli, siemens> {};
-struct microsiemens : prefixed_unit<microsiemens, micro, siemens> {};
+struct yoctosiemens : prefixed_unit<yoctosiemens, yocto, siemens> {};
+struct zeptosiemens : prefixed_unit<zeptosiemens, zepto, siemens> {};
+struct attosiemens : prefixed_unit<attosiemens, atto, siemens> {};
+struct femtosiemens : prefixed_unit<femtosiemens, femto, siemens> {};
+struct picosiemens : prefixed_unit<picosiemens, pico, siemens> {};
 struct nanosiemens : prefixed_unit<nanosiemens, nano, siemens> {};
+struct microsiemens : prefixed_unit<microsiemens, micro, siemens> {};
+struct millisiemens : prefixed_unit<millisiemens, milli, siemens> {};
+struct kilosiemens : prefixed_unit<kilosiemens, kilo, siemens> {};
+struct megasiemens : prefixed_unit<megasiemens, mega, siemens> {};
+struct gigasiemens : prefixed_unit<gigasiemens, giga, siemens> {};
+struct terasiemens : prefixed_unit<terasiemens, tera, siemens> {};
+struct petasiemens : prefixed_unit<petasiemens, peta, siemens> {};
+struct exasiemens : prefixed_unit<exasiemens, exa, siemens> {};
+struct zettasiemens : prefixed_unit<zettasiemens, zetta, siemens> {};
+struct yottasiemens : prefixed_unit<yottasiemens, yotta, siemens> {};
 
 struct dim_conductance : physical::dim_conductance<dim_conductance, siemens, dim_resistance> {};
 
@@ -45,17 +58,69 @@ inline namespace literals {
 constexpr auto operator"" q_S(unsigned long long l) { return conductance<siemens, std::int64_t>(l); }
 constexpr auto operator"" q_S(long double l) { return conductance<siemens, long double>(l); }
 
-// mS
-constexpr auto operator"" q_mS(unsigned long long l) { return conductance<millisiemens, std::int64_t>(l); }
-constexpr auto operator"" q_mS(long double l) { return conductance<millisiemens, long double>(l); }
+// yS
+constexpr auto operator"" q_yS(unsigned long long l) { return conductance<yoctosiemens, std::int64_t>(l); }
+constexpr auto operator"" q_yS(long double l) { return conductance<yoctosiemens, long double>(l); }
+
+// zS
+constexpr auto operator"" q_zS(unsigned long long l) { return conductance<zeptosiemens, std::int64_t>(l); }
+constexpr auto operator"" q_zS(long double l) { return conductance<zeptosiemens, long double>(l); }
+
+// aS
+constexpr auto operator"" q_aS(unsigned long long l) { return conductance<attosiemens, std::int64_t>(l); }
+constexpr auto operator"" q_aS(long double l) { return conductance<attosiemens, long double>(l); }
+
+// fS
+constexpr auto operator"" q_fS(unsigned long long l) { return conductance<femtosiemens, std::int64_t>(l); }
+constexpr auto operator"" q_fS(long double l) { return conductance<femtosiemens, long double>(l); }
+
+// pS
+constexpr auto operator"" q_pS(unsigned long long l) { return conductance<picosiemens, std::int64_t>(l); }
+constexpr auto operator"" q_pS(long double l) { return conductance<picosiemens, long double>(l); }
+
+// nS
+constexpr auto operator"" q_nS(unsigned long long l) { return conductance<nanosiemens, std::int64_t>(l); }
+constexpr auto operator"" q_nS(long double l) { return conductance<nanosiemens, long double>(l); }
 
 // µS
 constexpr auto operator"" q_uS(unsigned long long l) { return conductance<microsiemens, std::int64_t>(l); }
 constexpr auto operator"" q_uS(long double l) { return conductance<microsiemens, long double>(l); }
 
-// nS
-constexpr auto operator"" q_nS(unsigned long long l) { return conductance<nanosiemens, std::int64_t>(l); }
-constexpr auto operator"" q_nS(long double l) { return conductance<nanosiemens, long double>(l); }
+// mS
+constexpr auto operator"" q_mS(unsigned long long l) { return conductance<millisiemens, std::int64_t>(l); }
+constexpr auto operator"" q_mS(long double l) { return conductance<millisiemens, long double>(l); }
+
+// kS
+constexpr auto operator"" q_kS(unsigned long long l) { return conductance<kilosiemens, std::int64_t>(l); }
+constexpr auto operator"" q_kS(long double l) { return conductance<kilosiemens, long double>(l); }
+
+// MS
+constexpr auto operator"" q_MS(unsigned long long l) { return conductance<megasiemens, std::int64_t>(l); }
+constexpr auto operator"" q_MS(long double l) { return conductance<megasiemens, long double>(l); }
+
+// GS
+constexpr auto operator"" q_GS(unsigned long long l) { return conductance<gigasiemens, std::int64_t>(l); }
+constexpr auto operator"" q_GS(long double l) { return conductance<gigasiemens, long double>(l); }
+
+// TS
+constexpr auto operator"" q_TS(unsigned long long l) { return conductance<terasiemens, std::int64_t>(l); }
+constexpr auto operator"" q_TS(long double l) { return conductance<terasiemens, long double>(l); }
+
+// PS
+constexpr auto operator"" q_PS(unsigned long long l) { return conductance<petasiemens, std::int64_t>(l); }
+constexpr auto operator"" q_PS(long double l) { return conductance<petasiemens, long double>(l); }
+
+// ES
+constexpr auto operator"" q_ES(unsigned long long l) { return conductance<exasiemens, std::int64_t>(l); }
+constexpr auto operator"" q_ES(long double l) { return conductance<exasiemens, long double>(l); }
+
+// ZS
+constexpr auto operator"" q_ZS(unsigned long long l) { return conductance<zettasiemens, std::int64_t>(l); }
+constexpr auto operator"" q_ZS(long double l) { return conductance<zettasiemens, long double>(l); }
+
+// YS
+constexpr auto operator"" q_YS(unsigned long long l) { return conductance<yottasiemens, std::int64_t>(l); }
+constexpr auto operator"" q_YS(long double l) { return conductance<yottasiemens, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -29,6 +29,26 @@
 namespace units::si {
 
 struct ampere : named_unit<ampere, "A", prefix> {};
+struct yoctoampere : prefixed_unit<yoctoampere, yocto, ampere> {};
+struct zeptoampere : prefixed_unit<zeptoampere, zepto, ampere> {};
+struct attoampere : prefixed_unit<attoampere, atto, ampere> {};
+struct femtoampere : prefixed_unit<femtoampere, femto, ampere> {};
+struct picoampere : prefixed_unit<picoampere, pico, ampere> {};
+struct nanoampere : prefixed_unit<nanoampere, nano, ampere> {};
+struct microampere : prefixed_unit<microampere, micro, ampere> {};
+struct milliampere : prefixed_unit<milliampere, milli, ampere> {};
+struct centiampere : prefixed_unit<centiampere, centi, ampere> {};
+struct deciampere : prefixed_unit<deciampere, deci, ampere> {};
+struct decaampere : prefixed_unit<decaampere, deca, ampere> {};
+struct hectoampere : prefixed_unit<hectoampere, hecto, ampere> {};
+struct kiloampere : prefixed_unit<kiloampere, kilo, ampere> {};
+struct megaampere : prefixed_unit<megaampere, mega, ampere> {};
+struct gigaampere : prefixed_unit<gigaampere, giga, ampere> {};
+struct teraampere : prefixed_unit<teraampere, tera, ampere> {};
+struct petaampere : prefixed_unit<petaampere, peta, ampere> {};
+struct exaampere : prefixed_unit<exaampere, exa, ampere> {};
+struct zettaampere : prefixed_unit<zettaampere, zetta, ampere> {};
+struct yottaampere : prefixed_unit<yottaampere, yotta, ampere> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 
@@ -40,6 +60,86 @@ inline namespace literals {
 // A
 constexpr auto operator"" q_A(unsigned long long l) { return current<ampere, std::int64_t>(l); }
 constexpr auto operator"" q_A(long double l) { return current<ampere, long double>(l); }
+
+// yA
+constexpr auto operator"" q_yA(unsigned long long l) { return current<yoctoampere, std::int64_t>(l); }
+constexpr auto operator"" q_yA(long double l) { return current<yoctoampere, long double>(l); }
+
+// zA
+constexpr auto operator"" q_zA(unsigned long long l) { return current<zeptoampere, std::int64_t>(l); }
+constexpr auto operator"" q_zA(long double l) { return current<zeptoampere, long double>(l); }
+
+// aA
+constexpr auto operator"" q_aA(unsigned long long l) { return current<attoampere, std::int64_t>(l); }
+constexpr auto operator"" q_aA(long double l) { return current<attoampere, long double>(l); }
+
+// fA
+constexpr auto operator"" q_fA(unsigned long long l) { return current<femtoampere, std::int64_t>(l); }
+constexpr auto operator"" q_fA(long double l) { return current<femtoampere, long double>(l); }
+
+// pA
+constexpr auto operator"" q_pA(unsigned long long l) { return current<picoampere, std::int64_t>(l); }
+constexpr auto operator"" q_pA(long double l) { return current<picoampere, long double>(l); }
+
+// nA
+constexpr auto operator"" q_nA(unsigned long long l) { return current<nanoampere, std::int64_t>(l); }
+constexpr auto operator"" q_nA(long double l) { return current<nanoampere, long double>(l); }
+
+// uA
+constexpr auto operator"" q_uA(unsigned long long l) { return current<microampere, std::int64_t>(l); }
+constexpr auto operator"" q_uA(long double l) { return current<microampere, long double>(l); }
+
+// mA
+constexpr auto operator"" q_mA(unsigned long long l) { return current<milliampere, std::int64_t>(l); }
+constexpr auto operator"" q_mA(long double l) { return current<milliampere, long double>(l); }
+
+// cA
+constexpr auto operator"" q_cA(unsigned long long l) { return current<centiampere, std::int64_t>(l); }
+constexpr auto operator"" q_cA(long double l) { return current<centiampere, long double>(l); }
+
+// dA
+constexpr auto operator"" q_dA(unsigned long long l) { return current<deciampere, std::int64_t>(l); }
+constexpr auto operator"" q_dA(long double l) { return current<deciampere, long double>(l); }
+
+// daA
+constexpr auto operator"" q_daA(unsigned long long l) { return current<decaampere, std::int64_t>(l); }
+constexpr auto operator"" q_daA(long double l) { return current<decaampere, long double>(l); }
+
+// hA
+constexpr auto operator"" q_hA(unsigned long long l) { return current<hectoampere, std::int64_t>(l); }
+constexpr auto operator"" q_hA(long double l) { return current<hectoampere, long double>(l); }
+
+// kA
+constexpr auto operator"" q_kA(unsigned long long l) { return current<kiloampere, std::int64_t>(l); }
+constexpr auto operator"" q_kA(long double l) { return current<kiloampere, long double>(l); }
+
+// MA
+constexpr auto operator"" q_MA(unsigned long long l) { return current<megaampere, std::int64_t>(l); }
+constexpr auto operator"" q_MA(long double l) { return current<megaampere, long double>(l); }
+
+// GA
+constexpr auto operator"" q_GA(unsigned long long l) { return current<gigaampere, std::int64_t>(l); }
+constexpr auto operator"" q_GA(long double l) { return current<gigaampere, long double>(l); }
+
+// TA
+constexpr auto operator"" q_TA(unsigned long long l) { return current<teraampere, std::int64_t>(l); }
+constexpr auto operator"" q_TA(long double l) { return current<teraampere, long double>(l); }
+
+// PA
+constexpr auto operator"" q_PA(unsigned long long l) { return current<petaampere, std::int64_t>(l); }
+constexpr auto operator"" q_PA(long double l) { return current<petaampere, long double>(l); }
+
+// EA
+constexpr auto operator"" q_EA(unsigned long long l) { return current<exaampere, std::int64_t>(l); }
+constexpr auto operator"" q_EA(long double l) { return current<exaampere, long double>(l); }
+
+// ZA
+constexpr auto operator"" q_ZA(unsigned long long l) { return current<zettaampere, std::int64_t>(l); }
+constexpr auto operator"" q_ZA(long double l) { return current<zettaampere, long double>(l); }
+
+// YA
+constexpr auto operator"" q_YA(unsigned long long l) { return current<yottaampere, std::int64_t>(l); }
+constexpr auto operator"" q_YA(long double l) { return current<yottaampere, long double>(l); }
 
 } // namespace literals
 

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -30,10 +30,22 @@
 namespace units::si {
 
 struct joule : named_unit<joule, "J", prefix> {};
+struct yoctojoule : prefixed_unit<yoctojoule, yocto, joule> {};
+struct zeptojoule : prefixed_unit<zeptojoule, zepto, joule> {};
+struct attojoule : prefixed_unit<attojoule, atto, joule> {};
+struct femtojoule : prefixed_unit<femtojoule, femto, joule> {};
+struct picojoule : prefixed_unit<picojoule, pico, joule> {};
+struct nanojoule : prefixed_unit<nanojoule, nano, joule> {};
+struct microjoule : prefixed_unit<microjoule, micro, joule> {};
 struct millijoule : prefixed_unit<millijoule, milli, joule> {};
 struct kilojoule : prefixed_unit<kilojoule, kilo, joule> {};
 struct megajoule : prefixed_unit<megajoule, mega, joule> {};
 struct gigajoule : prefixed_unit<gigajoule, giga, joule> {};
+struct terajoule : prefixed_unit<terajoule, tera, joule> {};
+struct petajoule : prefixed_unit<petajoule, peta, joule> {};
+struct exajoule : prefixed_unit<exajoule, exa, joule> {};
+struct zettajoule : prefixed_unit<zettajoule, zetta, joule> {};
+struct yottajoule : prefixed_unit<yottajoule, yotta, joule> {};
 
 struct electronvolt : named_scaled_unit<electronvolt, "eV", prefix, ratio<1'602'176'634, 1'000'000'000, -19>, joule> {};
 struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {};
@@ -48,6 +60,34 @@ inline namespace literals {
 // J
 constexpr auto operator"" q_J(unsigned long long l) { return energy<joule, std::int64_t>(l); }
 constexpr auto operator"" q_J(long double l) { return energy<joule, long double>(l); }
+
+// yJ
+constexpr auto operator"" q_yJ(unsigned long long l) { return energy<yoctojoule, std::int64_t>(l); }
+constexpr auto operator"" q_yJ(long double l) { return energy<yoctojoule, long double>(l); }
+
+// zJ
+constexpr auto operator"" q_zJ(unsigned long long l) { return energy<zeptojoule, std::int64_t>(l); }
+constexpr auto operator"" q_zJ(long double l) { return energy<zeptojoule, long double>(l); }
+
+// aJ
+constexpr auto operator"" q_aJ(unsigned long long l) { return energy<attojoule, std::int64_t>(l); }
+constexpr auto operator"" q_aJ(long double l) { return energy<attojoule, long double>(l); }
+
+// fJ
+constexpr auto operator"" q_fJ(unsigned long long l) { return energy<femtojoule, std::int64_t>(l); }
+constexpr auto operator"" q_fJ(long double l) { return energy<femtojoule, long double>(l); }
+
+// pJ
+constexpr auto operator"" q_pJ(unsigned long long l) { return energy<picojoule, std::int64_t>(l); }
+constexpr auto operator"" q_pJ(long double l) { return energy<picojoule, long double>(l); }
+
+// nJ
+constexpr auto operator"" q_nJ(unsigned long long l) { return energy<nanojoule, std::int64_t>(l); }
+constexpr auto operator"" q_nJ(long double l) { return energy<nanojoule, long double>(l); }
+
+// uJ
+constexpr auto operator"" q_uJ(unsigned long long l) { return energy<microjoule, std::int64_t>(l); }
+constexpr auto operator"" q_uJ(long double l) { return energy<microjoule, long double>(l); }
 
 // mJ
 constexpr auto operator"" q_mJ(unsigned long long l) { return energy<millijoule, std::int64_t>(l); }
@@ -64,6 +104,26 @@ constexpr auto operator"" q_MJ(long double l) { return energy<megajoule, long do
 // GJ
 constexpr auto operator"" q_GJ(unsigned long long l) { return energy<gigajoule, std::int64_t>(l); }
 constexpr auto operator"" q_GJ(long double l) { return energy<gigajoule, long double>(l); }
+
+// TJ
+constexpr auto operator"" q_TJ(unsigned long long l) { return energy<terajoule, std::int64_t>(l); }
+constexpr auto operator"" q_TJ(long double l) { return energy<terajoule, long double>(l); }
+
+// PJ
+constexpr auto operator"" q_PJ(unsigned long long l) { return energy<petajoule, std::int64_t>(l); }
+constexpr auto operator"" q_PJ(long double l) { return energy<petajoule, long double>(l); }
+
+// EJ
+constexpr auto operator"" q_EJ(unsigned long long l) { return energy<exajoule, std::int64_t>(l); }
+constexpr auto operator"" q_EJ(long double l) { return energy<exajoule, long double>(l); }
+
+// ZJ
+constexpr auto operator"" q_ZJ(unsigned long long l) { return energy<zettajoule, std::int64_t>(l); }
+constexpr auto operator"" q_ZJ(long double l) { return energy<zettajoule, long double>(l); }
+
+// YJ
+constexpr auto operator"" q_YJ(unsigned long long l) { return energy<yottajoule, std::int64_t>(l); }
+constexpr auto operator"" q_YJ(long double l) { return energy<yottajoule, long double>(l); }
 
 // eV
 constexpr auto operator"" q_eV(unsigned long long l) { return energy<electronvolt, std::int64_t>(l); }

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -31,6 +31,26 @@
 namespace units::si {
 
 struct newton : named_unit<newton, "N", prefix> {};
+struct yoctonewton : prefixed_unit<yoctonewton, yocto, newton> {};
+struct zeptonewton : prefixed_unit<zeptonewton, zepto, newton> {};
+struct attonewton : prefixed_unit<attonewton, atto, newton> {};
+struct femtonewton : prefixed_unit<femtonewton, femto, newton> {};
+struct piconewton : prefixed_unit<piconewton, pico, newton> {};
+struct nanonewton : prefixed_unit<nanonewton, nano, newton> {};
+struct micronewton : prefixed_unit<micronewton, micro, newton> {};
+struct millinewton : prefixed_unit<millinewton, milli, newton> {};
+struct centinewton : prefixed_unit<centinewton, centi, newton> {};
+struct decinewton : prefixed_unit<decinewton, deci, newton> {};
+struct decanewton : prefixed_unit<decanewton, deca, newton> {};
+struct hectonewton : prefixed_unit<hectonewton, hecto, newton> {};
+struct kilonewton : prefixed_unit<kilonewton, kilo, newton> {};
+struct meganewton : prefixed_unit<meganewton, mega, newton> {};
+struct giganewton : prefixed_unit<giganewton, giga, newton> {};
+struct teranewton : prefixed_unit<teranewton, tera, newton> {};
+struct petanewton : prefixed_unit<petanewton, peta, newton> {};
+struct exanewton : prefixed_unit<exanewton, exa, newton> {};
+struct zettanewton : prefixed_unit<zettanewton, zetta, newton> {};
+struct yottanewton : prefixed_unit<yottanewton, yotta, newton> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 
@@ -42,6 +62,86 @@ inline namespace literals {
 // N
 constexpr auto operator"" q_N(unsigned long long l) { return force<newton, std::int64_t>(l); }
 constexpr auto operator"" q_N(long double l) { return force<newton, long double>(l); }
+
+// yN
+constexpr auto operator"" q_yN(unsigned long long l) { return force<yoctonewton, std::int64_t>(l); }
+constexpr auto operator"" q_yN(long double l) { return force<yoctonewton, long double>(l); }
+
+// zN
+constexpr auto operator"" q_zN(unsigned long long l) { return force<zeptonewton, std::int64_t>(l); }
+constexpr auto operator"" q_zN(long double l) { return force<zeptonewton, long double>(l); }
+
+// aN
+constexpr auto operator"" q_aN(unsigned long long l) { return force<attonewton, std::int64_t>(l); }
+constexpr auto operator"" q_aN(long double l) { return force<attonewton, long double>(l); }
+
+// fN
+constexpr auto operator"" q_fN(unsigned long long l) { return force<femtonewton, std::int64_t>(l); }
+constexpr auto operator"" q_fN(long double l) { return force<femtonewton, long double>(l); }
+
+// pN
+constexpr auto operator"" q_pN(unsigned long long l) { return force<piconewton, std::int64_t>(l); }
+constexpr auto operator"" q_pN(long double l) { return force<piconewton, long double>(l); }
+
+// nN
+constexpr auto operator"" q_nN(unsigned long long l) { return force<nanonewton, std::int64_t>(l); }
+constexpr auto operator"" q_nN(long double l) { return force<nanonewton, long double>(l); }
+
+// uN
+constexpr auto operator"" q_uN(unsigned long long l) { return force<micronewton, std::int64_t>(l); }
+constexpr auto operator"" q_uN(long double l) { return force<micronewton, long double>(l); }
+
+// mN
+constexpr auto operator"" q_mN(unsigned long long l) { return force<millinewton, std::int64_t>(l); }
+constexpr auto operator"" q_mN(long double l) { return force<millinewton, long double>(l); }
+
+// cN
+constexpr auto operator"" q_cN(unsigned long long l) { return force<centinewton, std::int64_t>(l); }
+constexpr auto operator"" q_cN(long double l) { return force<centinewton, long double>(l); }
+
+// dN
+constexpr auto operator"" q_dN(unsigned long long l) { return force<decinewton, std::int64_t>(l); }
+constexpr auto operator"" q_dN(long double l) { return force<decinewton, long double>(l); }
+
+// daN
+constexpr auto operator"" q_daN(unsigned long long l) { return force<decanewton, std::int64_t>(l); }
+constexpr auto operator"" q_daN(long double l) { return force<decanewton, long double>(l); }
+
+// hN
+constexpr auto operator"" q_hN(unsigned long long l) { return force<hectonewton, std::int64_t>(l); }
+constexpr auto operator"" q_hN(long double l) { return force<hectonewton, long double>(l); }
+
+// kN
+constexpr auto operator"" q_kN(unsigned long long l) { return force<kilonewton, std::int64_t>(l); }
+constexpr auto operator"" q_kN(long double l) { return force<kilonewton, long double>(l); }
+
+// MN
+constexpr auto operator"" q_MN(unsigned long long l) { return force<meganewton, std::int64_t>(l); }
+constexpr auto operator"" q_MN(long double l) { return force<meganewton, long double>(l); }
+
+// GN
+constexpr auto operator"" q_GN(unsigned long long l) { return force<giganewton, std::int64_t>(l); }
+constexpr auto operator"" q_GN(long double l) { return force<giganewton, long double>(l); }
+
+// TN
+constexpr auto operator"" q_TN(unsigned long long l) { return force<teranewton, std::int64_t>(l); }
+constexpr auto operator"" q_TN(long double l) { return force<teranewton, long double>(l); }
+
+// PN
+constexpr auto operator"" q_PN(unsigned long long l) { return force<petanewton, std::int64_t>(l); }
+constexpr auto operator"" q_PN(long double l) { return force<petanewton, long double>(l); }
+
+// EN
+constexpr auto operator"" q_EN(unsigned long long l) { return force<exanewton, std::int64_t>(l); }
+constexpr auto operator"" q_EN(long double l) { return force<exanewton, long double>(l); }
+
+// ZN
+constexpr auto operator"" q_ZN(unsigned long long l) { return force<zettanewton, std::int64_t>(l); }
+constexpr auto operator"" q_ZN(long double l) { return force<zettanewton, long double>(l); }
+
+// YN
+constexpr auto operator"" q_YN(unsigned long long l) { return force<yottanewton, std::int64_t>(l); }
+constexpr auto operator"" q_YN(long double l) { return force<yottanewton, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -29,11 +29,22 @@
 namespace units::si {
 
 struct hertz : named_unit<hertz, "Hz", prefix> {};
+struct yoctohertz : prefixed_unit<yoctohertz, yocto, hertz> {};
+struct zeptohertz : prefixed_unit<zeptohertz, zepto, hertz> {};
+struct attohertz : prefixed_unit<attohertz, atto, hertz> {};
+struct femtohertz : prefixed_unit<femtohertz, femto, hertz> {};
+struct picohertz : prefixed_unit<picohertz, pico, hertz> {};
+struct nanohertz : prefixed_unit<nanohertz, nano, hertz> {};
+struct microhertz : prefixed_unit<microhertz, micro, hertz> {};
 struct millihertz : prefixed_unit<millihertz, milli, hertz> {};
 struct kilohertz : prefixed_unit<kilohertz, kilo, hertz> {};
 struct megahertz : prefixed_unit<megahertz, mega, hertz> {};
 struct gigahertz : prefixed_unit<gigahertz, giga, hertz> {};
 struct terahertz : prefixed_unit<terahertz, tera, hertz> {};
+struct petahertz : prefixed_unit<petahertz, peta, hertz> {};
+struct exahertz : prefixed_unit<exahertz, exa, hertz> {};
+struct zettahertz : prefixed_unit<zettahertz, zetta, hertz> {};
+struct yottahertz : prefixed_unit<yottahertz, yotta, hertz> {};
 
 struct dim_frequency : physical::dim_frequency<dim_frequency, hertz, dim_time> {};
 
@@ -45,6 +56,34 @@ inline namespace literals {
 // Hz
 constexpr auto operator"" q_Hz(unsigned long long l) { return frequency<hertz, std::int64_t>(l); }
 constexpr auto operator"" q_Hz(long double l) { return frequency<hertz, long double>(l); }
+
+// yHz
+constexpr auto operator"" q_yHz(unsigned long long l) { return frequency<yoctohertz, std::int64_t>(l); }
+constexpr auto operator"" q_yHz(long double l) { return frequency<yoctohertz, long double>(l); }
+
+// zHz
+constexpr auto operator"" q_zHz(unsigned long long l) { return frequency<zeptohertz, std::int64_t>(l); }
+constexpr auto operator"" q_zHz(long double l) { return frequency<zeptohertz, long double>(l); }
+
+// aHz
+constexpr auto operator"" q_aHz(unsigned long long l) { return frequency<attohertz, std::int64_t>(l); }
+constexpr auto operator"" q_aHz(long double l) { return frequency<attohertz, long double>(l); }
+
+// fHz
+constexpr auto operator"" q_fHz(unsigned long long l) { return frequency<femtohertz, std::int64_t>(l); }
+constexpr auto operator"" q_fHz(long double l) { return frequency<femtohertz, long double>(l); }
+
+// pHz
+constexpr auto operator"" q_pHz(unsigned long long l) { return frequency<picohertz, std::int64_t>(l); }
+constexpr auto operator"" q_pHz(long double l) { return frequency<picohertz, long double>(l); }
+
+// nHz
+constexpr auto operator"" q_nHz(unsigned long long l) { return frequency<nanohertz, std::int64_t>(l); }
+constexpr auto operator"" q_nHz(long double l) { return frequency<nanohertz, long double>(l); }
+
+// uHz
+constexpr auto operator"" q_uHz(unsigned long long l) { return frequency<microhertz, std::int64_t>(l); }
+constexpr auto operator"" q_uHz(long double l) { return frequency<microhertz, long double>(l); }
 
 // mHz
 constexpr auto operator"" q_mHz(unsigned long long l) { return frequency<millihertz, std::int64_t>(l); }
@@ -65,6 +104,22 @@ constexpr auto operator"" q_GHz(long double l) { return frequency<gigahertz, lon
 // THz
 constexpr auto operator"" q_THz(unsigned long long l) { return frequency<terahertz, std::int64_t>(l); }
 constexpr auto operator"" q_THz(long double l) { return frequency<terahertz, long double>(l); }
+
+// PHz
+constexpr auto operator"" q_PHz(unsigned long long l) { return frequency<petahertz, std::int64_t>(l); }
+constexpr auto operator"" q_PHz(long double l) { return frequency<petahertz, long double>(l); }
+
+// EHz
+constexpr auto operator"" q_EHz(unsigned long long l) { return frequency<exahertz, std::int64_t>(l); }
+constexpr auto operator"" q_EHz(long double l) { return frequency<exahertz, long double>(l); }
+
+// ZHz
+constexpr auto operator"" q_ZHz(unsigned long long l) { return frequency<zettahertz, std::int64_t>(l); }
+constexpr auto operator"" q_ZHz(long double l) { return frequency<zettahertz, long double>(l); }
+
+// YHz
+constexpr auto operator"" q_YHz(unsigned long long l) { return frequency<yottahertz, std::int64_t>(l); }
+constexpr auto operator"" q_YHz(long double l) { return frequency<yottahertz, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/inductance.h
+++ b/src/include/units/physical/si/inductance.h
@@ -31,10 +31,22 @@ namespace units::si {
 
 struct henry : named_unit<henry, "H", prefix> {};
 
-struct millihenry : prefixed_unit<millihenry, milli, henry> {};
-struct microhenry : prefixed_unit<microhenry, micro, henry> {};
-struct nanohenry : prefixed_unit<nanohenry, nano, henry> {};
+struct yoctohenry : prefixed_unit<yoctohenry, yocto, henry> {};
+struct zeptohenry : prefixed_unit<zeptohenry, zepto, henry> {};
+struct attohenry : prefixed_unit<attohenry, atto, henry> {};
+struct femtohenry : prefixed_unit<femtohenry, femto, henry> {};
 struct picohenry : prefixed_unit<picohenry, pico, henry> {};
+struct nanohenry : prefixed_unit<nanohenry, nano, henry> {};
+struct microhenry : prefixed_unit<microhenry, micro, henry> {};
+struct millihenry : prefixed_unit<millihenry, milli, henry> {};
+struct kilohenry : prefixed_unit<kilohenry, kilo, henry> {};
+struct megahenry : prefixed_unit<megahenry, mega, henry> {};
+struct gigahenry : prefixed_unit<gigahenry, giga, henry> {};
+struct terahenry : prefixed_unit<terahenry, tera, henry> {};
+struct petahenry : prefixed_unit<petahenry, peta, henry> {};
+struct exahenry : prefixed_unit<exahenry, exa, henry> {};
+struct zettahenry : prefixed_unit<zettahenry, zetta, henry> {};
+struct yottahenry : prefixed_unit<yottahenry, yotta, henry> {};
 
 struct dim_inductance : physical::dim_inductance<dim_inductance, henry, dim_magnetic_flux, dim_electric_current> {};
 
@@ -47,21 +59,69 @@ inline namespace literals {
 constexpr auto operator"" q_H(unsigned long long l) { return inductance<henry, std::int64_t>(l); }
 constexpr auto operator"" q_H(long double l) { return inductance<henry, long double>(l); }
 
-// mH
-constexpr auto operator"" q_mH(unsigned long long l) { return inductance<millihenry, std::int64_t>(l); }
-constexpr auto operator"" q_mH(long double l) { return inductance<millihenry, long double>(l); }
+// yH
+constexpr auto operator"" q_yH(unsigned long long l) { return inductance<yoctohenry, std::int64_t>(l); }
+constexpr auto operator"" q_yH(long double l) { return inductance<yoctohenry, long double>(l); }
 
-// µH
-constexpr auto operator"" q_uH(unsigned long long l) { return inductance<microhenry, std::int64_t>(l); }
-constexpr auto operator"" q_uH(long double l) { return inductance<microhenry, long double>(l); }
+// zH
+constexpr auto operator"" q_zH(unsigned long long l) { return inductance<zeptohenry, std::int64_t>(l); }
+constexpr auto operator"" q_zH(long double l) { return inductance<zeptohenry, long double>(l); }
+
+// aH
+constexpr auto operator"" q_aH(unsigned long long l) { return inductance<attohenry, std::int64_t>(l); }
+constexpr auto operator"" q_aH(long double l) { return inductance<attohenry, long double>(l); }
+
+// fH
+constexpr auto operator"" q_fH(unsigned long long l) { return inductance<femtohenry, std::int64_t>(l); }
+constexpr auto operator"" q_fH(long double l) { return inductance<femtohenry, long double>(l); }
+
+// pH
+constexpr auto operator"" q_pH(unsigned long long l) { return inductance<picohenry, std::int64_t>(l); }
+constexpr auto operator"" q_pH(long double l) { return inductance<picohenry, long double>(l); }
 
 // nH
 constexpr auto operator"" q_nH(unsigned long long l) { return inductance<nanohenry, std::int64_t>(l); }
 constexpr auto operator"" q_nH(long double l) { return inductance<nanohenry, long double>(l); }
 
-// pH
-constexpr auto operator"" q_pH(unsigned long long l) { return inductance<picohenry, std::int64_t>(l); }
-constexpr auto operator"" q_pH(long double l) { return inductance<picohenry, long double>(l); }
+// µH
+constexpr auto operator"" q_uH(unsigned long long l) { return inductance<microhenry, std::int64_t>(l); }
+constexpr auto operator"" q_uH(long double l) { return inductance<microhenry, long double>(l); }
+
+// mH
+constexpr auto operator"" q_mH(unsigned long long l) { return inductance<millihenry, std::int64_t>(l); }
+constexpr auto operator"" q_mH(long double l) { return inductance<millihenry, long double>(l); }
+
+// kH
+constexpr auto operator"" q_kH(unsigned long long l) { return inductance<kilohenry, std::int64_t>(l); }
+constexpr auto operator"" q_kH(long double l) { return inductance<kilohenry, long double>(l); }
+
+// MH
+constexpr auto operator"" q_MH(unsigned long long l) { return inductance<megahenry, std::int64_t>(l); }
+constexpr auto operator"" q_MH(long double l) { return inductance<megahenry, long double>(l); }
+
+// GH
+constexpr auto operator"" q_GH(unsigned long long l) { return inductance<gigahenry, std::int64_t>(l); }
+constexpr auto operator"" q_GH(long double l) { return inductance<gigahenry, long double>(l); }
+
+// TH
+constexpr auto operator"" q_TH(unsigned long long l) { return inductance<terahenry, std::int64_t>(l); }
+constexpr auto operator"" q_TH(long double l) { return inductance<terahenry, long double>(l); }
+
+// PH
+constexpr auto operator"" q_PH(unsigned long long l) { return inductance<petahenry, std::int64_t>(l); }
+constexpr auto operator"" q_PH(long double l) { return inductance<petahenry, long double>(l); }
+
+// EH
+constexpr auto operator"" q_EH(unsigned long long l) { return inductance<exahenry, std::int64_t>(l); }
+constexpr auto operator"" q_EH(long double l) { return inductance<exahenry, long double>(l); }
+
+// ZH
+constexpr auto operator"" q_ZH(unsigned long long l) { return inductance<zettahenry, std::int64_t>(l); }
+constexpr auto operator"" q_ZH(long double l) { return inductance<zettahenry, long double>(l); }
+
+// YH
+constexpr auto operator"" q_YH(unsigned long long l) { return inductance<yottahenry, std::int64_t>(l); }
+constexpr auto operator"" q_YH(long double l) { return inductance<yottahenry, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -29,12 +29,26 @@
 namespace units::si {
 
 struct metre : named_unit<metre, "m", prefix> {};
+struct yoctometre : prefixed_unit<yoctometre, yocto, metre> {};
+struct zeptometre : prefixed_unit<zeptometre, zepto, metre> {};
+struct attometre : prefixed_unit<attometre, atto, metre> {};
+struct femtometre : prefixed_unit<femtometre, femto, metre> {};
+struct picometre : prefixed_unit<picometre, pico, metre> {};
+struct nanometre : prefixed_unit<nanometre, nano, metre> {};
+struct micrometre : prefixed_unit<micrometre, micro, metre> {};
 struct millimetre : prefixed_unit<millimetre, milli, metre> {};
 struct centimetre : prefixed_unit<centimetre, centi, metre> {};
 struct decimetre : prefixed_unit<decimetre, deci, metre> {};
+struct decametre : prefixed_unit<decametre, deca, metre> {};
 struct hectometre : prefixed_unit<hectometre, hecto, metre> {};
 struct kilometre : prefixed_unit<kilometre, kilo, metre> {};
-struct femtometre : prefixed_unit<femtometre, femto, metre> {};
+struct megametre : prefixed_unit<megametre, mega, metre> {};
+struct gigametre : prefixed_unit<gigametre, giga, metre> {};
+struct terametre : prefixed_unit<terametre, tera, metre> {};
+struct petametre : prefixed_unit<petametre, peta, metre> {};
+struct exametre : prefixed_unit<exametre, exa, metre> {};
+struct zettametre : prefixed_unit<zettametre, zetta, metre> {};
+struct yottametre : prefixed_unit<yottametre, yotta, metre> {};
 
 struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix, ratio<149'597'870'700>, metre> {};
 
@@ -49,9 +63,33 @@ inline namespace literals {
 constexpr auto operator"" q_m(unsigned long long l) { return length<metre, std::int64_t>(l); }
 constexpr auto operator"" q_m(long double l) { return length<metre, long double>(l); }
 
+// ym
+constexpr auto operator"" q_ym(unsigned long long l) { return length<yoctometre, std::int64_t>(l); }
+constexpr auto operator"" q_ym(long double l) { return length<yoctometre, long double>(l); }
+
+// zm
+constexpr auto operator"" q_zm(unsigned long long l) { return length<zeptometre, std::int64_t>(l); }
+constexpr auto operator"" q_zm(long double l) { return length<zeptometre, long double>(l); }
+
+// am
+constexpr auto operator"" q_am(unsigned long long l) { return length<attometre, std::int64_t>(l); }
+constexpr auto operator"" q_am(long double l) { return length<attometre, long double>(l); }
+
 // fm
 constexpr auto operator"" q_fm(unsigned long long l) { return length<femtometre, std::int64_t>(l); }
 constexpr auto operator"" q_fm(long double l) { return length<femtometre, long double>(l); }
+
+// pm
+constexpr auto operator"" q_pm(unsigned long long l) { return length<picometre, std::int64_t>(l); }
+constexpr auto operator"" q_pm(long double l) { return length<picometre, long double>(l); }
+
+// nm
+constexpr auto operator"" q_nm(unsigned long long l) { return length<nanometre, std::int64_t>(l); }
+constexpr auto operator"" q_nm(long double l) { return length<nanometre, long double>(l); }
+
+// um
+constexpr auto operator"" q_um(unsigned long long l) { return length<micrometre, std::int64_t>(l); }
+constexpr auto operator"" q_um(long double l) { return length<micrometre, long double>(l); }
 
 // mm
 constexpr auto operator"" q_mm(unsigned long long l) { return length<millimetre, std::int64_t>(l); }
@@ -65,6 +103,10 @@ constexpr auto operator"" q_cm(long double l) { return length<centimetre, long d
 constexpr auto operator"" q_dm(unsigned long long l) { return length<decimetre, std::int64_t>(l); }
 constexpr auto operator"" q_dm(long double l) { return length<decimetre, long double>(l); }
 
+// dam
+constexpr auto operator"" q_dam(unsigned long long l) { return length<decametre, std::int64_t>(l); }
+constexpr auto operator"" q_dam(long double l) { return length<decametre, long double>(l); }
+
 // hm
 constexpr auto operator"" q_hm(unsigned long long l) { return length<hectometre, std::int64_t>(l); }
 constexpr auto operator"" q_hm(long double l) { return length<hectometre, long double>(l); }
@@ -72,6 +114,34 @@ constexpr auto operator"" q_hm(long double l) { return length<hectometre, long d
 // km
 constexpr auto operator"" q_km(unsigned long long l) { return length<kilometre, std::int64_t>(l); }
 constexpr auto operator"" q_km(long double l) { return length<kilometre, long double>(l); }
+
+// Mm
+constexpr auto operator"" q_Mm(unsigned long long l) { return length<megametre, std::int64_t>(l); }
+constexpr auto operator"" q_Mm(long double l) { return length<megametre, long double>(l); }
+
+// Gm
+constexpr auto operator"" q_Gm(unsigned long long l) { return length<gigametre, std::int64_t>(l); }
+constexpr auto operator"" q_Gm(long double l) { return length<gigametre, long double>(l); }
+
+// Tm
+constexpr auto operator"" q_Tm(unsigned long long l) { return length<terametre, std::int64_t>(l); }
+constexpr auto operator"" q_Tm(long double l) { return length<terametre, long double>(l); }
+
+// Pm
+constexpr auto operator"" q_Pm(unsigned long long l) { return length<petametre, std::int64_t>(l); }
+constexpr auto operator"" q_Pm(long double l) { return length<petametre, long double>(l); }
+
+// Em
+constexpr auto operator"" q_Em(unsigned long long l) { return length<exametre, std::int64_t>(l); }
+constexpr auto operator"" q_Em(long double l) { return length<exametre, long double>(l); }
+
+// Zm
+constexpr auto operator"" q_Zm(unsigned long long l) { return length<zettametre, std::int64_t>(l); }
+constexpr auto operator"" q_Zm(long double l) { return length<zettametre, long double>(l); }
+
+// Ym
+constexpr auto operator"" q_Ym(unsigned long long l) { return length<yottametre, std::int64_t>(l); }
+constexpr auto operator"" q_Ym(long double l) { return length<yottametre, long double>(l); }
 
 // au
 constexpr auto operator"" q_au(unsigned long long l) { return length<astronomical_unit, std::int64_t>(l); }

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -29,6 +29,26 @@
 namespace units::si {
 
 struct candela : named_unit<candela, "cd", prefix> {};
+struct yoctocandela : prefixed_unit<yoctocandela, yocto, candela> {};
+struct zeptocandela : prefixed_unit<zeptocandela, zepto, candela> {};
+struct attocandela : prefixed_unit<attocandela, atto, candela> {};
+struct femtocandela : prefixed_unit<femtocandela, femto, candela> {};
+struct picocandela : prefixed_unit<picocandela, pico, candela> {};
+struct nanocandela : prefixed_unit<nanocandela, nano, candela> {};
+struct microcandela : prefixed_unit<microcandela, micro, candela> {};
+struct millicandela : prefixed_unit<millicandela, milli, candela> {};
+struct centicandela : prefixed_unit<centicandela, centi, candela> {};
+struct decicandela : prefixed_unit<decicandela, deci, candela> {};
+struct decacandela : prefixed_unit<decacandela, deca, candela> {};
+struct hectocandela : prefixed_unit<hectocandela, hecto, candela> {};
+struct kilocandela : prefixed_unit<kilocandela, kilo, candela> {};
+struct megacandela : prefixed_unit<megacandela, mega, candela> {};
+struct gigacandela : prefixed_unit<gigacandela, giga, candela> {};
+struct teracandela : prefixed_unit<teracandela, tera, candela> {};
+struct petacandela : prefixed_unit<petacandela, peta, candela> {};
+struct exacandela : prefixed_unit<exacandela, exa, candela> {};
+struct zettacandela : prefixed_unit<zettacandela, zetta, candela> {};
+struct yottacandela : prefixed_unit<yottacandela, yotta, candela> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 
@@ -40,6 +60,86 @@ inline namespace literals {
 // cd
 constexpr auto operator"" q_cd(unsigned long long l) { return luminous_intensity<candela, std::int64_t>(l); }
 constexpr auto operator"" q_cd(long double l) { return luminous_intensity<candela, long double>(l); }
+
+// ycd
+constexpr auto operator"" q_ycd(unsigned long long l) { return luminous_intensity<yoctocandela, std::int64_t>(l); }
+constexpr auto operator"" q_ycd(long double l) { return luminous_intensity<yoctocandela, long double>(l); }
+
+// zcd
+constexpr auto operator"" q_zcd(unsigned long long l) { return luminous_intensity<zeptocandela, std::int64_t>(l); }
+constexpr auto operator"" q_zcd(long double l) { return luminous_intensity<zeptocandela, long double>(l); }
+
+// acd
+constexpr auto operator"" q_acd(unsigned long long l) { return luminous_intensity<attocandela, std::int64_t>(l); }
+constexpr auto operator"" q_acd(long double l) { return luminous_intensity<attocandela, long double>(l); }
+
+// fcd
+constexpr auto operator"" q_fcd(unsigned long long l) { return luminous_intensity<femtocandela, std::int64_t>(l); }
+constexpr auto operator"" q_fcd(long double l) { return luminous_intensity<femtocandela, long double>(l); }
+
+// pcd
+constexpr auto operator"" q_pcd(unsigned long long l) { return luminous_intensity<picocandela, std::int64_t>(l); }
+constexpr auto operator"" q_pcd(long double l) { return luminous_intensity<picocandela, long double>(l); }
+
+// ncd
+constexpr auto operator"" q_ncd(unsigned long long l) { return luminous_intensity<nanocandela, std::int64_t>(l); }
+constexpr auto operator"" q_ncd(long double l) { return luminous_intensity<nanocandela, long double>(l); }
+
+// ucd
+constexpr auto operator"" q_ucd(unsigned long long l) { return luminous_intensity<microcandela, std::int64_t>(l); }
+constexpr auto operator"" q_ucd(long double l) { return luminous_intensity<microcandela, long double>(l); }
+
+// mcd
+constexpr auto operator"" q_mcd(unsigned long long l) { return luminous_intensity<millicandela, std::int64_t>(l); }
+constexpr auto operator"" q_mcd(long double l) { return luminous_intensity<millicandela, long double>(l); }
+
+// ccd
+constexpr auto operator"" q_ccd(unsigned long long l) { return luminous_intensity<centicandela, std::int64_t>(l); }
+constexpr auto operator"" q_ccd(long double l) { return luminous_intensity<centicandela, long double>(l); }
+
+// dcd
+constexpr auto operator"" q_dcd(unsigned long long l) { return luminous_intensity<decicandela, std::int64_t>(l); }
+constexpr auto operator"" q_dcd(long double l) { return luminous_intensity<decicandela, long double>(l); }
+
+// dacd
+constexpr auto operator"" q_dacd(unsigned long long l) { return luminous_intensity<decacandela, std::int64_t>(l); }
+constexpr auto operator"" q_dacd(long double l) { return luminous_intensity<decacandela, long double>(l); }
+
+// hcd
+constexpr auto operator"" q_hcd(unsigned long long l) { return luminous_intensity<hectocandela, std::int64_t>(l); }
+constexpr auto operator"" q_hcd(long double l) { return luminous_intensity<hectocandela, long double>(l); }
+
+// kcd
+constexpr auto operator"" q_kcd(unsigned long long l) { return luminous_intensity<kilocandela, std::int64_t>(l); }
+constexpr auto operator"" q_kcd(long double l) { return luminous_intensity<kilocandela, long double>(l); }
+
+// Mcd
+constexpr auto operator"" q_Mcd(unsigned long long l) { return luminous_intensity<megacandela, std::int64_t>(l); }
+constexpr auto operator"" q_Mcd(long double l) { return luminous_intensity<megacandela, long double>(l); }
+
+// Gcd
+constexpr auto operator"" q_Gcd(unsigned long long l) { return luminous_intensity<gigacandela, std::int64_t>(l); }
+constexpr auto operator"" q_Gcd(long double l) { return luminous_intensity<gigacandela, long double>(l); }
+
+// Tcd
+constexpr auto operator"" q_Tcd(unsigned long long l) { return luminous_intensity<teracandela, std::int64_t>(l); }
+constexpr auto operator"" q_Tcd(long double l) { return luminous_intensity<teracandela, long double>(l); }
+
+// Pcd
+constexpr auto operator"" q_Pcd(unsigned long long l) { return luminous_intensity<petacandela, std::int64_t>(l); }
+constexpr auto operator"" q_Pcd(long double l) { return luminous_intensity<petacandela, long double>(l); }
+
+// Ecd
+constexpr auto operator"" q_Ecd(unsigned long long l) { return luminous_intensity<exacandela, std::int64_t>(l); }
+constexpr auto operator"" q_Ecd(long double l) { return luminous_intensity<exacandela, long double>(l); }
+
+// Zcd
+constexpr auto operator"" q_Zcd(unsigned long long l) { return luminous_intensity<zettacandela, std::int64_t>(l); }
+constexpr auto operator"" q_Zcd(long double l) { return luminous_intensity<zettacandela, long double>(l); }
+
+// Ycd
+constexpr auto operator"" q_Ycd(unsigned long long l) { return luminous_intensity<yottacandela, std::int64_t>(l); }
+constexpr auto operator"" q_Ycd(long double l) { return luminous_intensity<yottacandela, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/magnetic_flux.h
+++ b/src/include/units/physical/si/magnetic_flux.h
@@ -31,10 +31,22 @@ namespace units::si {
 
 struct weber : named_unit<weber, "Wb", prefix> {};
 
-struct milliweber : prefixed_unit<milliweber, milli, weber> {};
-struct microweber : prefixed_unit<microweber, micro, weber> {};
-struct nanoweber : prefixed_unit<nanoweber, nano, weber> {};
+struct yoctoweber : prefixed_unit<yoctoweber, yocto, weber> {};
+struct zeptoweber : prefixed_unit<zeptoweber, zepto, weber> {};
+struct attoweber : prefixed_unit<attoweber, atto, weber> {};
+struct femtoweber : prefixed_unit<femtoweber, femto, weber> {};
 struct picoweber : prefixed_unit<picoweber, pico, weber> {};
+struct nanoweber : prefixed_unit<nanoweber, nano, weber> {};
+struct microweber : prefixed_unit<microweber, micro, weber> {};
+struct milliweber : prefixed_unit<milliweber, milli, weber> {};
+struct kiloweber : prefixed_unit<kiloweber, kilo, weber> {};
+struct megaweber : prefixed_unit<megaweber, mega, weber> {};
+struct gigaweber : prefixed_unit<gigaweber, giga, weber> {};
+struct teraweber : prefixed_unit<teraweber, tera, weber> {};
+struct petaweber : prefixed_unit<petaweber, peta, weber> {};
+struct exaweber : prefixed_unit<exaweber, exa, weber> {};
+struct zettaweber : prefixed_unit<zettaweber, zetta, weber> {};
+struct yottaweber : prefixed_unit<yottaweber, yotta, weber> {};
 
 struct dim_magnetic_flux : physical::dim_magnetic_flux<dim_magnetic_flux, weber, dim_magnetic_induction, dim_area> {};
 
@@ -47,21 +59,69 @@ inline namespace literals {
 constexpr auto operator"" q_Wb(unsigned long long l) { return magnetic_flux<weber, std::int64_t>(l); }
 constexpr auto operator"" q_Wb(long double l) { return magnetic_flux<weber, long double>(l); }
 
-// mWb
-constexpr auto operator"" q_mWb(unsigned long long l) { return magnetic_flux<milliweber, std::int64_t>(l); }
-constexpr auto operator"" q_mWb(long double l) { return magnetic_flux<milliweber, long double>(l); }
+// yWb
+constexpr auto operator"" q_yWb(unsigned long long l) { return magnetic_flux<yoctoweber, std::int64_t>(l); }
+constexpr auto operator"" q_yWb(long double l) { return magnetic_flux<yoctoweber, long double>(l); }
 
-// µWb
-constexpr auto operator"" q_uWb(unsigned long long l) { return magnetic_flux<microweber, std::int64_t>(l); }
-constexpr auto operator"" q_uWb(long double l) { return magnetic_flux<microweber, long double>(l); }
+// zWb
+constexpr auto operator"" q_zWb(unsigned long long l) { return magnetic_flux<zeptoweber, std::int64_t>(l); }
+constexpr auto operator"" q_zWb(long double l) { return magnetic_flux<zeptoweber, long double>(l); }
+
+// aWb
+constexpr auto operator"" q_aWb(unsigned long long l) { return magnetic_flux<attoweber, std::int64_t>(l); }
+constexpr auto operator"" q_aWb(long double l) { return magnetic_flux<attoweber, long double>(l); }
+
+// fWb
+constexpr auto operator"" q_fWb(unsigned long long l) { return magnetic_flux<femtoweber, std::int64_t>(l); }
+constexpr auto operator"" q_fWb(long double l) { return magnetic_flux<femtoweber, long double>(l); }
+
+// pWb
+constexpr auto operator"" q_pWb(unsigned long long l) { return magnetic_flux<picoweber, std::int64_t>(l); }
+constexpr auto operator"" q_pWb(long double l) { return magnetic_flux<picoweber, long double>(l); }
 
 // nWb
 constexpr auto operator"" q_nWb(unsigned long long l) { return magnetic_flux<nanoweber, std::int64_t>(l); }
 constexpr auto operator"" q_nWb(long double l) { return magnetic_flux<nanoweber, long double>(l); }
 
-// pWb
-constexpr auto operator"" q_pWb(unsigned long long l) { return magnetic_flux<picoweber, std::int64_t>(l); }
-constexpr auto operator"" q_pWb(long double l) { return magnetic_flux<picoweber, long double>(l); }
+// µWb
+constexpr auto operator"" q_uWb(unsigned long long l) { return magnetic_flux<microweber, std::int64_t>(l); }
+constexpr auto operator"" q_uWb(long double l) { return magnetic_flux<microweber, long double>(l); }
+
+// mWb
+constexpr auto operator"" q_mWb(unsigned long long l) { return magnetic_flux<milliweber, std::int64_t>(l); }
+constexpr auto operator"" q_mWb(long double l) { return magnetic_flux<milliweber, long double>(l); }
+
+// kWb
+constexpr auto operator"" q_kWb(unsigned long long l) { return magnetic_flux<kiloweber, std::int64_t>(l); }
+constexpr auto operator"" q_kWb(long double l) { return magnetic_flux<kiloweber, long double>(l); }
+
+// MWb
+constexpr auto operator"" q_MWb(unsigned long long l) { return magnetic_flux<megaweber, std::int64_t>(l); }
+constexpr auto operator"" q_MWb(long double l) { return magnetic_flux<megaweber, long double>(l); }
+
+// GWb
+constexpr auto operator"" q_GWb(unsigned long long l) { return magnetic_flux<gigaweber, std::int64_t>(l); }
+constexpr auto operator"" q_GWb(long double l) { return magnetic_flux<gigaweber, long double>(l); }
+
+// TWb
+constexpr auto operator"" q_TWb(unsigned long long l) { return magnetic_flux<teraweber, std::int64_t>(l); }
+constexpr auto operator"" q_TWb(long double l) { return magnetic_flux<teraweber, long double>(l); }
+
+// PWb
+constexpr auto operator"" q_PWb(unsigned long long l) { return magnetic_flux<petaweber, std::int64_t>(l); }
+constexpr auto operator"" q_PWb(long double l) { return magnetic_flux<petaweber, long double>(l); }
+
+// EWb
+constexpr auto operator"" q_EWb(unsigned long long l) { return magnetic_flux<exaweber, std::int64_t>(l); }
+constexpr auto operator"" q_EWb(long double l) { return magnetic_flux<exaweber, long double>(l); }
+
+// ZWb
+constexpr auto operator"" q_ZWb(unsigned long long l) { return magnetic_flux<zettaweber, std::int64_t>(l); }
+constexpr auto operator"" q_ZWb(long double l) { return magnetic_flux<zettaweber, long double>(l); }
+
+// YWb
+constexpr auto operator"" q_YWb(unsigned long long l) { return magnetic_flux<yottaweber, std::int64_t>(l); }
+constexpr auto operator"" q_YWb(long double l) { return magnetic_flux<yottaweber, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/magnetic_induction.h
+++ b/src/include/units/physical/si/magnetic_induction.h
@@ -33,10 +33,22 @@ namespace units::si {
 
 struct tesla : named_unit<tesla, "T", prefix> {};
 
-struct millitesla : prefixed_unit<millitesla, milli, tesla> {};
-struct microtesla : prefixed_unit<microtesla, micro, tesla> {};
-struct nanotesla : prefixed_unit<nanotesla, nano, tesla> {};
+struct yoctotesla : prefixed_unit<yoctotesla, yocto, tesla> {};
+struct zeptotesla : prefixed_unit<zeptotesla, zepto, tesla> {};
+struct attotesla : prefixed_unit<attotesla, atto, tesla> {};
+struct femtotesla : prefixed_unit<femtotesla, femto, tesla> {};
 struct picotesla : prefixed_unit<picotesla, pico, tesla> {};
+struct nanotesla : prefixed_unit<nanotesla, nano, tesla> {};
+struct microtesla : prefixed_unit<microtesla, micro, tesla> {};
+struct millitesla : prefixed_unit<millitesla, milli, tesla> {};
+struct kilotesla : prefixed_unit<kilotesla, kilo, tesla> {};
+struct megatesla : prefixed_unit<megatesla, mega, tesla> {};
+struct gigatesla : prefixed_unit<gigatesla, giga, tesla> {};
+struct teratesla : prefixed_unit<teratesla, tera, tesla> {};
+struct petatesla : prefixed_unit<petatesla, peta, tesla> {};
+struct exatesla : prefixed_unit<exatesla, exa, tesla> {};
+struct zettatesla : prefixed_unit<zettatesla, zetta, tesla> {};
+struct yottatesla : prefixed_unit<yottatesla, yotta, tesla> {};
 
 struct gauss : named_scaled_unit<gauss, "G", prefix, ratio<1, 10'000>, tesla> {};
 
@@ -51,21 +63,69 @@ inline namespace literals {
 constexpr auto operator"" q_T(unsigned long long l) { return magnetic_induction<tesla, std::int64_t>(l); }
 constexpr auto operator"" q_T(long double l) { return magnetic_induction<tesla, long double>(l); }
 
-// mT
-constexpr auto operator"" q_mT(unsigned long long l) { return magnetic_induction<millitesla, std::int64_t>(l); }
-constexpr auto operator"" q_mT(long double l) { return magnetic_induction<millitesla, long double>(l); }
+// yT
+constexpr auto operator"" q_yT(unsigned long long l) { return magnetic_induction<yoctotesla, std::int64_t>(l); }
+constexpr auto operator"" q_yT(long double l) { return magnetic_induction<yoctotesla, long double>(l); }
 
-// µT
-constexpr auto operator"" q_uT(unsigned long long l) { return magnetic_induction<microtesla, std::int64_t>(l); }
-constexpr auto operator"" q_uT(long double l) { return magnetic_induction<microtesla, long double>(l); }
+// zT
+constexpr auto operator"" q_zT(unsigned long long l) { return magnetic_induction<zeptotesla, std::int64_t>(l); }
+constexpr auto operator"" q_zT(long double l) { return magnetic_induction<zeptotesla, long double>(l); }
+
+// aT
+constexpr auto operator"" q_aT(unsigned long long l) { return magnetic_induction<attotesla, std::int64_t>(l); }
+constexpr auto operator"" q_aT(long double l) { return magnetic_induction<attotesla, long double>(l); }
+
+// fT
+constexpr auto operator"" q_fT(unsigned long long l) { return magnetic_induction<femtotesla, std::int64_t>(l); }
+constexpr auto operator"" q_fT(long double l) { return magnetic_induction<femtotesla, long double>(l); }
+
+// pT
+constexpr auto operator"" q_pT(unsigned long long l) { return magnetic_induction<picotesla, std::int64_t>(l); }
+constexpr auto operator"" q_pT(long double l) { return magnetic_induction<picotesla, long double>(l); }
 
 // nT
 constexpr auto operator"" q_nT(unsigned long long l) { return magnetic_induction<nanotesla, std::int64_t>(l); }
 constexpr auto operator"" q_nT(long double l) { return magnetic_induction<nanotesla, long double>(l); }
 
-//pT
-constexpr auto operator"" q_pT(unsigned long long l) { return magnetic_induction<picotesla, std::int64_t>(l); }
-constexpr auto operator"" q_pT(long double l) { return magnetic_induction<picotesla, long double>(l); }
+// µT
+constexpr auto operator"" q_uT(unsigned long long l) { return magnetic_induction<microtesla, std::int64_t>(l); }
+constexpr auto operator"" q_uT(long double l) { return magnetic_induction<microtesla, long double>(l); }
+
+// mT
+constexpr auto operator"" q_mT(unsigned long long l) { return magnetic_induction<millitesla, std::int64_t>(l); }
+constexpr auto operator"" q_mT(long double l) { return magnetic_induction<millitesla, long double>(l); }
+
+// kT
+constexpr auto operator"" q_kT(unsigned long long l) { return magnetic_induction<kilotesla, std::int64_t>(l); }
+constexpr auto operator"" q_kT(long double l) { return magnetic_induction<kilotesla, long double>(l); }
+
+// MT
+constexpr auto operator"" q_MT(unsigned long long l) { return magnetic_induction<megatesla, std::int64_t>(l); }
+constexpr auto operator"" q_MT(long double l) { return magnetic_induction<megatesla, long double>(l); }
+
+// GT
+constexpr auto operator"" q_GT(unsigned long long l) { return magnetic_induction<gigatesla, std::int64_t>(l); }
+constexpr auto operator"" q_GT(long double l) { return magnetic_induction<gigatesla, long double>(l); }
+
+// TT
+constexpr auto operator"" q_TT(unsigned long long l) { return magnetic_induction<teratesla, std::int64_t>(l); }
+constexpr auto operator"" q_TT(long double l) { return magnetic_induction<teratesla, long double>(l); }
+
+// PT
+constexpr auto operator"" q_PT(unsigned long long l) { return magnetic_induction<petatesla, std::int64_t>(l); }
+constexpr auto operator"" q_PT(long double l) { return magnetic_induction<petatesla, long double>(l); }
+
+// ET
+constexpr auto operator"" q_ET(unsigned long long l) { return magnetic_induction<exatesla, std::int64_t>(l); }
+constexpr auto operator"" q_ET(long double l) { return magnetic_induction<exatesla, long double>(l); }
+
+// ZT
+constexpr auto operator"" q_ZT(unsigned long long l) { return magnetic_induction<zettatesla, std::int64_t>(l); }
+constexpr auto operator"" q_ZT(long double l) { return magnetic_induction<zettatesla, long double>(l); }
+
+// YT
+constexpr auto operator"" q_YT(unsigned long long l) { return magnetic_induction<yottatesla, std::int64_t>(l); }
+constexpr auto operator"" q_YT(long double l) { return magnetic_induction<yottatesla, long double>(l); }
 
 // G
 constexpr auto operator"" q_G(unsigned long long l) { return magnetic_induction<gauss, std::int64_t>(l); }

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -50,7 +50,7 @@ struct exagram : prefixed_unit<exagram, exa, gram> {};
 struct zettagram : prefixed_unit<zettagram, zetta, gram> {};
 struct yottagram : prefixed_unit<yottagram, yotta, gram> {};
 
-struct tonne : alias_unit<megagram, "t"> {};
+struct tonne : alias_unit<megagram, "t", prefix> {};
 struct yoctotonne : prefixed_alias_unit<attogram, yocto, tonne> {};
 struct zeptotonne : prefixed_alias_unit<femtogram, zepto, tonne> {};
 struct attotonne : prefixed_alias_unit<picogram, atto, tonne> {};

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -29,8 +29,48 @@
 namespace units::si {
 
 struct gram : named_unit<gram, "g", prefix> {};
+struct yoctogram : prefixed_unit<yoctogram, yocto, gram> {};
+struct zeptogram : prefixed_unit<zeptogram, zepto, gram> {};
+struct attogram : prefixed_unit<attogram, atto, gram> {};
+struct femtogram : prefixed_unit<femtogram, femto, gram> {};
+struct picogram : prefixed_unit<picogram, pico, gram> {};
+struct nanogram : prefixed_unit<nanogram, nano, gram> {};
+struct microgram : prefixed_unit<microgram, micro, gram> {};
+struct milligram : prefixed_unit<milligram, milli, gram> {};
+struct centigram : prefixed_unit<centigram, centi, gram> {};
+struct decigram : prefixed_unit<decigram, deci, gram> {};
+struct decagram : prefixed_unit<decagram, deca, gram> {};
+struct hectogram : prefixed_unit<hectogram, hecto, gram> {};
 struct kilogram : prefixed_unit<kilogram, kilo, gram> {};
-struct tonne : named_scaled_unit<tonne, "t", prefix, ratio<1'000>, kilogram> {};
+struct megagram : prefixed_unit<megagram, mega, gram> {};
+struct gigagram : prefixed_unit<gigagram, giga, gram> {};
+struct teragram : prefixed_unit<teragram, tera, gram> {};
+struct petagram : prefixed_unit<petagram, peta, gram> {};
+struct exagram : prefixed_unit<exagram, exa, gram> {};
+struct zettagram : prefixed_unit<zettagram, zetta, gram> {};
+struct yottagram : prefixed_unit<yottagram, yotta, gram> {};
+
+struct tonne : alias_unit<megagram, "t"> {};
+struct yoctotonne : prefixed_alias_unit<attogram, yocto, tonne> {};
+struct zeptotonne : prefixed_alias_unit<femtogram, zepto, tonne> {};
+struct attotonne : prefixed_alias_unit<picogram, atto, tonne> {};
+struct femtotonne : prefixed_alias_unit<nanogram, femto, tonne> {};
+struct picotonne : prefixed_alias_unit<microgram, pico, tonne> {};
+struct nanotonne : prefixed_alias_unit<milligram, nano, tonne> {};
+struct microtonne : prefixed_alias_unit<gram, micro, tonne> {};
+struct millitonne : prefixed_alias_unit<kilogram, milli, tonne> {};
+struct centitonne : prefixed_unit<centitonne, centi, tonne> {};
+struct decitonne : prefixed_unit<decitonne, deci, tonne> {};
+struct decatonne : prefixed_unit<decatonne, deca, tonne> {};
+struct hectotonne : prefixed_unit<hectotonne, hecto, tonne> {};
+struct kilotonne : prefixed_alias_unit<gigagram, kilo, tonne> {};
+struct megatonne : prefixed_alias_unit<teragram, mega, tonne> {};
+struct gigatonne : prefixed_alias_unit<petagram, giga, tonne> {};
+struct teratonne : prefixed_alias_unit<exagram, tera, tonne> {};
+struct petatonne : prefixed_alias_unit<zettagram, peta, tonne> {};
+struct exatonne : prefixed_alias_unit<yottagram, exa, tonne> {};
+struct zettatonne : prefixed_unit<zettatonne, zetta, tonne> {};
+struct yottatonne : prefixed_unit<yottatonne, yotta, tonne> {};
 
 struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'050, 10'000'000'000'000, -27>, kilogram> {};
 
@@ -45,13 +85,169 @@ inline namespace literals {
 constexpr auto operator"" q_g(unsigned long long l) { return mass<gram, std::int64_t>(l); }
 constexpr auto operator"" q_g(long double l) { return mass<gram, long double>(l); }
 
+// yg
+constexpr auto operator"" q_yg(unsigned long long l) { return mass<yoctogram, std::int64_t>(l); }
+constexpr auto operator"" q_yg(long double l) { return mass<yoctogram, long double>(l); }
+
+// zg
+constexpr auto operator"" q_zg(unsigned long long l) { return mass<zeptogram, std::int64_t>(l); }
+constexpr auto operator"" q_zg(long double l) { return mass<zeptogram, long double>(l); }
+
+// ag
+constexpr auto operator"" q_ag(unsigned long long l) { return mass<attogram, std::int64_t>(l); }
+constexpr auto operator"" q_ag(long double l) { return mass<attogram, long double>(l); }
+
+// fg
+constexpr auto operator"" q_fg(unsigned long long l) { return mass<femtogram, std::int64_t>(l); }
+constexpr auto operator"" q_fg(long double l) { return mass<femtogram, long double>(l); }
+
+// pg
+constexpr auto operator"" q_pg(unsigned long long l) { return mass<picogram, std::int64_t>(l); }
+constexpr auto operator"" q_pg(long double l) { return mass<picogram, long double>(l); }
+
+// ng
+constexpr auto operator"" q_ng(unsigned long long l) { return mass<nanogram, std::int64_t>(l); }
+constexpr auto operator"" q_ng(long double l) { return mass<nanogram, long double>(l); }
+
+// ug
+constexpr auto operator"" q_ug(unsigned long long l) { return mass<microgram, std::int64_t>(l); }
+constexpr auto operator"" q_ug(long double l) { return mass<microgram, long double>(l); }
+
+// mg
+constexpr auto operator"" q_mg(unsigned long long l) { return mass<milligram, std::int64_t>(l); }
+constexpr auto operator"" q_mg(long double l) { return mass<milligram, long double>(l); }
+
+// cg
+constexpr auto operator"" q_cg(unsigned long long l) { return mass<centigram, std::int64_t>(l); }
+constexpr auto operator"" q_cg(long double l) { return mass<centigram, long double>(l); }
+
+// dg
+constexpr auto operator"" q_dg(unsigned long long l) { return mass<decigram, std::int64_t>(l); }
+constexpr auto operator"" q_dg(long double l) { return mass<decigram, long double>(l); }
+
+// dag
+constexpr auto operator"" q_dag(unsigned long long l) { return mass<decagram, std::int64_t>(l); }
+constexpr auto operator"" q_dag(long double l) { return mass<decagram, long double>(l); }
+
+// hg
+constexpr auto operator"" q_hg(unsigned long long l) { return mass<hectogram, std::int64_t>(l); }
+constexpr auto operator"" q_hg(long double l) { return mass<hectogram, long double>(l); }
+
 // kg
 constexpr auto operator"" q_kg(unsigned long long l) { return mass<kilogram, std::int64_t>(l); }
 constexpr auto operator"" q_kg(long double l) { return mass<kilogram, long double>(l); }
 
+// Mg
+constexpr auto operator"" q_Mg(unsigned long long l) { return mass<megagram, std::int64_t>(l); }
+constexpr auto operator"" q_Mg(long double l) { return mass<megagram, long double>(l); }
+
+// Gg
+constexpr auto operator"" q_Gg(unsigned long long l) { return mass<gigagram, std::int64_t>(l); }
+constexpr auto operator"" q_Gg(long double l) { return mass<gigagram, long double>(l); }
+
+// Tg
+constexpr auto operator"" q_Tg(unsigned long long l) { return mass<teragram, std::int64_t>(l); }
+constexpr auto operator"" q_Tg(long double l) { return mass<teragram, long double>(l); }
+
+// Pg
+constexpr auto operator"" q_Pg(unsigned long long l) { return mass<petagram, std::int64_t>(l); }
+constexpr auto operator"" q_Pg(long double l) { return mass<petagram, long double>(l); }
+
+// Eg
+constexpr auto operator"" q_Eg(unsigned long long l) { return mass<exagram, std::int64_t>(l); }
+constexpr auto operator"" q_Eg(long double l) { return mass<exagram, long double>(l); }
+
+// Zg
+constexpr auto operator"" q_Zg(unsigned long long l) { return mass<zettagram, std::int64_t>(l); }
+constexpr auto operator"" q_Zg(long double l) { return mass<zettagram, long double>(l); }
+
+// Yg
+constexpr auto operator"" q_Yg(unsigned long long l) { return mass<yottagram, std::int64_t>(l); }
+constexpr auto operator"" q_Yg(long double l) { return mass<yottagram, long double>(l); }
+
 // t
 constexpr auto operator"" q_t(unsigned long long l) { return mass<tonne, std::int64_t>(l); }
 constexpr auto operator"" q_t(long double l) { return mass<tonne, long double>(l); }
+
+// yt
+constexpr auto operator"" q_yt(unsigned long long l) { return mass<yoctotonne, std::int64_t>(l); }
+constexpr auto operator"" q_yt(long double l) { return mass<yoctotonne, long double>(l); }
+
+// zt
+constexpr auto operator"" q_zt(unsigned long long l) { return mass<zeptotonne, std::int64_t>(l); }
+constexpr auto operator"" q_zt(long double l) { return mass<zeptotonne, long double>(l); }
+
+// at
+constexpr auto operator"" q_at(unsigned long long l) { return mass<attotonne, std::int64_t>(l); }
+constexpr auto operator"" q_at(long double l) { return mass<attotonne, long double>(l); }
+
+// ft
+/*constexpr auto operator"" q_ft(unsigned long long l) { return mass<femtotonne, std::int64_t>(l); }
+constexpr auto operator"" q_ft(long double l) { return mass<femtotonne, long double>(l); }*/
+
+// pt
+constexpr auto operator"" q_pt(unsigned long long l) { return mass<picotonne, std::int64_t>(l); }
+constexpr auto operator"" q_pt(long double l) { return mass<picotonne, long double>(l); }
+
+// nt
+constexpr auto operator"" q_nt(unsigned long long l) { return mass<nanotonne, std::int64_t>(l); }
+constexpr auto operator"" q_nt(long double l) { return mass<nanotonne, long double>(l); }
+
+// ut
+constexpr auto operator"" q_ut(unsigned long long l) { return mass<microtonne, std::int64_t>(l); }
+constexpr auto operator"" q_ut(long double l) { return mass<microtonne, long double>(l); }
+
+// mt
+constexpr auto operator"" q_mt(unsigned long long l) { return mass<millitonne, std::int64_t>(l); }
+constexpr auto operator"" q_mt(long double l) { return mass<millitonne, long double>(l); }
+
+// ct
+constexpr auto operator"" q_ct(unsigned long long l) { return mass<centitonne, std::int64_t>(l); }
+constexpr auto operator"" q_ct(long double l) { return mass<centitonne, long double>(l); }
+
+// dt
+constexpr auto operator"" q_dt(unsigned long long l) { return mass<decitonne, std::int64_t>(l); }
+constexpr auto operator"" q_dt(long double l) { return mass<decitonne, long double>(l); }
+
+// dat
+constexpr auto operator"" q_dat(unsigned long long l) { return mass<decatonne, std::int64_t>(l); }
+constexpr auto operator"" q_dat(long double l) { return mass<decatonne, long double>(l); }
+
+// ht
+constexpr auto operator"" q_ht(unsigned long long l) { return mass<hectotonne, std::int64_t>(l); }
+constexpr auto operator"" q_ht(long double l) { return mass<hectotonne, long double>(l); }
+
+// kt
+constexpr auto operator"" q_kt(unsigned long long l) { return mass<kilotonne, std::int64_t>(l); }
+constexpr auto operator"" q_kt(long double l) { return mass<kilotonne, long double>(l); }
+
+// Mt
+constexpr auto operator"" q_Mt(unsigned long long l) { return mass<megatonne, std::int64_t>(l); }
+constexpr auto operator"" q_Mt(long double l) { return mass<megatonne, long double>(l); }
+
+// Gt
+constexpr auto operator"" q_Gt(unsigned long long l) { return mass<gigatonne, std::int64_t>(l); }
+constexpr auto operator"" q_Gt(long double l) { return mass<gigatonne, long double>(l); }
+
+// Tt
+constexpr auto operator"" q_Tt(unsigned long long l) { return mass<teratonne, std::int64_t>(l); }
+constexpr auto operator"" q_Tt(long double l) { return mass<teratonne, long double>(l); }
+
+// Pt
+constexpr auto operator"" q_Pt(unsigned long long l) { return mass<petatonne, std::int64_t>(l); }
+constexpr auto operator"" q_Pt(long double l) { return mass<petatonne, long double>(l); }
+
+// Et
+constexpr auto operator"" q_Et(unsigned long long l) { return mass<exatonne, std::int64_t>(l); }
+constexpr auto operator"" q_Et(long double l) { return mass<exatonne, long double>(l); }
+
+// Zt
+constexpr auto operator"" q_Zt(unsigned long long l) { return mass<zettatonne, std::int64_t>(l); }
+constexpr auto operator"" q_Zt(long double l) { return mass<zettatonne, long double>(l); }
+
+// Yt
+constexpr auto operator"" q_Yt(unsigned long long l) { return mass<yottatonne, std::int64_t>(l); }
+constexpr auto operator"" q_Yt(long double l) { return mass<yottatonne, long double>(l); }
 
 // Da
 constexpr auto operator"" q_Da(unsigned long long l) { return mass<dalton, std::int64_t>(l); }

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -30,10 +30,22 @@
 namespace units::si {
 
 struct watt : named_unit<watt, "W", prefix> {};
+struct yoctowatt : prefixed_unit<yoctowatt, yocto, watt> {};
+struct zeptowatt : prefixed_unit<zeptowatt, zepto, watt> {};
+struct attowatt : prefixed_unit<attowatt, atto, watt> {};
+struct femtowatt : prefixed_unit<femtowatt, femto, watt> {};
+struct picowatt : prefixed_unit<picowatt, pico, watt> {};
+struct nanowatt : prefixed_unit<nanowatt, nano, watt> {};
+struct microwatt : prefixed_unit<microwatt, micro, watt> {};
 struct milliwatt : prefixed_unit<milliwatt, milli, watt> {};
 struct kilowatt : prefixed_unit<kilowatt, kilo, watt> {};
 struct megawatt : prefixed_unit<megawatt, mega, watt> {};
 struct gigawatt : prefixed_unit<gigawatt, giga, watt> {};
+struct terawatt : prefixed_unit<terawatt, tera, watt> {};
+struct petawatt : prefixed_unit<petawatt, peta, watt> {};
+struct exawatt : prefixed_unit<exawatt, exa, watt> {};
+struct zettawatt : prefixed_unit<zettawatt, zetta, watt> {};
+struct yottawatt : prefixed_unit<yottawatt, yotta, watt> {};
 
 struct dim_power : physical::dim_power<dim_power, watt, dim_energy, dim_time> {};
 
@@ -45,6 +57,34 @@ inline namespace literals {
 // W
 constexpr auto operator"" q_W(unsigned long long l) { return power<watt, std::int64_t>(l); }
 constexpr auto operator"" q_W(long double l) { return power<watt, long double>(l); }
+
+// yW
+constexpr auto operator"" q_yW(unsigned long long l) { return power<yoctowatt, std::int64_t>(l); }
+constexpr auto operator"" q_yW(long double l) { return power<yoctowatt, long double>(l); }
+
+// zW
+constexpr auto operator"" q_zW(unsigned long long l) { return power<zeptowatt, std::int64_t>(l); }
+constexpr auto operator"" q_zW(long double l) { return power<zeptowatt, long double>(l); }
+
+// aW
+constexpr auto operator"" q_aW(unsigned long long l) { return power<attowatt, std::int64_t>(l); }
+constexpr auto operator"" q_aW(long double l) { return power<attowatt, long double>(l); }
+
+// fW
+constexpr auto operator"" q_fW(unsigned long long l) { return power<femtowatt, std::int64_t>(l); }
+constexpr auto operator"" q_fW(long double l) { return power<femtowatt, long double>(l); }
+
+// pW
+constexpr auto operator"" q_pW(unsigned long long l) { return power<picowatt, std::int64_t>(l); }
+constexpr auto operator"" q_pW(long double l) { return power<picowatt, long double>(l); }
+
+// nW
+constexpr auto operator"" q_nW(unsigned long long l) { return power<nanowatt, std::int64_t>(l); }
+constexpr auto operator"" q_nW(long double l) { return power<nanowatt, long double>(l); }
+
+// uW
+constexpr auto operator"" q_uW(unsigned long long l) { return power<microwatt, std::int64_t>(l); }
+constexpr auto operator"" q_uW(long double l) { return power<microwatt, long double>(l); }
 
 // mW
 constexpr auto operator"" q_mW(unsigned long long l) { return power<milliwatt, std::int64_t>(l); }
@@ -61,6 +101,26 @@ constexpr auto operator"" q_MW(long double l) { return power<megawatt, long doub
 // GW
 constexpr auto operator"" q_GW(unsigned long long l) { return power<gigawatt, std::int64_t>(l); }
 constexpr auto operator"" q_GW(long double l) { return power<gigawatt, long double>(l); }
+
+// TW
+constexpr auto operator"" q_TW(unsigned long long l) { return power<terawatt, std::int64_t>(l); }
+constexpr auto operator"" q_TW(long double l) { return power<terawatt, long double>(l); }
+
+// PW
+constexpr auto operator"" q_PW(unsigned long long l) { return power<petawatt, std::int64_t>(l); }
+constexpr auto operator"" q_PW(long double l) { return power<petawatt, long double>(l); }
+
+// EW
+constexpr auto operator"" q_EW(unsigned long long l) { return power<exawatt, std::int64_t>(l); }
+constexpr auto operator"" q_EW(long double l) { return power<exawatt, long double>(l); }
+
+// ZW
+constexpr auto operator"" q_ZW(unsigned long long l) { return power<zettawatt, std::int64_t>(l); }
+constexpr auto operator"" q_ZW(long double l) { return power<zettawatt, long double>(l); }
+
+// YW
+constexpr auto operator"" q_YW(unsigned long long l) { return power<yottawatt, std::int64_t>(l); }
+constexpr auto operator"" q_YW(long double l) { return power<yottawatt, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -31,6 +31,26 @@
 namespace units::si {
 
 struct pascal : named_unit<pascal, "Pa", prefix> {};
+struct yoctopascal : prefixed_unit<yoctopascal, yocto, pascal> {};
+struct zeptopascal : prefixed_unit<zeptopascal, zepto, pascal> {};
+struct attopascal : prefixed_unit<attopascal, atto, pascal> {};
+struct femtopascal : prefixed_unit<femtopascal, femto, pascal> {};
+struct picopascal : prefixed_unit<picopascal, pico, pascal> {};
+struct nanopascal : prefixed_unit<nanopascal, nano, pascal> {};
+struct micropascal : prefixed_unit<micropascal, micro, pascal> {};
+struct millipascal : prefixed_unit<millipascal, milli, pascal> {};
+struct centipascal : prefixed_unit<centipascal, centi, pascal> {};
+struct decipascal : prefixed_unit<decipascal, deci, pascal> {};
+struct decapascal : prefixed_unit<decapascal, deca, pascal> {};
+struct hectopascal : prefixed_unit<hectopascal, hecto, pascal> {};
+struct kilopascal : prefixed_unit<kilopascal, kilo, pascal> {};
+struct megapascal : prefixed_unit<megapascal, mega, pascal> {};
+struct gigapascal : prefixed_unit<gigapascal, giga, pascal> {};
+struct terapascal : prefixed_unit<terapascal, tera, pascal> {};
+struct petapascal : prefixed_unit<petapascal, peta, pascal> {};
+struct exapascal : prefixed_unit<exapascal, exa, pascal> {};
+struct zettapascal : prefixed_unit<zettapascal, zetta, pascal> {};
+struct yottapascal : prefixed_unit<yottapascal, yotta, pascal> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 
@@ -42,6 +62,86 @@ inline namespace literals {
 // Pa
 constexpr auto operator"" q_Pa(unsigned long long l) { return pressure<pascal, std::int64_t>(l); }
 constexpr auto operator"" q_Pa(long double l) { return pressure<pascal, long double>(l); }
+
+// yPa
+constexpr auto operator"" q_yPa(unsigned long long l) { return pressure<yoctopascal, std::int64_t>(l); }
+constexpr auto operator"" q_yPa(long double l) { return pressure<yoctopascal, long double>(l); }
+
+// zPa
+constexpr auto operator"" q_zPa(unsigned long long l) { return pressure<zeptopascal, std::int64_t>(l); }
+constexpr auto operator"" q_zPa(long double l) { return pressure<zeptopascal, long double>(l); }
+
+// aPa
+constexpr auto operator"" q_aPa(unsigned long long l) { return pressure<attopascal, std::int64_t>(l); }
+constexpr auto operator"" q_aPa(long double l) { return pressure<attopascal, long double>(l); }
+
+// fPa
+constexpr auto operator"" q_fPa(unsigned long long l) { return pressure<femtopascal, std::int64_t>(l); }
+constexpr auto operator"" q_fPa(long double l) { return pressure<femtopascal, long double>(l); }
+
+// pPa
+constexpr auto operator"" q_pPa(unsigned long long l) { return pressure<picopascal, std::int64_t>(l); }
+constexpr auto operator"" q_pPa(long double l) { return pressure<picopascal, long double>(l); }
+
+// nPa
+constexpr auto operator"" q_nPa(unsigned long long l) { return pressure<nanopascal, std::int64_t>(l); }
+constexpr auto operator"" q_nPa(long double l) { return pressure<nanopascal, long double>(l); }
+
+// uPa
+constexpr auto operator"" q_uPa(unsigned long long l) { return pressure<micropascal, std::int64_t>(l); }
+constexpr auto operator"" q_uPa(long double l) { return pressure<micropascal, long double>(l); }
+
+// mPa
+constexpr auto operator"" q_mPa(unsigned long long l) { return pressure<millipascal, std::int64_t>(l); }
+constexpr auto operator"" q_mPa(long double l) { return pressure<millipascal, long double>(l); }
+
+// cPa
+constexpr auto operator"" q_cPa(unsigned long long l) { return pressure<centipascal, std::int64_t>(l); }
+constexpr auto operator"" q_cPa(long double l) { return pressure<centipascal, long double>(l); }
+
+// dPa
+constexpr auto operator"" q_dPa(unsigned long long l) { return pressure<decipascal, std::int64_t>(l); }
+constexpr auto operator"" q_dPa(long double l) { return pressure<decipascal, long double>(l); }
+
+// daPa
+constexpr auto operator"" q_daPa(unsigned long long l) { return pressure<decapascal, std::int64_t>(l); }
+constexpr auto operator"" q_daPa(long double l) { return pressure<decapascal, long double>(l); }
+
+// hPa
+constexpr auto operator"" q_hPa(unsigned long long l) { return pressure<hectopascal, std::int64_t>(l); }
+constexpr auto operator"" q_hPa(long double l) { return pressure<hectopascal, long double>(l); }
+
+// kPa
+constexpr auto operator"" q_kPa(unsigned long long l) { return pressure<kilopascal, std::int64_t>(l); }
+constexpr auto operator"" q_kPa(long double l) { return pressure<kilopascal, long double>(l); }
+
+// MPa
+constexpr auto operator"" q_MPa(unsigned long long l) { return pressure<megapascal, std::int64_t>(l); }
+constexpr auto operator"" q_MPa(long double l) { return pressure<megapascal, long double>(l); }
+
+// GPa
+constexpr auto operator"" q_GPa(unsigned long long l) { return pressure<gigapascal, std::int64_t>(l); }
+constexpr auto operator"" q_GPa(long double l) { return pressure<gigapascal, long double>(l); }
+
+// TPa
+constexpr auto operator"" q_TPa(unsigned long long l) { return pressure<terapascal, std::int64_t>(l); }
+constexpr auto operator"" q_TPa(long double l) { return pressure<terapascal, long double>(l); }
+
+// PPa
+constexpr auto operator"" q_PPa(unsigned long long l) { return pressure<petapascal, std::int64_t>(l); }
+constexpr auto operator"" q_PPa(long double l) { return pressure<petapascal, long double>(l); }
+
+// EPa
+constexpr auto operator"" q_EPa(unsigned long long l) { return pressure<exapascal, std::int64_t>(l); }
+constexpr auto operator"" q_EPa(long double l) { return pressure<exapascal, long double>(l); }
+
+// ZPa
+constexpr auto operator"" q_ZPa(unsigned long long l) { return pressure<zettapascal, std::int64_t>(l); }
+constexpr auto operator"" q_ZPa(long double l) { return pressure<zettapascal, long double>(l); }
+
+// YPa
+constexpr auto operator"" q_YPa(unsigned long long l) { return pressure<yottapascal, std::int64_t>(l); }
+constexpr auto operator"" q_YPa(long double l) { return pressure<yottapascal, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -31,9 +31,22 @@
 namespace units::si {
 
 struct ohm : named_unit<ohm, {"Ω", "ohm"}, prefix> {};
+struct yoctoohm : prefixed_unit<yoctoohm, yocto, ohm> {};
+struct zeptoohm : prefixed_unit<zeptoohm, zepto, ohm> {};
+struct attoohm : prefixed_unit<attoohm, atto, ohm> {};
+struct femtoohm : prefixed_unit<femtoohm, femto, ohm> {};
+struct picoohm : prefixed_unit<picoohm, pico, ohm> {};
+struct nanoohm : prefixed_unit<nanoohm, nano, ohm> {};
+struct microohm : prefixed_unit<microohm, micro, ohm> {};
 struct milliohm : prefixed_unit<milliohm, milli, ohm> {};
 struct kiloohm : prefixed_unit<kiloohm, kilo, ohm> {};
 struct megaohm : prefixed_unit<megaohm, mega, ohm> {};
+struct gigaohm : prefixed_unit<gigaohm, giga, ohm> {};
+struct teraohm : prefixed_unit<teraohm, tera, ohm> {};
+struct petaohm : prefixed_unit<petaohm, peta, ohm> {};
+struct exaohm : prefixed_unit<exaohm, exa, ohm> {};
+struct zettaohm : prefixed_unit<zettaohm, zetta, ohm> {};
+struct yottaohm : prefixed_unit<yottaohm, yotta, ohm> {};
 
 struct dim_resistance : physical::dim_resistance<dim_resistance, ohm, dim_voltage, dim_electric_current> {};
 
@@ -46,6 +59,34 @@ inline namespace literals {
 constexpr auto operator"" q_R(unsigned long long l) { return resistance<ohm, std::int64_t>(l); }
 constexpr auto operator"" q_R(long double l) { return resistance<ohm, long double>(l); }
 
+// yR
+constexpr auto operator"" q_yR(unsigned long long l) { return resistance<yoctoohm, std::int64_t>(l); }
+constexpr auto operator"" q_yR(long double l) { return resistance<yoctoohm, long double>(l); }
+
+// zR
+constexpr auto operator"" q_zR(unsigned long long l) { return resistance<zeptoohm, std::int64_t>(l); }
+constexpr auto operator"" q_zR(long double l) { return resistance<zeptoohm, long double>(l); }
+
+// aR
+constexpr auto operator"" q_aR(unsigned long long l) { return resistance<attoohm, std::int64_t>(l); }
+constexpr auto operator"" q_aR(long double l) { return resistance<attoohm, long double>(l); }
+
+// fR
+constexpr auto operator"" q_fR(unsigned long long l) { return resistance<femtoohm, std::int64_t>(l); }
+constexpr auto operator"" q_fR(long double l) { return resistance<femtoohm, long double>(l); }
+
+// pR
+constexpr auto operator"" q_pR(unsigned long long l) { return resistance<picoohm, std::int64_t>(l); }
+constexpr auto operator"" q_pR(long double l) { return resistance<picoohm, long double>(l); }
+
+// nR
+constexpr auto operator"" q_nR(unsigned long long l) { return resistance<nanoohm, std::int64_t>(l); }
+constexpr auto operator"" q_nR(long double l) { return resistance<nanoohm, long double>(l); }
+
+// uR
+constexpr auto operator"" q_uR(unsigned long long l) { return resistance<microohm, std::int64_t>(l); }
+constexpr auto operator"" q_uR(long double l) { return resistance<microohm, long double>(l); }
+
 // mR
 constexpr auto operator"" q_mR(unsigned long long l) { return resistance<milliohm, std::int64_t>(l); }
 constexpr auto operator"" q_mR(long double l) { return resistance<milliohm, long double>(l); }
@@ -57,6 +98,30 @@ constexpr auto operator"" q_kR(long double l) { return resistance<kiloohm, long 
 // MR
 constexpr auto operator"" q_MR(unsigned long long l) { return resistance<megaohm, std::int64_t>(l); }
 constexpr auto operator"" q_MR(long double l) { return resistance<megaohm, long double>(l); }
+
+// GR
+constexpr auto operator"" q_GR(unsigned long long l) { return resistance<gigaohm, std::int64_t>(l); }
+constexpr auto operator"" q_GR(long double l) { return resistance<gigaohm, long double>(l); }
+
+// TR
+constexpr auto operator"" q_TR(unsigned long long l) { return resistance<teraohm, std::int64_t>(l); }
+constexpr auto operator"" q_TR(long double l) { return resistance<teraohm, long double>(l); }
+
+// PR
+constexpr auto operator"" q_PR(unsigned long long l) { return resistance<petaohm, std::int64_t>(l); }
+constexpr auto operator"" q_PR(long double l) { return resistance<petaohm, long double>(l); }
+
+// ER
+constexpr auto operator"" q_ER(unsigned long long l) { return resistance<exaohm, std::int64_t>(l); }
+constexpr auto operator"" q_ER(long double l) { return resistance<exaohm, long double>(l); }
+
+// ZR
+constexpr auto operator"" q_ZR(unsigned long long l) { return resistance<zettaohm, std::int64_t>(l); }
+constexpr auto operator"" q_ZR(long double l) { return resistance<zettaohm, long double>(l); }
+
+// YR
+constexpr auto operator"" q_YR(unsigned long long l) { return resistance<yottaohm, std::int64_t>(l); }
+constexpr auto operator"" q_YR(long double l) { return resistance<yottaohm, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -29,6 +29,11 @@
 namespace units::si {
 
 struct second : named_unit<second, "s", prefix> {};
+struct yoctosecond : prefixed_unit<yoctosecond, yocto, second> {};
+struct zeptosecond : prefixed_unit<zeptosecond, zepto, second> {};
+struct attosecond : prefixed_unit<attosecond, atto, second> {};
+struct femtosecond : prefixed_unit<femtosecond, femto, second> {};
+struct picosecond : prefixed_unit<picosecond, pico, second> {};
 struct nanosecond : prefixed_unit<nanosecond, nano, second> {};
 struct microsecond : prefixed_unit<microsecond, micro, second> {};
 struct millisecond : prefixed_unit<millisecond, milli, second> {};
@@ -42,6 +47,26 @@ template<Unit U, Scalar Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 inline namespace literals {
+
+// ys
+constexpr auto operator"" q_ys(unsigned long long l) { return time<yoctosecond, std::int64_t>(l); }
+constexpr auto operator"" q_ys(long double l) { return time<yoctosecond, long double>(l); }
+
+// zs
+constexpr auto operator"" q_zs(unsigned long long l) { return time<zeptosecond, std::int64_t>(l); }
+constexpr auto operator"" q_zs(long double l) { return time<zeptosecond, long double>(l); }
+
+// as
+constexpr auto operator"" q_as(unsigned long long l) { return time<attosecond, std::int64_t>(l); }
+constexpr auto operator"" q_as(long double l) { return time<attosecond, long double>(l); }
+
+// fs
+constexpr auto operator"" q_fs(unsigned long long l) { return time<femtosecond, std::int64_t>(l); }
+constexpr auto operator"" q_fs(long double l) { return time<femtosecond, long double>(l); }
+
+// ps
+constexpr auto operator"" q_ps(unsigned long long l) { return time<picosecond, std::int64_t>(l); }
+constexpr auto operator"" q_ps(long double l) { return time<picosecond, long double>(l); }
 
 // ns
 constexpr auto operator"" q_ns(unsigned long long l) { return time<nanosecond, std::int64_t>(l); }

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -31,10 +31,26 @@
 namespace units::si {
 
 struct volt : named_unit<volt, "V", prefix> {};
-struct millivolt : prefixed_unit<millivolt, milli, volt> {};
-struct microvolt : prefixed_unit<microvolt, micro, volt> {};
-struct nanovolt : prefixed_unit<nanovolt, nano, volt> {};
+struct yoctovolt : prefixed_unit<yoctovolt, yocto, volt> {};
+struct zeptovolt : prefixed_unit<zeptovolt, zepto, volt> {};
+struct attovolt : prefixed_unit<attovolt, atto, volt> {};
+struct femtovolt : prefixed_unit<femtovolt, femto, volt> {};
 struct picovolt : prefixed_unit<picovolt, pico, volt> {};
+struct nanovolt : prefixed_unit<nanovolt, nano, volt> {};
+struct microvolt : prefixed_unit<microvolt, micro, volt> {};
+struct millivolt : prefixed_unit<millivolt, milli, volt> {};
+struct centivolt : prefixed_unit<centivolt, centi, volt> {};
+struct decivolt : prefixed_unit<decivolt, deci, volt> {};
+struct decavolt : prefixed_unit<decavolt, deca, volt> {};
+struct hectovolt : prefixed_unit<hectovolt, hecto, volt> {};
+struct kilovolt : prefixed_unit<kilovolt, kilo, volt> {};
+struct megavolt : prefixed_unit<megavolt, mega, volt> {};
+struct gigavolt : prefixed_unit<gigavolt, giga, volt> {};
+struct teravolt : prefixed_unit<teravolt, tera, volt> {};
+struct petavolt : prefixed_unit<petavolt, peta, volt> {};
+struct exavolt : prefixed_unit<exavolt, exa, volt> {};
+struct zettavolt : prefixed_unit<zettavolt, zetta, volt> {};
+struct yottavolt : prefixed_unit<yottavolt, yotta, volt> {};
 
 struct dim_voltage : physical::dim_voltage<dim_voltage, volt, dim_power, dim_electric_current> {};
 
@@ -47,17 +63,85 @@ inline namespace literals {
 constexpr auto operator"" q_V(unsigned long long l) { return voltage<volt, std::int64_t>(l); }
 constexpr auto operator"" q_V(long double l) { return voltage<volt, long double>(l); }
 
-constexpr auto operator"" q_mV(unsigned long long l) { return voltage<millivolt, std::int64_t>(l); }
-constexpr auto operator"" q_mV(long double l) { return voltage<millivolt, long double>(l); }
+// yV
+constexpr auto operator"" q_yV(unsigned long long l) { return voltage<yoctovolt, std::int64_t>(l); }
+constexpr auto operator"" q_yV(long double l) { return voltage<yoctovolt, long double>(l); }
 
-constexpr auto operator"" q_uV(unsigned long long l) { return voltage<microvolt, std::int64_t>(l); }
-constexpr auto operator"" q_uV(long double l) { return voltage<microvolt, long double>(l); }
+// zV
+constexpr auto operator"" q_zV(unsigned long long l) { return voltage<zeptovolt, std::int64_t>(l); }
+constexpr auto operator"" q_zV(long double l) { return voltage<zeptovolt, long double>(l); }
 
+// aV
+constexpr auto operator"" q_aV(unsigned long long l) { return voltage<attovolt, std::int64_t>(l); }
+constexpr auto operator"" q_aV(long double l) { return voltage<attovolt, long double>(l); }
+
+// fV
+constexpr auto operator"" q_fV(unsigned long long l) { return voltage<femtovolt, std::int64_t>(l); }
+constexpr auto operator"" q_fV(long double l) { return voltage<femtovolt, long double>(l); }
+
+// pV
+constexpr auto operator"" q_pV(unsigned long long l) { return voltage<picovolt, std::int64_t>(l); }
+constexpr auto operator"" q_pV(long double l) { return voltage<picovolt, long double>(l); }
+
+// nV
 constexpr auto operator"" q_nV(unsigned long long l) { return voltage<nanovolt, std::int64_t>(l); }
 constexpr auto operator"" q_nV(long double l) { return voltage<nanovolt, long double>(l); }
 
-constexpr auto operator"" q_pV(unsigned long long l) { return voltage<picovolt, std::int64_t>(l); }
-constexpr auto operator"" q_pV(long double l) { return voltage<picovolt, long double>(l); }
+// uV
+constexpr auto operator"" q_uV(unsigned long long l) { return voltage<microvolt, std::int64_t>(l); }
+constexpr auto operator"" q_uV(long double l) { return voltage<microvolt, long double>(l); }
+
+// mV
+constexpr auto operator"" q_mV(unsigned long long l) { return voltage<millivolt, std::int64_t>(l); }
+constexpr auto operator"" q_mV(long double l) { return voltage<millivolt, long double>(l); }
+
+// cV
+constexpr auto operator"" q_cV(unsigned long long l) { return voltage<centivolt, std::int64_t>(l); }
+constexpr auto operator"" q_cV(long double l) { return voltage<centivolt, long double>(l); }
+
+// dV
+constexpr auto operator"" q_dV(unsigned long long l) { return voltage<decivolt, std::int64_t>(l); }
+constexpr auto operator"" q_dV(long double l) { return voltage<decivolt, long double>(l); }
+
+// daV
+constexpr auto operator"" q_daV(unsigned long long l) { return voltage<decavolt, std::int64_t>(l); }
+constexpr auto operator"" q_daV(long double l) { return voltage<decavolt, long double>(l); }
+
+// hV
+constexpr auto operator"" q_hV(unsigned long long l) { return voltage<hectovolt, std::int64_t>(l); }
+constexpr auto operator"" q_hV(long double l) { return voltage<hectovolt, long double>(l); }
+
+// kV
+constexpr auto operator"" q_kV(unsigned long long l) { return voltage<kilovolt, std::int64_t>(l); }
+constexpr auto operator"" q_kV(long double l) { return voltage<kilovolt, long double>(l); }
+
+// MV
+constexpr auto operator"" q_MV(unsigned long long l) { return voltage<megavolt, std::int64_t>(l); }
+constexpr auto operator"" q_MV(long double l) { return voltage<megavolt, long double>(l); }
+
+// GV
+constexpr auto operator"" q_GV(unsigned long long l) { return voltage<gigavolt, std::int64_t>(l); }
+constexpr auto operator"" q_GV(long double l) { return voltage<gigavolt, long double>(l); }
+
+// TV
+constexpr auto operator"" q_TV(unsigned long long l) { return voltage<teravolt, std::int64_t>(l); }
+constexpr auto operator"" q_TV(long double l) { return voltage<teravolt, long double>(l); }
+
+// PV
+constexpr auto operator"" q_PV(unsigned long long l) { return voltage<petavolt, std::int64_t>(l); }
+constexpr auto operator"" q_PV(long double l) { return voltage<petavolt, long double>(l); }
+
+// EV
+constexpr auto operator"" q_EV(unsigned long long l) { return voltage<exavolt, std::int64_t>(l); }
+constexpr auto operator"" q_EV(long double l) { return voltage<exavolt, long double>(l); }
+
+// ZV
+constexpr auto operator"" q_ZV(unsigned long long l) { return voltage<zettavolt, std::int64_t>(l); }
+constexpr auto operator"" q_ZV(long double l) { return voltage<zettavolt, long double>(l); }
+
+// YV
+constexpr auto operator"" q_YV(unsigned long long l) { return voltage<yottavolt, std::int64_t>(l); }
+constexpr auto operator"" q_YV(long double l) { return voltage<yottavolt, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -31,17 +31,85 @@ namespace units::si {
 struct cubic_metre : unit<cubic_metre> {};
 struct dim_volume : physical::dim_volume<dim_volume, cubic_metre, dim_length> {};
 
+struct cubic_yoctometre : deduced_unit<cubic_yoctometre, dim_volume, yoctometre> {};
+struct cubic_zeptometre : deduced_unit<cubic_zeptometre, dim_volume, zeptometre> {};
+struct cubic_attometre : deduced_unit<cubic_attometre, dim_volume, attometre> {};
+struct cubic_femtometre : deduced_unit<cubic_femtometre, dim_volume, femtometre> {};
+struct cubic_picometre : deduced_unit<cubic_picometre, dim_volume, picometre> {};
+struct cubic_nanometre : deduced_unit<cubic_nanometre, dim_volume, nanometre> {};
+struct cubic_micrometre : deduced_unit<cubic_micrometre, dim_volume, micrometre> {};
 struct cubic_millimetre : deduced_unit<cubic_millimetre, dim_volume, millimetre> {};
 struct cubic_centimetre : deduced_unit<cubic_centimetre, dim_volume, centimetre> {};
+struct cubic_decimetre : deduced_unit<cubic_decimetre, dim_volume, decimetre> {};
+struct cubic_decametre : deduced_unit<cubic_decametre, dim_volume, decametre> {};
+struct cubic_hectometre : deduced_unit<cubic_hectometre, dim_volume, hectometre> {};
 struct cubic_kilometre : deduced_unit<cubic_kilometre, dim_volume, kilometre> {};
+struct cubic_megametre : deduced_unit<cubic_megametre, dim_volume, megametre> {};
+struct cubic_gigametre : deduced_unit<cubic_gigametre, dim_volume, gigametre> {};
+struct cubic_terametre : deduced_unit<cubic_terametre, dim_volume, terametre> {};
+struct cubic_petametre : deduced_unit<cubic_petametre, dim_volume, petametre> {};
+struct cubic_exametre : deduced_unit<cubic_exametre, dim_volume, exametre> {};
+struct cubic_zettametre : deduced_unit<cubic_zettametre, dim_volume, zettametre> {};
+struct cubic_yottametre : deduced_unit<cubic_yottametre, dim_volume, yottametre> {};
 
-struct litre : deduced_unit<litre, dim_volume, decimetre> {};
-
+struct litre : alias_unit<cubic_decimetre, "l"> {};
+struct yoctolitre : prefixed_alias_unit<cubic_nanometre, yocto, litre> {};
+struct zeptolitre : prefixed_unit<zeptolitre, zepto, litre> {};
+struct attolitre : prefixed_unit<attolitre, atto, litre> {};
+struct femtolitre : prefixed_alias_unit<cubic_micrometre, femto, litre> {};
+struct picolitre : prefixed_unit<picolitre, pico, litre> {};
+struct nanolitre : prefixed_unit<nanolitre, nano, litre> {};
+struct microlitre : prefixed_alias_unit<cubic_millimetre, micro, litre> {};
+struct millilitre : prefixed_alias_unit<cubic_centimetre, milli, litre> {};
+struct centilitre : prefixed_unit<centilitre, centi, litre> {};
+struct decilitre : prefixed_unit<decilitre, deci, litre> {};
+struct decalitre : prefixed_unit<decalitre, deca, litre> {};
+struct hectolitre : prefixed_alias_unit<cubic_decimetre, hecto, litre> {};
+struct kilolitre : prefixed_alias_unit<cubic_metre, kilo, litre> {};
+struct megalitre : prefixed_alias_unit<cubic_decametre, mega, litre> {};
+struct gigalitre : prefixed_alias_unit<cubic_hectometre, giga, litre> {};
+struct teralitre : prefixed_alias_unit<cubic_kilometre, tera, litre> {};
+struct petalitre : prefixed_unit<petalitre, peta, litre> {};
+struct exalitre : prefixed_unit<petalitre, exa, litre> {};
+struct zettalitre : prefixed_alias_unit<cubic_megametre, zetta, litre> {};
+struct yottalitre : prefixed_unit<yottalitre, yotta, litre> {};
 
 template<Unit U, Scalar Rep = double>
 using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {
+
+// m3
+constexpr auto operator"" q_m3(unsigned long long l) { return volume<cubic_metre, std::int64_t>(l); }
+constexpr auto operator"" q_m3(long double l) { return volume<cubic_metre, long double>(l); }
+
+// ym3
+constexpr auto operator"" q_ym3(unsigned long long l) { return volume<cubic_yoctometre, std::int64_t>(l); }
+constexpr auto operator"" q_ym3(long double l) { return volume<cubic_yoctometre, long double>(l); }
+
+// zm3
+constexpr auto operator"" q_zm3(unsigned long long l) { return volume<cubic_zeptometre, std::int64_t>(l); }
+constexpr auto operator"" q_zm3(long double l) { return volume<cubic_zeptometre, long double>(l); }
+
+// am3
+constexpr auto operator"" q_am3(unsigned long long l) { return volume<cubic_attometre, std::int64_t>(l); }
+constexpr auto operator"" q_am3(long double l) { return volume<cubic_attometre, long double>(l); }
+
+// fm3
+constexpr auto operator"" q_fm3(unsigned long long l) { return volume<cubic_femtometre, std::int64_t>(l); }
+constexpr auto operator"" q_fm3(long double l) { return volume<cubic_femtometre, long double>(l); }
+
+// pm3
+constexpr auto operator"" q_pm3(unsigned long long l) { return volume<cubic_picometre, std::int64_t>(l); }
+constexpr auto operator"" q_pm3(long double l) { return volume<cubic_picometre, long double>(l); }
+
+// nm3
+constexpr auto operator"" q_nm3(unsigned long long l) { return volume<cubic_nanometre, std::int64_t>(l); }
+constexpr auto operator"" q_nm3(long double l) { return volume<cubic_nanometre, long double>(l); }
+
+// um3
+constexpr auto operator"" q_um3(unsigned long long l) { return volume<cubic_micrometre, std::int64_t>(l); }
+constexpr auto operator"" q_um3(long double l) { return volume<cubic_micrometre, long double>(l); }
 
 // mm3
 constexpr auto operator"" q_mm3(unsigned long long l) { return volume<cubic_millimetre, std::int64_t>(l); }
@@ -51,17 +119,133 @@ constexpr auto operator"" q_mm3(long double l) { return volume<cubic_millimetre,
 constexpr auto operator"" q_cm3(unsigned long long l) { return volume<cubic_centimetre, std::int64_t>(l); }
 constexpr auto operator"" q_cm3(long double l) { return volume<cubic_centimetre, long double>(l); }
 
-// m3
-constexpr auto operator"" q_m3(unsigned long long l) { return volume<cubic_metre, std::int64_t>(l); }
-constexpr auto operator"" q_m3(long double l) { return volume<cubic_metre, long double>(l); }
+// dm3
+constexpr auto operator"" q_dm3(unsigned long long l) { return volume<cubic_decimetre, std::int64_t>(l); }
+constexpr auto operator"" q_dm3(long double l) { return volume<cubic_decimetre, long double>(l); }
+
+// dam3
+constexpr auto operator"" q_dam3(unsigned long long l) { return volume<cubic_decametre, std::int64_t>(l); }
+constexpr auto operator"" q_dam3(long double l) { return volume<cubic_decametre, long double>(l); }
+
+// hm3
+constexpr auto operator"" q_hm3(unsigned long long l) { return volume<cubic_hectometre, std::int64_t>(l); }
+constexpr auto operator"" q_hm3(long double l) { return volume<cubic_hectometre, long double>(l); }
 
 // km3
 constexpr auto operator"" q_km3(unsigned long long l) { return volume<cubic_kilometre, std::int64_t>(l); }
 constexpr auto operator"" q_km3(long double l) { return volume<cubic_kilometre, long double>(l); }
 
+// Mm3
+constexpr auto operator"" q_Mm3(unsigned long long l) { return volume<cubic_megametre, std::int64_t>(l); }
+constexpr auto operator"" q_Mm3(long double l) { return volume<cubic_megametre, long double>(l); }
+
+// Gm3
+constexpr auto operator"" q_Gm3(unsigned long long l) { return volume<cubic_gigametre, std::int64_t>(l); }
+constexpr auto operator"" q_Gm3(long double l) { return volume<cubic_gigametre, long double>(l); }
+
+// Tm3
+constexpr auto operator"" q_Tm3(unsigned long long l) { return volume<cubic_terametre, std::int64_t>(l); }
+constexpr auto operator"" q_Tm3(long double l) { return volume<cubic_terametre, long double>(l); }
+
+// Pm3
+constexpr auto operator"" q_Pm3(unsigned long long l) { return volume<cubic_petametre, std::int64_t>(l); }
+constexpr auto operator"" q_Pm3(long double l) { return volume<cubic_petametre, long double>(l); }
+
+// Em3
+constexpr auto operator"" q_Em3(unsigned long long l) { return volume<cubic_exametre, std::int64_t>(l); }
+constexpr auto operator"" q_Em3(long double l) { return volume<cubic_exametre, long double>(l); }
+
+// Zm3
+constexpr auto operator"" q_Zm3(unsigned long long l) { return volume<cubic_zettametre, std::int64_t>(l); }
+constexpr auto operator"" q_Zm3(long double l) { return volume<cubic_zettametre, long double>(l); }
+
+// Ym3
+constexpr auto operator"" q_Ym3(unsigned long long l) { return volume<cubic_yottametre, std::int64_t>(l); }
+constexpr auto operator"" q_Ym3(long double l) { return volume<cubic_yottametre, long double>(l); }
+
 // l
 constexpr auto operator"" q_l(unsigned long long l) { return volume<litre, std::int64_t>(l); }
 constexpr auto operator"" q_l(long double l) { return volume<litre, long double>(l); }
+
+// yl
+constexpr auto operator"" q_yl(unsigned long long l) { return volume<yoctolitre, std::int64_t>(l); }
+constexpr auto operator"" q_yl(long double l) { return volume<yoctolitre, long double>(l); }
+
+// zl
+constexpr auto operator"" q_zl(unsigned long long l) { return volume<zeptolitre, std::int64_t>(l); }
+constexpr auto operator"" q_zl(long double l) { return volume<zeptolitre, long double>(l); }
+
+// al
+constexpr auto operator"" q_al(unsigned long long l) { return volume<attolitre, std::int64_t>(l); }
+constexpr auto operator"" q_al(long double l) { return volume<attolitre, long double>(l); }
+
+// fl
+constexpr auto operator"" q_fl(unsigned long long l) { return volume<femtolitre, std::int64_t>(l); }
+constexpr auto operator"" q_fl(long double l) { return volume<femtolitre, long double>(l); }
+
+// pl
+constexpr auto operator"" q_pl(unsigned long long l) { return volume<picolitre, std::int64_t>(l); }
+constexpr auto operator"" q_pl(long double l) { return volume<picolitre, long double>(l); }
+
+// nl
+constexpr auto operator"" q_nl(unsigned long long l) { return volume<nanolitre, std::int64_t>(l); }
+constexpr auto operator"" q_nl(long double l) { return volume<nanolitre, long double>(l); }
+
+// ul
+constexpr auto operator"" q_ul(unsigned long long l) { return volume<microlitre, std::int64_t>(l); }
+constexpr auto operator"" q_ul(long double l) { return volume<microlitre, long double>(l); }
+
+// ml
+constexpr auto operator"" q_ml(unsigned long long l) { return volume<millilitre, std::int64_t>(l); }
+constexpr auto operator"" q_ml(long double l) { return volume<millilitre, long double>(l); }
+
+// cl
+constexpr auto operator"" q_cl(unsigned long long l) { return volume<centilitre, std::int64_t>(l); }
+constexpr auto operator"" q_cl(long double l) { return volume<centilitre, long double>(l); }
+
+// dl
+constexpr auto operator"" q_dl(unsigned long long l) { return volume<decilitre, std::int64_t>(l); }
+constexpr auto operator"" q_dl(long double l) { return volume<decilitre, long double>(l); }
+
+// dal
+constexpr auto operator"" q_dal(unsigned long long l) { return volume<decalitre, std::int64_t>(l); }
+constexpr auto operator"" q_dal(long double l) { return volume<decalitre, long double>(l); }
+
+// hl
+constexpr auto operator"" q_hl(unsigned long long l) { return volume<hectolitre, std::int64_t>(l); }
+constexpr auto operator"" q_hl(long double l) { return volume<hectolitre, long double>(l); }
+
+// kl
+constexpr auto operator"" q_kl(unsigned long long l) { return volume<kilolitre, std::int64_t>(l); }
+constexpr auto operator"" q_kl(long double l) { return volume<kilolitre, long double>(l); }
+
+// Ml
+constexpr auto operator"" q_Ml(unsigned long long l) { return volume<megalitre, std::int64_t>(l); }
+constexpr auto operator"" q_Ml(long double l) { return volume<megalitre, long double>(l); }
+
+// Gl
+constexpr auto operator"" q_Gl(unsigned long long l) { return volume<gigalitre, std::int64_t>(l); }
+constexpr auto operator"" q_Gl(long double l) { return volume<gigalitre, long double>(l); }
+
+// Tl
+constexpr auto operator"" q_Tl(unsigned long long l) { return volume<teralitre, std::int64_t>(l); }
+constexpr auto operator"" q_Tl(long double l) { return volume<teralitre, long double>(l); }
+
+// Pl
+constexpr auto operator"" q_Pl(unsigned long long l) { return volume<petalitre, std::int64_t>(l); }
+constexpr auto operator"" q_Pl(long double l) { return volume<petalitre, long double>(l); }
+
+// El
+constexpr auto operator"" q_El(unsigned long long l) { return volume<exalitre, std::int64_t>(l); }
+constexpr auto operator"" q_El(long double l) { return volume<exalitre, long double>(l); }
+
+// Zl
+constexpr auto operator"" q_Zl(unsigned long long l) { return volume<zettalitre, std::int64_t>(l); }
+constexpr auto operator"" q_Zl(long double l) { return volume<zettalitre, long double>(l); }
+
+// Yl
+constexpr auto operator"" q_Yl(unsigned long long l) { return volume<yottalitre, std::int64_t>(l); }
+constexpr auto operator"" q_Yl(long double l) { return volume<yottalitre, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -52,7 +52,7 @@ struct cubic_exametre : deduced_unit<cubic_exametre, dim_volume, exametre> {};
 struct cubic_zettametre : deduced_unit<cubic_zettametre, dim_volume, zettametre> {};
 struct cubic_yottametre : deduced_unit<cubic_yottametre, dim_volume, yottametre> {};
 
-struct litre : alias_unit<cubic_decimetre, "l"> {};
+struct litre : alias_unit<cubic_decimetre, "l", prefix> {};
 struct yoctolitre : prefixed_alias_unit<cubic_nanometre, yocto, litre> {};
 struct zeptolitre : prefixed_unit<zeptolitre, zepto, litre> {};
 struct attolitre : prefixed_unit<attolitre, atto, litre> {};

--- a/src/include/units/unit.h
+++ b/src/include/units/unit.h
@@ -74,7 +74,6 @@ template<typename Child>
 struct unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
   static constexpr bool is_named = false;
   using prefix_family = no_prefix;
-  using base_prefix_family = no_prefix;
 };
 
 /**
@@ -101,7 +100,6 @@ struct named_unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
   using prefix_family = PT;
-  using base_prefix_family = PT;
 };
 
 /**
@@ -123,7 +121,6 @@ struct named_scaled_unit : downcast_child<Child, scaled_unit<ratio_multiply<R, t
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
   using prefix_family = PT;
-  using base_prefix_family = PT;
 };
 
 /**
@@ -144,7 +141,6 @@ struct prefixed_unit :
   static constexpr bool is_named = true;
   static constexpr auto symbol = P::symbol + U::symbol;
   using prefix_family = no_prefix;
-  using base_prefix_family = U::base_prefix_family;
 };
 
 /**
@@ -167,7 +163,6 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
   static constexpr bool is_named = false;
   static constexpr auto symbol = detail::deduced_symbol_text<Dim, U, URest...>();
   using prefix_family = no_prefix;
-  using base_prefix_family = U::base_prefix_family;
 };
 
 // template<typename Child, Dimension Dim, basic_fixed_string Symbol, PrefixFamily PT, Unit U, Unit... Us>
@@ -177,20 +172,18 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
 //   using prefix_family = PT;
 // };
 
-template<Unit U, basic_symbol_text Symbol>
+template<Unit U, basic_symbol_text Symbol, PrefixFamily PT>
 struct alias_unit : U {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
-  using prefix_family = U::base_prefix_family;
-  using base_prefix_family = U::base_prefix_family;
+  using prefix_family = PT;
 };
 
 template<Unit U, Prefix P, Unit AU>
 struct prefixed_alias_unit : U {
   static constexpr bool is_named = true;
   static constexpr auto symbol = P::symbol + AU::symbol;
-  using prefix_family = no_prefix;
-  using base_prefix_family = AU::base_prefix_family;
+  using prefix_family = AU::prefix_family;
 };
 
 }  // namespace units

--- a/src/include/units/unit.h
+++ b/src/include/units/unit.h
@@ -74,6 +74,7 @@ template<typename Child>
 struct unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
   static constexpr bool is_named = false;
   using prefix_family = no_prefix;
+  using base_prefix_family = no_prefix;
 };
 
 /**
@@ -100,6 +101,7 @@ struct named_unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
   using prefix_family = PT;
+  using base_prefix_family = PT;
 };
 
 /**
@@ -121,6 +123,7 @@ struct named_scaled_unit : downcast_child<Child, scaled_unit<ratio_multiply<R, t
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
   using prefix_family = PT;
+  using base_prefix_family = PT;
 };
 
 /**
@@ -141,6 +144,7 @@ struct prefixed_unit :
   static constexpr bool is_named = true;
   static constexpr auto symbol = P::symbol + U::symbol;
   using prefix_family = no_prefix;
+  using base_prefix_family = U::base_prefix_family;
 };
 
 /**
@@ -163,6 +167,7 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
   static constexpr bool is_named = false;
   static constexpr auto symbol = detail::deduced_symbol_text<Dim, U, URest...>();
   using prefix_family = no_prefix;
+  using base_prefix_family = U::base_prefix_family;
 };
 
 // template<typename Child, Dimension Dim, basic_fixed_string Symbol, PrefixFamily PT, Unit U, Unit... Us>
@@ -171,5 +176,21 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
 //   static constexpr auto symbol = Symbol;
 //   using prefix_family = PT;
 // };
+
+template<Unit U, basic_symbol_text Symbol>
+struct alias_unit : U {
+  static constexpr bool is_named = true;
+  static constexpr auto symbol = Symbol;
+  using prefix_family = U::base_prefix_family;
+  using base_prefix_family = U::base_prefix_family;
+};
+
+template<Unit U, Prefix P, Unit AU>
+struct prefixed_alias_unit : U {
+  static constexpr bool is_named = true;
+  static constexpr auto symbol = P::symbol + AU::symbol;
+  using prefix_family = no_prefix;
+  using base_prefix_family = AU::base_prefix_family;
+};
 
 }  // namespace units

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -300,7 +300,8 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
       SECTION("iostream")
       {
-        CHECK(os.str() == "8 × 10⁻² m³");
+        //CHECK(os.str() == "8 × 10⁻² m³");
+        CHECK(os.str() == "8 dal");
       }
 
       SECTION("fmt with default format {} on a quantity")

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -295,13 +295,12 @@ TEST_CASE("operator<< on a quantity", "[text][ostream][fmt]")
 
     SECTION("unit::ratio for a dimension without a special symbol")
     {
-      const auto q = 2q_cm * 2q_m * 2q_m;
+      const auto q = 2q_um * 2q_cm * 2q_cm;
       os << q;
 
       SECTION("iostream")
       {
-        //CHECK(os.str() == "8 × 10⁻² m³");
-        CHECK(os.str() == "8 dal");
+        CHECK(os.str() == "8 × 10⁻¹⁰ m³");
       }
 
       SECTION("fmt with default format {} on a quantity")

--- a/test/unit_test/static/si_test.cpp
+++ b/test/unit_test/static/si_test.cpp
@@ -52,8 +52,11 @@ static_assert(kilometre::symbol == "km");
 
 static_assert(1q_kg == 1000q_g);
 static_assert(1q_t == 1000q_kg);
+static_assert(1q_kt == 1000000q_kg);
 
 static_assert(kilogram::symbol == "kg");
+static_assert(tonne::symbol == "t");
+static_assert(kilotonne::symbol == "kt");
 
 // time
 
@@ -281,6 +284,10 @@ static_assert(10q_km * 10q_km * 10q_km == 1000q_km3);
 static_assert(1q_m3 == 1'000'000q_cm3);
 static_assert(1q_dm * 1q_dm * 1q_dm == 1q_l);
 static_assert(1000q_l == 1q_m3);
+static_assert(1q_kl == 1q_m3);
+
+static_assert(litre::symbol == "l");
+static_assert(kilolitre::symbol == "kl");
 
 static_assert(detail::unit_text<dim_volume, cubic_metre>() == basic_symbol_text("m³", "m^3"));
 

--- a/test/unit_test/static/si_test.cpp
+++ b/test/unit_test/static/si_test.cpp
@@ -274,6 +274,8 @@ static_assert(10q_km * 10q_km == 100q_km2);
 static_assert(1q_m2 == 10'000q_cm2);
 static_assert(1q_ha == 10'000q_m2);
 
+static_assert(hectare::symbol == "ha");
+
 static_assert(detail::unit_text<dim_area, square_metre>() == basic_symbol_text("m²", "m^2"));
 
 // volume


### PR DESCRIPTION
Dear Mr. Mateusz Pusz,

I added more prefixed SI units after I found that ```nanometer``` was missing. I needed that unit for my SPICE circuit simulation work. Please let me know if there is anything I am missing - if I added anything redundant, conflicting, etc ...

Most importantly, I added ```alias_unit``` and ```prefixed_alias_unit``` types to deal with units such as ```litre``` which, due to having been equivalent to ```cubic_decimetre```, used to have its unit printed out as ```dm³``` rather than ```l```. ```tonne```, on the other hand, due to having been a ```scaled_unit``` from kilogram, had its unit printed out properly as ```t```. However, after having defined ```megagram```, which is equivalent to ```tonne```, I would get an error concerning a redeclaration of ```friend auto downcast_guide(typename downcast_child::downcast_base /* base */) { return Target(); }``` (bits/external/downcasting.h, line 45) due to both units essentially boiling down to the same entity. The two aforementioned added types avoid this issue and allow the aliasing of a unit, and further prefixing of the alias, without disturbing the inner mathematical workings of the library, or implementation in general.

I hope these adhere to the library's philosophy. If they do not, then please let me know of any suggestions you might have to improve / replace them.

Thank you very much, as always.

Ramzi