### PR TITLE
Adding basedims to international

### DIFF
--- a/example/alternative_namespaces/clcpp_response.cpp
+++ b/example/alternative_namespaces/clcpp_response.cpp
@@ -24,8 +24,9 @@
 #include "./area.h"
 #include "./units_str.h"
 
+
 using namespace units::physical::si::literals;
-using namespace units::physical::international;
+using namespace units::physical::international::literals;
 using namespace units::experimental;
 
 void simple_quantities()

--- a/example/alternative_namespaces/clcpp_response.cpp
+++ b/example/alternative_namespaces/clcpp_response.cpp
@@ -24,7 +24,6 @@
 #include "./area.h"
 #include "./units_str.h"
 
-
 using namespace units::physical::si::literals;
 using namespace units::physical::international::literals;
 using namespace units::experimental;

--- a/example/clcpp_response.cpp
+++ b/example/clcpp_response.cpp
@@ -15,7 +15,6 @@
  along with this program. If not, see http://www.gnu.org/licenses./
 */
 
-
 #include <units/physical/iau/length.h>
 #include <units/physical/imperial/length.h>
 #include <units/physical/international/length.h>

--- a/example/clcpp_response.cpp
+++ b/example/clcpp_response.cpp
@@ -15,6 +15,7 @@
  along with this program. If not, see http://www.gnu.org/licenses./
 */
 
+
 #include <units/physical/iau/length.h>
 #include <units/physical/imperial/length.h>
 #include <units/physical/international/length.h>
@@ -35,6 +36,7 @@ void simple_quantities()
 {
   using namespace units::physical::si;
   using namespace units::physical::international;
+  using units::physical::si::length;
 
   using distance = length<metre>;
   using duration = physical::si::time<second>;
@@ -60,6 +62,7 @@ void quantities_with_typed_units()
   using namespace units::physical;
   using namespace units::physical::si;
   using namespace units::physical::international;
+  using units::physical::si::length;
 
   constexpr length<kilometre> km = 1.0q_km;
   constexpr length<mile> miles = 1.0q_mi;

--- a/src/include/units/physical/international/acceleration.h
+++ b/src/include/units/physical/international/acceleration.h
@@ -23,33 +23,24 @@
 #pragma once
 
 #include <units/physical/dimensions.h>
-#include <units/physical/international/length.h>
-#include <units/physical/international/time.h>
+#include <units/physical/international/speed.h>
 #include <units/quantity.h>
 
 namespace units::physical::international {
 
-struct foot_per_second : unit<foot_per_second> {};
+struct foot_per_second_sq : unit<foot_per_second_sq> {};
 
-struct dim_speed : physical::dim_speed<dim_speed, foot_per_second, dim_length, dim_time> {};
+struct dim_acceleration : physical::dim_acceleration<dim_acceleration, foot_per_second_sq, dim_length, dim_time> {};
 
 template<Unit U, Scalar Rep = double>
-using speed = quantity<dim_speed, U, Rep>;
-
-struct mile_per_hour : deduced_unit<mile_per_hour, dim_speed, international::mile, si::hour> {};
-
+using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {
 
-// mph
-constexpr auto operator"" q_mi_per_h(unsigned long long l) { return speed<mile_per_hour, std::int64_t>(l); }
-constexpr auto operator"" q_mi_per_h(long double l) { return speed<mile_per_hour, long double>(l); }
-
-// fps
-constexpr auto operator"" q_ft_per_s(unsigned long long l) { return speed<foot_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_per_s(long double l) { return speed<foot_per_second, long double>(l); }
-
+// Gal
+constexpr auto operator"" q_ft_per_s2(unsigned long long l) { return acceleration<foot_per_second_sq, std::int64_t>(l); }
+constexpr auto operator"" q_ft_per_s2(long double l) { return acceleration<foot_per_second_sq, long double>(l); }
 
 }  // namespace literals
 
-}  // namespace units::physical::international
+}  // namespace units::physical::cgs

--- a/src/include/units/physical/international/area.h
+++ b/src/include/units/physical/international/area.h
@@ -22,18 +22,23 @@
 
 #pragma once
 
-#include <units/physical/si/area.h>
 #include <units/physical/international/length.h>
 
 namespace units::physical::international {
 
-struct square_foot : deduced_unit<square_foot, si::dim_area, international::foot> {};
+struct square_foot : unit<square_foot> {};
+
+struct dim_area : physical::dim_area<dim_area, square_foot, dim_length> {};
+
+template<Unit U, Scalar Rep = double>
+using area = quantity<dim_area, U, Rep>;
+
 
 inline namespace literals {
 
 // ft2
-constexpr auto operator"" q_ft2(unsigned long long l) { return si::area<square_foot, std::int64_t>(l); }
-constexpr auto operator"" q_ft2(long double l) { return si::area<square_foot, long double>(l); }
+constexpr auto operator"" q_ft2(unsigned long long l) { return area<square_foot, std::int64_t>(l); }
+constexpr auto operator"" q_ft2(long double l) { return area<square_foot, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/international/force.h
+++ b/src/include/units/physical/international/force.h
@@ -23,32 +23,25 @@
 #pragma once
 
 #include <units/physical/dimensions.h>
-#include <units/physical/international/length.h>
-#include <units/physical/international/time.h>
+#include <units/physical/international/acceleration.h>
+#include <units/physical/international/mass.h>
+#include <units/physical/si/prefixes.h>
 #include <units/quantity.h>
 
 namespace units::physical::international {
 
-struct foot_per_second : unit<foot_per_second> {};
+struct poundforce : named_unit<poundforce, "lbf", si::prefix> {};
 
-struct dim_speed : physical::dim_speed<dim_speed, foot_per_second, dim_length, dim_time> {};
+struct dim_force : physical::dim_force<dim_force, poundforce, dim_mass, dim_acceleration> {};
 
 template<Unit U, Scalar Rep = double>
-using speed = quantity<dim_speed, U, Rep>;
-
-struct mile_per_hour : deduced_unit<mile_per_hour, dim_speed, international::mile, si::hour> {};
-
+using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {
 
-// mph
-constexpr auto operator"" q_mi_per_h(unsigned long long l) { return speed<mile_per_hour, std::int64_t>(l); }
-constexpr auto operator"" q_mi_per_h(long double l) { return speed<mile_per_hour, long double>(l); }
-
-// fps
-constexpr auto operator"" q_ft_per_s(unsigned long long l) { return speed<foot_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_per_s(long double l) { return speed<foot_per_second, long double>(l); }
-
+// dyn
+constexpr auto operator"" q_lbf(unsigned long long l) { return force<poundforce, std::int64_t>(l); }
+constexpr auto operator"" q_lbf(long double l) { return force<poundforce, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/international/length.h
+++ b/src/include/units/physical/international/length.h
@@ -58,39 +58,45 @@ struct thou : named_scaled_unit<thou, "thou", no_prefix, ratio<1, 1000>, inch> {
 // https://en.wikipedia.org/wiki/Thousandth_of_an_inch
 using mil = thou;
 
+struct dim_length : physical::dim_length<foot> {};
+
+template<Unit U, Scalar Rep = double>
+using length = quantity<dim_length, U, Rep>;
+
+
 inline namespace literals {
 
 // yd
-constexpr auto operator"" q_yd(unsigned long long l) { return si::length<yard, std::int64_t>(l); }
-constexpr auto operator"" q_yd(long double l) { return si::length<yard, long double>(l); }
+constexpr auto operator"" q_yd(unsigned long long l) { return length<yard, std::int64_t>(l); }
+constexpr auto operator"" q_yd(long double l) { return length<yard, long double>(l); }
 
 // ft
-constexpr auto operator"" q_ft(unsigned long long l) { return si::length<foot, std::int64_t>(l); }
-constexpr auto operator"" q_ft(long double l) { return si::length<foot, long double>(l); }
+constexpr auto operator"" q_ft(unsigned long long l) { return length<foot, std::int64_t>(l); }
+constexpr auto operator"" q_ft(long double l) { return length<foot, long double>(l); }
 
 // fathom
-constexpr auto operator"" q_fathom(unsigned long long l) { return si::length<fathom, std::int64_t>(l); }
-constexpr auto operator"" q_fathom(long double l) { return si::length<fathom, long double>(l); }
+constexpr auto operator"" q_fathom(unsigned long long l) { return length<fathom, std::int64_t>(l); }
+constexpr auto operator"" q_fathom(long double l) { return length<fathom, long double>(l); }
 
 // in
-constexpr auto operator"" q_in(unsigned long long l) { return si::length<inch, std::int64_t>(l); }
-constexpr auto operator"" q_in(long double l) { return si::length<inch, long double>(l); }
+constexpr auto operator"" q_in(unsigned long long l) { return length<inch, std::int64_t>(l); }
+constexpr auto operator"" q_in(long double l) { return length<inch, long double>(l); }
 
 // mi
-constexpr auto operator"" q_mi(unsigned long long l) { return si::length<mile, std::int64_t>(l); }
-constexpr auto operator"" q_mi(long double l) { return si::length<mile, long double>(l); }
+constexpr auto operator"" q_mi(unsigned long long l) { return length<mile, std::int64_t>(l); }
+constexpr auto operator"" q_mi(long double l) { return length<mile, long double>(l); }
 
 // mi_naut
-constexpr auto operator"" q_naut_mi(unsigned long long l) { return si::length<nautical_mile, std::int64_t>(l); }
-constexpr auto operator"" q_naut_mi(long double l) { return si::length<nautical_mile, long double>(l); }
+constexpr auto operator"" q_naut_mi(unsigned long long l) { return length<nautical_mile, std::int64_t>(l); }
+constexpr auto operator"" q_naut_mi(long double l) { return length<nautical_mile, long double>(l); }
 
 // thou
-constexpr auto operator"" q_thou(unsigned long long l) { return si::length<thou, std::int64_t>(l); }
-constexpr auto operator"" q_thou(long double l) { return si::length<thou, long double>(l); }
+constexpr auto operator"" q_thou(unsigned long long l) { return length<thou, std::int64_t>(l); }
+constexpr auto operator"" q_thou(long double l) { return length<thou, long double>(l); }
 
 // mil
-constexpr auto operator"" q_mil(unsigned long long l) { return si::length<mil, std::int64_t>(l); }
-constexpr auto operator"" q_mil(long double l) { return si::length<mil, long double>(l); }
+constexpr auto operator"" q_mil(unsigned long long l) { return length<mil, std::int64_t>(l); }
+constexpr auto operator"" q_mil(long double l) { return length<mil, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/international/mass.h
+++ b/src/include/units/physical/international/mass.h
@@ -23,33 +23,25 @@
 #pragma once
 
 #include <units/physical/dimensions.h>
-#include <units/physical/international/length.h>
-#include <units/physical/international/time.h>
+#include <units/physical/si/mass.h>
 #include <units/quantity.h>
 
-namespace units::physical::international {
+namespace units::physical::cgs {
 
-struct foot_per_second : unit<foot_per_second> {};
+struct pound : named_scaled_unit<pound, "lb", no_prefix, ratio<456'359'237, 1'000'000'000>, si::kilogram> {};
 
-struct dim_speed : physical::dim_speed<dim_speed, foot_per_second, dim_length, dim_time> {};
+
+struct dim_mass : physical::dim_mass<pound> {};
 
 template<Unit U, Scalar Rep = double>
-using speed = quantity<dim_speed, U, Rep>;
-
-struct mile_per_hour : deduced_unit<mile_per_hour, dim_speed, international::mile, si::hour> {};
-
+using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {
 
-// mph
-constexpr auto operator"" q_mi_per_h(unsigned long long l) { return speed<mile_per_hour, std::int64_t>(l); }
-constexpr auto operator"" q_mi_per_h(long double l) { return speed<mile_per_hour, long double>(l); }
+// g
+constexpr auto operator"" q_lb(unsigned long long l) { return mass<pound, std::int64_t>(l); }
+constexpr auto operator"" q_lb(long double l) { return mass<pound, long double>(l); }
 
-// fps
-constexpr auto operator"" q_ft_per_s(unsigned long long l) { return speed<foot_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_per_s(long double l) { return speed<foot_per_second, long double>(l); }
+}
 
-
-}  // namespace literals
-
-}  // namespace units::physical::international
+}  // namespace units::physical::cgs

--- a/src/include/units/physical/international/pressure.h
+++ b/src/include/units/physical/international/pressure.h
@@ -23,32 +23,25 @@
 #pragma once
 
 #include <units/physical/dimensions.h>
-#include <units/physical/international/length.h>
-#include <units/physical/international/time.h>
+#include <units/physical/international/area.h>
+#include <units/physical/international/force.h>
+#include <units/physical/si/prefixes.h>
 #include <units/quantity.h>
 
 namespace units::physical::international {
 
-struct foot_per_second : unit<foot_per_second> {};
+struct poundforce_per_square_inch : named_unit<poundforce_per_square_inch, "psi", si::prefix> {};
 
-struct dim_speed : physical::dim_speed<dim_speed, foot_per_second, dim_length, dim_time> {};
+struct dim_pressure : physical::dim_pressure<dim_pressure, poundforce_per_square_inch, dim_force, dim_area> {};
 
 template<Unit U, Scalar Rep = double>
-using speed = quantity<dim_speed, U, Rep>;
-
-struct mile_per_hour : deduced_unit<mile_per_hour, dim_speed, international::mile, si::hour> {};
-
+using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {
 
-// mph
-constexpr auto operator"" q_mi_per_h(unsigned long long l) { return speed<mile_per_hour, std::int64_t>(l); }
-constexpr auto operator"" q_mi_per_h(long double l) { return speed<mile_per_hour, long double>(l); }
-
-// fps
-constexpr auto operator"" q_ft_per_s(unsigned long long l) { return speed<foot_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_per_s(long double l) { return speed<foot_per_second, long double>(l); }
-
+// Ba
+constexpr auto operator"" q_psi(unsigned long long l) { return pressure<poundforce_per_square_inch, std::int64_t>(l); }
+constexpr auto operator"" q_psi(long double l) { return pressure<poundforce_per_square_inch, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/international/time.h
+++ b/src/include/units/physical/international/time.h
@@ -23,33 +23,20 @@
 #pragma once
 
 #include <units/physical/dimensions.h>
-#include <units/physical/international/length.h>
-#include <units/physical/international/time.h>
+#include <units/physical/si/time.h>
 #include <units/quantity.h>
 
 namespace units::physical::international {
 
-struct foot_per_second : unit<foot_per_second> {};
+using si::second;
 
-struct dim_speed : physical::dim_speed<dim_speed, foot_per_second, dim_length, dim_time> {};
-
-template<Unit U, Scalar Rep = double>
-using speed = quantity<dim_speed, U, Rep>;
-
-struct mile_per_hour : deduced_unit<mile_per_hour, dim_speed, international::mile, si::hour> {};
-
+using si::dim_time;
+using si::time;
 
 inline namespace literals {
 
-// mph
-constexpr auto operator"" q_mi_per_h(unsigned long long l) { return speed<mile_per_hour, std::int64_t>(l); }
-constexpr auto operator"" q_mi_per_h(long double l) { return speed<mile_per_hour, long double>(l); }
+using si::literals::operator"" q_s;
 
-// fps
-constexpr auto operator"" q_ft_per_s(unsigned long long l) { return speed<foot_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_per_s(long double l) { return speed<foot_per_second, long double>(l); }
-
-
-}  // namespace literals
+}
 
 }  // namespace units::physical::international


### PR DESCRIPTION
Added dim_length, dim_time, dim_mass and related dims in the international system to create derived quantities.

Is this the right approach to create things like pressure in psi, or is it better to define psi in terms of a named_scaled_unit with a ratio and si::Pa?

Note that this breaks some tests, but if its the right approach then the tests need updating:
1) runtime/fmt_units_test - 1 mile ^3 now given in cubic feet, not cubic metres
2) static/math_test  is_same_v<decltype(pow<2>(2q_ft)), decltype(4q_ft2)> - the pow<2> returns 4q_ft2 in si, not imperial
1) is easy for me to correct, 2) I've not looked at
