### PR TITLE
si angle header : angle literal should return an angle not a length

### DIFF
--- a/src/include/units/physical/si/angle.h
+++ b/src/include/units/physical/si/angle.h
@@ -38,8 +38,8 @@ using angle = quantity<dim_angle, U, Rep>;
 inline namespace literals {
 
 // rad
-constexpr auto operator"" q_rad(unsigned long long l) { return length<metre, std::int64_t>(l); }
-constexpr auto operator"" q_rad(long double l) { return length<metre, long double>(l); }
+constexpr auto operator"" q_rad(unsigned long long l) { return angle<radian, std::int64_t>(l); }
+constexpr auto operator"" q_rad(long double l) { return angle<radian, long double>(l); }
 
 
 }  // namespace literals


### PR DESCRIPTION
si angle header : fix wrong literal return type so now returns an angle not a length