### PR TITLE
units::quantity :

### DIFF
--- a/src/include/units/math.h
+++ b/src/include/units/math.h
@@ -38,15 +38,16 @@ namespace units {
  * @param q Quantity being the base of the operation
  * @return Quantity The result of computation 
  */
-template<std::intmax_t N, typename D, typename U, typename Rep>
+template<std::intmax_t N, Quantity Q>
   requires(N != 0)
-inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
+inline Quantity AUTO pow(const Q& q) noexcept
   requires requires { std::pow(q.count(), N); }
 {
-  using dim = dimension_pow<D, N>;
-  using ratio = ratio_pow<typename U::ratio, N>;
+  using dim = dimension_pow<typename Q::dimension, N>;
+  using ratio = ratio_pow<typename Q::unit::ratio, N>;
   using unit = downcast_unit<dim, ratio>;
-  return quantity<dim, unit, Rep>(static_cast<Rep>(std::pow(q.count(), N)));
+  using rep = Q::rep;
+  return quantity<dim, unit, rep>(static_cast<rep>(std::pow(q.count(), N)));
 }
 
 /**
@@ -54,9 +55,9 @@ inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
  * 
  * @return Rep A scalar value of @c 1. 
  */
-template<std::intmax_t N, typename D, typename U, typename Rep>
+template<std::intmax_t N, Quantity Q>
   requires(N == 0)
-inline Rep pow(const quantity<D, U, Rep>&) noexcept
+inline typename Q::rep pow(const Q&) noexcept
 {
   return 1;
 }
@@ -69,14 +70,15 @@ inline Rep pow(const quantity<D, U, Rep>&) noexcept
  * @param q Quantity being the base of the operation
  * @return Quantity The result of computation 
  */
-template<typename D, typename U, typename Rep>
-inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
+template<Quantity Q>
+inline Quantity AUTO sqrt(const Q& q) noexcept
   requires requires { std::sqrt(q.count()); }
 {
-  using dim = dimension_sqrt<D>;
-  using ratio = ratio_sqrt<typename U::ratio>;
+  using dim = dimension_sqrt<typename Q::dimension>;
+  using ratio = ratio_sqrt<typename Q::unit::ratio>;
   using unit = downcast_unit<dim, ratio>;
-  return quantity<dim, unit, Rep>(static_cast<Rep>(std::sqrt(q.count())));
+  using rep = Q::rep;
+  return quantity<dim, unit,rep>(static_cast<rep>(std::sqrt(q.count())));
 }
 
 /**
@@ -85,11 +87,11 @@ inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
  * @param q Quantity being the base of the operation
  * @return Quantity The absolute value of a provided quantity
  */
-template<typename D, typename U, typename Rep>
-constexpr Quantity AUTO abs(const quantity<D, U, Rep>& q) noexcept
+template<Quantity Q>
+constexpr Quantity AUTO abs(const Q& q) noexcept
   requires requires { std::abs(q.count()); }
 {
-  return quantity<D, U, Rep>(std::abs(q.count()));
+  return Q(std::abs(q.count()));
 }
 
 /**

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -48,6 +48,158 @@ concept safe_divisible = // exposition only
     treat_as_floating_point<Rep> ||
     ratio_divide<typename UnitFrom::ratio, typename UnitTo::ratio>::is_integral();
 
+//  constrain operators to mpusz::units::quantity only
+template<typename T>
+concept ll_quantity_concept = detail::is_quantity<T>;
+
+// base class for quantity
+// no increase in size of derived object , see https://en.cppreference.com/w/cpp/language/ebo
+struct quantity_friend_operations{
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator+(const Lhs& lhs, const Rhs& rhs)
+     requires 
+            equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
+            std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() + rhs.count());
+     using ret = common_quantity<Lhs, Rhs, common_rep>;
+     return ret(ret(lhs).count() + ret(rhs).count());
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend  constexpr Quantity AUTO operator-(const Lhs& lhs, const Rhs& rhs)
+     requires 
+            equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
+            std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() + rhs.count());
+     using ret = common_quantity<Lhs, Rhs, common_rep>;
+     return ret(ret(lhs).count() - ret(rhs).count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Q& q, const Value& v)
+     requires std::regular_invocable<std::multiplies<>, typename Q::rep, Value>
+   {
+     using common_rep = decltype(q.count() * v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() * v);
+   }
+
+   template<Scalar Value, ll_quantity_concept Q>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Value& v, const Q& q)
+     requires std::regular_invocable<std::multiplies<>, Value, typename Q::rep>
+   {
+     return q * v;
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Scalar AUTO operator*(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep> &&
+              equivalent_dim<typename Lhs::dimension, dim_invert<typename Rhs::dimension>>
+   {
+     using common_rep = decltype(lhs.count() * rhs.count());
+     using ratio = ratio_multiply<typename Lhs::unit::ratio, typename Rhs::unit::ratio>;
+     if constexpr (treat_as_floating_point<common_rep>) {
+       return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * fpow10(ratio::exp) / common_rep(ratio::den);
+     } else {
+       return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * ipow10(ratio::exp) / common_rep(ratio::den);
+     }
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using dim = dimension_multiply<typename Lhs::dimension, typename Rhs::dimension>;
+     using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
+     using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
+     using ratio = ratio_multiply<ratio_multiply<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
+     using unit = downcast_unit<dim, ratio>;
+     using common_rep = decltype(lhs.count() * rhs.count());
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(lhs.count() * rhs.count());
+   }
+
+   template<Scalar Value, ll_quantity_concept Q>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Value& v, const Q& q)
+     requires std::regular_invocable<std::divides<>, Value, typename Q::rep>
+   {
+     Expects(q.count() != 0);
+
+     using dim = dim_invert<typename Q::dimension>;
+     using ratio = ratio<Q::unit::ratio::den, Q::unit::ratio::num, -Q::unit::ratio::exp>;
+     using unit = downcast_unit<dim, ratio>;
+     using common_rep = decltype(v / q.count());
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(v / q.count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Q& q, const Value& v)
+     requires std::regular_invocable<std::divides<>, typename Q::rep, Value>
+   {
+     Expects(v != Value{0});
+
+     using common_rep = decltype(q.count() / v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() / v);
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Scalar AUTO operator/(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep> &&
+              equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>
+   {
+     Expects(rhs.count() != 0);
+
+     using common_rep = decltype(lhs.count() / rhs.count());
+     using cq = common_quantity<Lhs,Rhs, common_rep>;
+     return cq(lhs).count() / cq(rhs).count();
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     Expects(rhs.count() != 0);
+
+     using common_rep = decltype(lhs.count() / rhs.count());
+     using dim = dimension_divide<typename Lhs::dimension, typename Rhs::dimension>;
+     using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
+     using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
+     using ratio = ratio_multiply<ratio_divide<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
+     using unit = downcast_unit<dim, ratio>;
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(lhs.count() / rhs.count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator%(const Q& q, const Value& v)
+     requires (!treat_as_floating_point<typename Q::rep>) &&
+              (!treat_as_floating_point<Value>) &&
+              std::regular_invocable<std::modulus<>, typename Q::rep, Value>
+   {
+     using common_rep = decltype(q.count() % v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() % v);
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator%(const Lhs& lhs, const Rhs& rhs)
+     requires (!treat_as_floating_point<typename Lhs::rep>) &&
+              (!treat_as_floating_point<typename Rhs::rep>) &&
+              equivalent_dim<typename Lhs::dimension,typename Rhs::dimension> &&
+              std::regular_invocable<std::modulus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() % rhs.count());
+     using ret = common_quantity<Lhs,Rhs, common_rep>;
+     return ret(ret(lhs).count() % ret(rhs).count());
+   }
+
+};
+
 } // namespace detail
 
 /**
@@ -61,7 +213,7 @@ concept safe_divisible = // exposition only
  * @tparam Rep a type to be used to represent values of a quantity
  */
 template<Dimension D, UnitOf<D> U, Scalar Rep = double>
-class quantity {
+class quantity : detail::quantity_friend_operations {
   Rep value_{};
 
 public:
@@ -304,155 +456,12 @@ public:
   }
 };
 
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator+(const Lhs& lhs, const Rhs& rhs)
-  requires 
-         equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
-         std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using common_rep = decltype(lhs.count() + rhs.count());
-  using ret = common_quantity<Lhs, Rhs, common_rep>;
-  return ret(ret(lhs).count() + ret(rhs).count());
-}
-
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator-(const Lhs& lhs, const Rhs& rhs)
-  requires 
-         equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
-         std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using common_rep = decltype(lhs.count() + rhs.count());
-  using ret = common_quantity<Lhs, Rhs, common_rep>;
-  return ret(ret(lhs).count() - ret(rhs).count());
-}
-
-template<Quantity Q, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Q& q, const Value& v)
-  requires std::regular_invocable<std::multiplies<>, typename Q::rep, Value>
-{
-  using common_rep = decltype(q.count() * v);
-  using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
-  return ret(q.count() * v);
-}
-
-template<Scalar Value, Quantity Q>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const Q& q)
-  requires std::regular_invocable<std::multiplies<>, Value, typename Q::rep>
-{
-  return q * v;
-}
-
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Scalar AUTO operator*(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep> &&
-           equivalent_dim<typename Lhs::dimension, dim_invert<typename Rhs::dimension>>
-{
-  using common_rep = decltype(lhs.count() * rhs.count());
-  using ratio = ratio_multiply<typename Lhs::unit::ratio, typename Rhs::unit::ratio>;
-  if constexpr (treat_as_floating_point<common_rep>) {
-    return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * fpow10(ratio::exp) / common_rep(ratio::den);
-  } else {
-    return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * ipow10(ratio::exp) / common_rep(ratio::den);
-  }
-}
-
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using dim = dimension_multiply<typename Lhs::dimension, typename Rhs::dimension>;
-  using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
-  using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
-  using ratio = ratio_multiply<ratio_multiply<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
-  using unit = downcast_unit<dim, ratio>;
-  using common_rep = decltype(lhs.count() * rhs.count());
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(lhs.count() * rhs.count());
-}
-
-template<Scalar Value, Quantity Q>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Value& v, const Q& q)
-  requires std::regular_invocable<std::divides<>, Value, typename Q::rep>
-{
-  Expects(q.count() != 0);
-
-  using dim = dim_invert<typename Q::dimension>;
-  using ratio = ratio<Q::unit::ratio::den, Q::unit::ratio::num, -Q::unit::ratio::exp>;
-  using unit = downcast_unit<dim, ratio>;
-  using common_rep = decltype(v / q.count());
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(v / q.count());
-}
-
-template<Quantity Q, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Q& q, const Value& v)
-  requires std::regular_invocable<std::divides<>, typename Q::rep, Value>
-{
-  Expects(v != Value{0});
-
-  using common_rep = decltype(q.count() / v);
-  using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
-  return ret(q.count() / v);
-}
-
-template<Quantity Lhs , Quantity Rhs>
-[[nodiscard]] constexpr Scalar AUTO operator/(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep> &&
-           equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>
-{
-  Expects(rhs.count() != 0);
-
-  using common_rep = decltype(lhs.count() / rhs.count());
-  using cq = common_quantity<Lhs,Rhs, common_rep>;
-  return cq(lhs).count() / cq(rhs).count();
-}
-
-template<Quantity Lhs , Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep>
-{
-  Expects(rhs.count() != 0);
-
-  using common_rep = decltype(lhs.count() / rhs.count());
-  using dim = dimension_divide<typename Lhs::dimension, typename Rhs::dimension>;
-  using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
-  using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
-  using ratio = ratio_multiply<ratio_divide<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
-  using unit = downcast_unit<dim, ratio>;
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(lhs.count() / rhs.count());
-}
-
-template<Quantity Q, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator%(const Q& q, const Value& v)
-  requires (!treat_as_floating_point<typename Q::rep>) &&
-           (!treat_as_floating_point<Value>) &&
-           std::regular_invocable<std::modulus<>, typename Q::rep, Value>
-{
-  using common_rep = decltype(q.count() % v);
-  using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
-  return ret(q.count() % v);
-}
-
-template<Quantity Lhs , Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator%(const Lhs& lhs, const Rhs& rhs)
-  requires (!treat_as_floating_point<typename Lhs::rep>) &&
-           (!treat_as_floating_point<typename Rhs::rep>) &&
-           equivalent_dim<typename Lhs::dimension,typename Rhs::dimension> &&
-           std::regular_invocable<std::modulus<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using common_rep = decltype(lhs.count() % rhs.count());
-  using ret = common_quantity<Lhs,Rhs, common_rep>;
-  return ret(ret(lhs).count() % ret(rhs).count());
-}
-
 namespace detail {
 
 template<typename D, typename U, typename Rep>
 inline constexpr bool is_quantity<quantity<D, U, Rep>> = true;
 
 }  // namespace detail
-
 
 
 }  // namespace units

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -32,6 +32,7 @@
 #include <compare>
 #endif
 
+#include <type_traits>
 #include <ostream>
 
 namespace units {
@@ -48,9 +49,10 @@ concept safe_divisible = // exposition only
     treat_as_floating_point<Rep> ||
     ratio_divide<typename UnitFrom::ratio, typename UnitTo::ratio>::is_integral();
 
+struct quantity_friend_operations;
 //  constrain operators to mpusz::units::quantity only
 template<typename T>
-concept ll_quantity_concept = detail::is_quantity<T>;
+concept ll_quantity_concept = std::is_base_of_v<quantity_friend_operations,T>;
 
 // base class for quantity
 // no increase in size of derived object , see https://en.cppreference.com/w/cpp/language/ebo


### PR DESCRIPTION
Use Concept names rather than class-template names for units::Quantity operator function signatures.
- The resulting function signature is shorter and easier to read and understand.
- The functions are not restricted to quantity<...> type, but can be reused by other models of Quantity.