### PR TITLE
Added absolute functions (abs, fabs) and epsilon to math.h, and tests

### DIFF
--- a/src/include/units/math.h
+++ b/src/include/units/math.h
@@ -22,34 +22,53 @@
 
 #pragma once
 
+#include <units/concepts.h>
 #include <units/quantity.h>
 #include <cmath>
+#include <limits>
 
 namespace units {
 
-  template<std::intmax_t N, typename D, typename U, typename Rep>
-    requires (N == 0)
-  inline Rep pow(const quantity<D, U, Rep>&) noexcept
-  {
-    return 1;
-  }
+template<std::intmax_t N, typename D, typename U, typename Rep>
+requires(N == 0) inline Rep pow(const quantity<D, U, Rep>&) noexcept
+{
+  return 1;
+}
 
-  template<std::intmax_t N, typename D, typename U, typename Rep>
-  inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
-  {
-    using dim = dimension_pow<D, N>;
-    using ratio = ratio_pow<typename U::ratio, N>;
-    using unit = downcast_unit<dim, ratio>;
-    return quantity<dim, unit, Rep>(static_cast<Rep>(std::pow(q.count(), N)));
-  }
+template<std::intmax_t N, typename D, typename U, typename Rep>
+inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
+{
+  using dim = dimension_pow<D, N>;
+  using ratio = ratio_pow<typename U::ratio, N>;
+  using unit = downcast_unit<dim, ratio>;
+  return quantity<dim, unit, Rep>(static_cast<Rep>(std::pow(q.count(), N)));
+}
 
-  template<typename D, typename U, typename Rep>
-  inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
-  {
-    using dim = dimension_sqrt<D>;
-    using ratio = ratio_sqrt<typename U::ratio>;
-    using unit = downcast_unit<dim, ratio>;
-    return quantity<dim, unit, Rep>(static_cast<Rep>(std::sqrt(q.count())));
-  }
+template<typename D, typename U, typename Rep>
+inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
+{
+  using dim = dimension_sqrt<D>;
+  using ratio = ratio_sqrt<typename U::ratio>;
+  using unit = downcast_unit<dim, ratio>;
+  return quantity<dim, unit, Rep>(static_cast<Rep>(std::sqrt(q.count())));
+}
+
+template<typename D, typename U, typename Rep>
+constexpr Quantity AUTO abs(const quantity<D, U, Rep>& q) noexcept
+{
+  return quantity<D, U, Rep>(std::abs(q.count()));
+}
+
+template<typename D, typename U, typename Rep>
+constexpr Quantity AUTO fabs(const quantity<D, U, Rep>& q) noexcept
+{
+  return quantity<D, U, Rep>(std::fabs(q.count()));
+}
+
+template<Quantity Q>
+constexpr Quantity AUTO epsilon() noexcept
+{
+  return Q(std::numeric_limits<typename Q::rep>::epsilon());
+}
 
 }  // namespace units

--- a/test/unit_test/runtime/math_test.cpp
+++ b/test/unit_test/runtime/math_test.cpp
@@ -53,3 +53,35 @@ TEST_CASE("'sqrt()' on quantity changes the value and the dimension accordingly"
 {
   REQUIRE(sqrt(4q_m2) == 2q_m);
 }
+
+TEST_CASE("absolute functions on quantity returns the absolute value", "[math][abs][fabs]")
+{
+  SECTION ("'abs()' on a negative quantity returns the abs") {
+    REQUIRE(abs(-1q_m) == 1q_m);
+  }
+
+  SECTION ("'abs()' on a positive quantity returns the abs") {
+    REQUIRE(abs(1q_m) == 1q_m);
+  }
+
+  SECTION ("'fabs()' on a negative quantity returns the abs") {
+    REQUIRE(fabs(-1.q_m) == 1.q_m);
+  }
+
+  SECTION ("'fabs()' on a positive quantity returns the abs") {
+    REQUIRE(fabs(1.q_m) == 1.q_m);
+  }
+}
+
+TEST_CASE("numeric_limits functions", "[limits]")
+{
+  SECTION ("'epsilon' works as expected using default floating type") {
+    REQUIRE(epsilon<decltype(1.q_m)>().count() == std::numeric_limits<decltype(1.q_m)::rep>::epsilon());
+  }
+  SECTION ("'epsilon' works as expected using integers") {
+    REQUIRE(epsilon<decltype(1q_m)>().count() == std::numeric_limits<decltype(1q_m)::rep>::epsilon());
+  }
+  SECTION ("'epsilon' works as expected using mixed Rep types") {
+    REQUIRE(epsilon<decltype(1q_m)>().count() != std::numeric_limits<decltype(1.q_m)::rep>::epsilon());
+  }
+}


### PR DESCRIPTION
Maybe the epsilon (and any other functions to be added to mimic std::numeric_limits) should relate to the "quantity_values" class.
