### PR TITLE
quantity: add definite constraint on q* "scalar" fixes https://github…

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - **0.6.0 WIP**
   - linear_algebra updated to 0.7.0/testing
+  - Added angle as SI base dimension (thanks [@kwikius](https://github.com/kwikius))
+  - Added STL random number distribution wrappers (thanks [@yasamoka](https://github.com/yasamoka))
+  - `math.h` function signatures refactored to use a `Quantity` concept (thanks [@kwikius](https://github.com/kwikius))
 
 - **0.5.0 May 17, 2020**
   - Major refactoring and rewrite of the library

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -36,6 +36,7 @@ add_example(clcpp_response)
 add_example(conversion_factor)
 add_example(kalman_filter-alpha_beta_filter_example2)
 add_example(experimental_angle)
+add_example(quantity_ratio)
 
 conan_check_testing(linear_algebra)
 add_example(linear_algebra)

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -211,9 +211,9 @@ void quantity_of_vector_add()
 {
   std::cout << "\nquantity_of_vector_add:\n";
 
-  length_v<> v(vector<>{ 1, 2, 3 });
-  length_v<> u(vector<>{ 3, 2, 1 });
-  length_v<si::kilometre> t(vector<>{ 3, 2, 1 });
+  length_v<> v(vector<>{ 1.0, 2.0, 3.0 });
+  length_v<> u(vector<>{ 3.0, 2.0, 1.0 });
+  length_v<si::kilometre> t(vector<>{ 3.0, 2.0, 1.0 });
 
   std::cout << "v = " << v << "\n";
   std::cout << "u = " << u << "\n";

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -266,7 +266,6 @@ void quantity_of_vector_divide_by_scalar()
   // std::cout << "v / 2 = " << v / 2 << "\n";
 }
 
-#if 0
 void vector_of_double_multiply_quantity()
 {
    std::cout << "\nvector_of_double_multiply_quantity:\n";
@@ -278,7 +277,6 @@ void vector_of_double_multiply_quantity()
 
    std::cout << "q * v = " << vv << '\n';
 }
-#endif
 
 void quantity_of_vector_tests()
 {
@@ -286,7 +284,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_multiply_same();
   quantity_of_vector_multiply_different();
   quantity_of_vector_divide_by_scalar();
- // vector_of_double_multiply_quantity();
+  vector_of_double_multiply_quantity();
 }
 
 template<units::Unit U = si::metre, units::Scalar Rep = double>

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -266,12 +266,25 @@ void quantity_of_vector_divide_by_scalar()
   // std::cout << "v / 2 = " << v / 2 << "\n";
 }
 
+void vector_of_double_multiply_quantity()
+{
+   std::cout << "\nvector_of_double_multiply_quantity:\n";
+   vector<double> v{1.0,2.0,3.0};
+
+   si::length<si::metre> q{10};
+
+   auto vv = q * v ;
+
+   std::cout << "q * v = " << vv << '\n';
+}
+
 void quantity_of_vector_tests()
 {
   quantity_of_vector_add();
   quantity_of_vector_multiply_same();
   quantity_of_vector_multiply_different();
   quantity_of_vector_divide_by_scalar();
+  vector_of_double_multiply_quantity();
 }
 
 template<units::Unit U = si::metre, units::Scalar Rep = double>

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -132,6 +132,23 @@ void vector_of_quantity_tests()
   vector_of_quantity_divide_by_scalar();
 }
 
+void vector_of_double_multiply_quantity()
+{
+   std::cout << "\nvector_of_double_multiply_quantity:\n";
+   vector<double> v{1.0,2.0,3.0};
+
+   si::length<si::metre> q{10};
+
+   auto vv = q * v ;
+
+   std::cout << "q * v = " << vv << '\n';
+}
+
+void vector_of_double_tests()
+{
+  vector_of_double_multiply_quantity();
+}
+
 void matrix_of_quantity_add()
 {
   std::cout << "\nmatrix_of_quantity_add:\n";
@@ -201,11 +218,13 @@ void matrix_of_quantity_tests()
   matrix_of_quantity_divide_by_scalar();
 }
 
+/*
 template<units::Unit U = si::metre, units::Scalar Rep = double>
 using length_v = si::length<U, vector<Rep>>;
 
 template<units::Unit U = si::newton, units::Scalar Rep = double>
 using force_v = si::force<U, vector<Rep>>;
+
 
 void quantity_of_vector_add()
 {
@@ -267,17 +286,7 @@ void quantity_of_vector_divide_by_scalar()
   // std::cout << "v / 2 = " << v / 2 << "\n";
 }
 
-void vector_of_double_multiply_quantity()
-{
-   std::cout << "\nvector_of_double_multiply_quantity:\n";
-   vector<double> v{1.0,2.0,3.0};
 
-   si::length<si::metre> q{10};
-
-   auto vv = q * v ;
-
-   std::cout << "q * v = " << vv << '\n';
-}
 
 void quantity_of_vector_tests()
 {
@@ -285,8 +294,9 @@ void quantity_of_vector_tests()
   quantity_of_vector_multiply_same();
   quantity_of_vector_multiply_different();
   quantity_of_vector_divide_by_scalar();
-  vector_of_double_multiply_quantity();
 }
+
+
 
 template<units::Unit U = si::metre, units::Scalar Rep = double>
 using length_m = si::length<U, matrix<Rep>>;
@@ -360,12 +370,15 @@ void quantity_of_matrix_tests()
   quantity_of_matrix_divide_by_scalar();
 }
 
+*/
+
 }
 
 int main()
 {
   vector_of_quantity_tests();
   matrix_of_quantity_tests();
-  quantity_of_vector_tests();
-  quantity_of_matrix_tests();
+  vector_of_double_tests();
+ // quantity_of_vector_tests();
+ // quantity_of_matrix_tests();
 }

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -211,7 +211,8 @@ void quantity_of_vector_add()
 {
   std::cout << "\nquantity_of_vector_add:\n";
 
-  length_v<> v(vector<>{ 1.0, 2.0, 3.0 });
+  vector<> vrep { 1.0, 2.0, 3.0 };
+  length_v<> v(vrep);
   length_v<> u(vector<>{ 3.0, 2.0, 1.0 });
   length_v<si::kilometre> t(vector<>{ 3.0, 2.0, 1.0 });
 

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -266,6 +266,7 @@ void quantity_of_vector_divide_by_scalar()
   // std::cout << "v / 2 = " << v / 2 << "\n";
 }
 
+#if 0
 void vector_of_double_multiply_quantity()
 {
    std::cout << "\nvector_of_double_multiply_quantity:\n";
@@ -277,6 +278,7 @@ void vector_of_double_multiply_quantity()
 
    std::cout << "q * v = " << vv << '\n';
 }
+#endif
 
 void quantity_of_vector_tests()
 {
@@ -284,7 +286,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_multiply_same();
   quantity_of_vector_multiply_different();
   quantity_of_vector_divide_by_scalar();
-  vector_of_double_multiply_quantity();
+ // vector_of_double_multiply_quantity();
 }
 
 template<units::Unit U = si::metre, units::Scalar Rep = double>

--- a/example/quantity_ratio.cpp
+++ b/example/quantity_ratio.cpp
@@ -1,0 +1,70 @@
+
+
+#include <units/quantity.h>
+
+#include <iostream>
+
+#include <units/physical/dimensions.h>
+#include <units/physical/si/prefixes.h>
+#include <units/quantity.h>
+
+/**
+*  In some case a constant times a dimensionless ratio of 2 quantities is required
+*  // https://www.sciencedirect.com/topics/engineering/standing-correlation
+*  The class provides a means of output the ratio and to get at the underlying numeric value of the constant
+*/
+
+template <units::Quantity Num, units::Quantity Den>
+requires units::DimensionlessQuantity<decltype( Num{}/ Den{})>
+struct quantity_ratio{
+   using rep = std::common_type_t<float,typename Num::rep,typename Den::rep>;
+   constexpr quantity_ratio( const rep & v)
+   : m_value{v}{};
+   // convert it to a number
+   constexpr rep numeric_value ()const
+   {
+      return (m_value * Num::one()) / Den::one();
+   }
+ private:
+   friend std::ostream& operator << (std::ostream & os,quantity_ratio const & r)
+   {
+      // get at the units text of the quantity, without its numeric value
+      auto unit_str = [] (const units::Quantity AUTO& q)
+      {
+        typedef std::remove_cvref_t<decltype(q)> qtype;
+        return units::detail::unit_text<typename qtype::dimension, typename qtype::unit>().standard();
+      };
+      return os <<  r.m_value << ' ' << unit_str(Num{}) << '/' << unit_str(Den{})  ;
+   }
+   rep m_value;
+};
+
+//-----------------------
+
+#include <units/physical/si/volume.h>
+#include <units/physical/international/volume.h>
+
+namespace {
+
+using namespace units::physical;
+using namespace units::physical::si::literals;
+using namespace units::physical::international::literals;
+
+}
+
+// https://www.sciencedirect.com/topics/engineering/standing-correlation
+
+int main()
+{
+    // using decltype on the quantity constants is a lazy way to get the definitions
+    using CF_STB_ratio = quantity_ratio<decltype(0q_ft3),decltype(0q_stb)> ;
+
+    constexpr CF_STB_ratio Rs = 456;
+
+    std::cout << "Rs = " << Rs <<'\n'; 
+
+    constexpr auto v = Rs.numeric_value();
+
+    std::cout << "Rs numeric value = " << v << '\n'; 
+
+}

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -65,7 +65,15 @@ using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 
 }  // namespace units
 
+#if COMP_GCC >= 10
+
 namespace std {
+
+#else
+
+namespace concepts {
+
+#endif
 
 template<units::Quantity Q1, units::Quantity Q2>
   requires units::equivalent_dim<typename Q1::dimension, typename Q2::dimension>

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -64,3 +64,13 @@ template<Quantity Q1, Quantity Q2, Scalar Rep = std::common_type_t<typename Q1::
 using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 
 }  // namespace units
+
+namespace std {
+
+template<units::Quantity Q1, units::Quantity Q2>
+  requires units::equivalent_dim<typename Q1::dimension, typename Q2::dimension>
+struct common_type<Q1, Q2> {
+  using type = units::common_quantity<Q1, Q2>;
+};
+
+}

--- a/src/include/units/bits/external/hacks.h
+++ b/src/include/units/bits/external/hacks.h
@@ -76,6 +76,7 @@ namespace std {
   using concepts::convertible_to;
   using concepts::default_constructible;
   using concepts::derived_from;
+  using concepts::equality_comparable;
   using concepts::equality_comparable_with;
   // using concepts::floating_point;
   using concepts::integral;

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -294,8 +294,7 @@ concept Scalar =
 
 namespace detail{
 
-#if __GNUC__ >= 10
-
+#if 0
   // by default identify DimensionlessQuantity structurally but
   // allow customisation, since there are some cases which
   // dont conform to this definition.

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -294,8 +294,7 @@ concept Scalar =
 
 namespace detail{
 
-//#if __GNUC__ >= 10
-#if 0
+#if __GNUC__ >= 10
 
   // by default identify DimensionlessQuantity structurally but
   // allow customisation, since there are some cases which

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -294,16 +294,30 @@ concept Scalar =
 
 namespace detail{
 
-  template <typename T>
-  inline constexpr bool is_dimensionless_quantity = false;
+#if __GNUC__ >= 10
 
-  //The built in arithmetic types are dimensionless
+  // by default identify DimensionlessQuantity structurally but
+  // allow customisation, since there are some cases which
+  // dont conform to this definition.
+  template <typename T>
+  inline constexpr bool is_dimensionless_quantity = requires(T a, T b) {
+    { a * b } -> std::same_as<T>;
+  };
+#else
+  // structural version blows up in gcc9
+  // by default exclude everything
+  template <typename T>
+  inline constexpr bool is_dimensionless_quantity =  false;
+
+  // customise dimensionless by hand
+  // The built in arithmetic types are dimensionless
   template <Arithmetic T>
   inline constexpr bool is_dimensionless_quantity<T> = true;
+#endif
+
 }
 
 template <typename T>
 concept DimensionlessQuantity = detail::is_dimensionless_quantity<T>;
-
 
 }  // namespace units

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -289,4 +289,21 @@ concept Scalar =
   std::regular<T> &&
   (detail::constructible_from_integral<T> || detail::not_constructible_from_integral<T>);
 
+ template <typename T> 
+ concept Arithmetic = std::is_arithmetic_v<T>;
+
+namespace detail{
+
+  template <typename T>
+  inline constexpr bool is_dimensionless_quantity = false;
+
+  //The built in arithmetic types are dimensionless
+  template <Arithmetic T>
+  inline constexpr bool is_dimensionless_quantity<T> = true;
+}
+
+template <typename T>
+concept DimensionlessQuantity = detail::is_dimensionless_quantity<T>;
+
+
 }  // namespace units

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -294,7 +294,8 @@ concept Scalar =
 
 namespace detail{
 
-#if __GNUC__ >= 10
+//#if __GNUC__ >= 10
+#if 0
 
   // by default identify DimensionlessQuantity structurally but
   // allow customisation, since there are some cases which

--- a/src/include/units/math.h
+++ b/src/include/units/math.h
@@ -38,15 +38,16 @@ namespace units {
  * @param q Quantity being the base of the operation
  * @return Quantity The result of computation 
  */
-template<std::intmax_t N, typename D, typename U, typename Rep>
+template<std::intmax_t N, Quantity Q>
   requires(N != 0)
-inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
+inline Quantity AUTO pow(const Q& q) noexcept
   requires requires { std::pow(q.count(), N); }
 {
-  using dim = dimension_pow<D, N>;
-  using ratio = ratio_pow<typename U::ratio, N>;
+  using dim = dimension_pow<typename Q::dimension, N>;
+  using ratio = ratio_pow<typename Q::unit::ratio, N>;
   using unit = downcast_unit<dim, ratio>;
-  return quantity<dim, unit, Rep>(static_cast<Rep>(std::pow(q.count(), N)));
+  using rep = Q::rep;
+  return quantity<dim, unit, rep>(static_cast<rep>(std::pow(q.count(), N)));
 }
 
 /**
@@ -54,9 +55,9 @@ inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
  * 
  * @return Rep A scalar value of @c 1. 
  */
-template<std::intmax_t N, typename D, typename U, typename Rep>
+template<std::intmax_t N, Quantity Q>
   requires(N == 0)
-inline Rep pow(const quantity<D, U, Rep>&) noexcept
+inline Q::rep pow(const Q&) noexcept
 {
   return 1;
 }
@@ -69,14 +70,15 @@ inline Rep pow(const quantity<D, U, Rep>&) noexcept
  * @param q Quantity being the base of the operation
  * @return Quantity The result of computation 
  */
-template<typename D, typename U, typename Rep>
-inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
+template<Quantity Q>
+inline Quantity AUTO sqrt(const Q& q) noexcept
   requires requires { std::sqrt(q.count()); }
 {
-  using dim = dimension_sqrt<D>;
-  using ratio = ratio_sqrt<typename U::ratio>;
+  using dim = dimension_sqrt<typename Q::dimension>;
+  using ratio = ratio_sqrt<typename Q::unit::ratio>;
   using unit = downcast_unit<dim, ratio>;
-  return quantity<dim, unit, Rep>(static_cast<Rep>(std::sqrt(q.count())));
+  using rep = Q::rep;
+  return quantity<dim, unit, rep>(static_cast<rep>(std::sqrt(q.count())));
 }
 
 /**
@@ -85,11 +87,11 @@ inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
  * @param q Quantity being the base of the operation
  * @return Quantity The absolute value of a provided quantity
  */
-template<typename D, typename U, typename Rep>
-constexpr Quantity AUTO abs(const quantity<D, U, Rep>& q) noexcept
+template<Quantity Q>
+constexpr Quantity AUTO abs(const Q& q) noexcept
   requires requires { std::abs(q.count()); }
 {
-  return quantity<D, U, Rep>(std::abs(q.count()));
+  return Q(std::abs(q.count()));
 }
 
 /**

--- a/src/include/units/physical/international/volume.h
+++ b/src/include/units/physical/international/volume.h
@@ -29,11 +29,19 @@ namespace units::physical::international {
 
 struct cubic_foot : deduced_unit<cubic_foot, si::dim_volume, international::foot> {};
 
+//barrel
+//https://en.wikipedia.org/wiki/Volume_units_used_in_petroleum_engineering
+struct barrel : named_scaled_unit<barrel,"stb", no_prefix, ratio<1'000'000,6'289'811> , si::cubic_metre> {};
+
 inline namespace literals {
 
 // ft3
 constexpr auto operator"" q_ft3(unsigned long long l) { return si::volume<cubic_foot, std::int64_t>(l); }
 constexpr auto operator"" q_ft3(long double l) { return si::volume<cubic_foot, long double>(l); }
+
+// ft3
+constexpr auto operator"" q_stb(unsigned long long l) { return si::volume<barrel, std::int64_t>(l); }
+constexpr auto operator"" q_stb(long double l) { return si::volume<barrel, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -322,18 +322,18 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
+template<typename D, typename U, typename Rep, DimensionlessQuantity Value>
 [[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::multiplies<>, Rep, Value> && std::is_arithmetic_v<Value>
+  requires std::regular_invocable<std::multiplies<>, Rep, Value> 
 {
   using common_rep = decltype(q.count() * v);
   using ret = quantity<D, U, common_rep>;
   return ret(q.count() * v);
 }
 
-template<Scalar Value, typename D, typename U, typename Rep>
+template<DimensionlessQuantity Value, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::multiplies<>, Value, Rep> && std::is_arithmetic_v<Value>
+  requires std::regular_invocable<std::multiplies<>, Value, Rep>
 {
   return q * v;
 }

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -366,7 +366,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() * rhs.count());
 }
 
-template<Scalar Value, typename D, typename U, typename Rep>
+template<DimensionlessQuantity Value, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator/(const Value& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::divides<>, Value, Rep>
 {
@@ -380,7 +380,7 @@ template<Scalar Value, typename D, typename U, typename Rep>
   return ret(v / q.count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
+template<typename D, typename U, typename Rep, DimensionlessQuantity  Value>
 [[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Value& v)
   requires std::regular_invocable<std::divides<>, Rep, Value>
 {

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -324,7 +324,7 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
 
 template<typename D, typename U, typename Rep, Scalar Value>
 [[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::multiplies<>, Rep, Value>
+  requires std::regular_invocable<std::multiplies<>, Rep, Value> && std::is_arithmetic_v<Value>
 {
   using common_rep = decltype(q.count() * v);
   using ret = quantity<D, U, common_rep>;
@@ -333,7 +333,7 @@ template<typename D, typename U, typename Rep, Scalar Value>
 
 template<Scalar Value, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::multiplies<>, Value, Rep>
+  requires std::regular_invocable<std::multiplies<>, Value, Rep> && std::is_arithmetic_v<Value>
 {
   return q * v;
 }

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -322,7 +322,7 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
+template<typename D, typename U, typename Rep, DimensionlessQuantity Value>
 [[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Value& v)
   requires std::regular_invocable<std::multiplies<>, Rep, Value> 
 {
@@ -331,7 +331,7 @@ template<typename D, typename U, typename Rep, Scalar Value>
   return ret(q.count() * v);
 }
 
-template<Scalar Value, typename D, typename U, typename Rep>
+template<DimensionlessQuantity Value, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::multiplies<>, Value, Rep>
 {

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -322,7 +322,7 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, DimensionlessQuantity Value>
+template<typename D, typename U, typename Rep, Scalar Value>
 [[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Value& v)
   requires std::regular_invocable<std::multiplies<>, Rep, Value> 
 {
@@ -331,7 +331,7 @@ template<typename D, typename U, typename Rep, DimensionlessQuantity Value>
   return ret(q.count() * v);
 }
 
-template<DimensionlessQuantity Value, typename D, typename U, typename Rep>
+template<Scalar Value, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::multiplies<>, Value, Rep>
 {

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -25,6 +25,7 @@
 #include "units/physical/si/frequency.h"
 #include "units/physical/si/speed.h"
 #include "units/physical/si/volume.h"
+#include "units/physical/us/length.h"
 #include <chrono>
 #include <utility>
 
@@ -221,6 +222,15 @@ static_assert(
     std::is_same_v<common_quantity<length<kilometre, long long>, length<metre, int>>, length<metre, long long>>);
 static_assert(std::is_same_v<common_quantity<length<kilometre, long long>, length<millimetre, double>>,
                              length<millimetre, double>>);
+
+// common_type
+
+using namespace units::physical::us::literals;
+
+static_assert(std::equality_comparable<decltype(1q_m)>);
+static_assert(std::equality_comparable_with<decltype(1q_m), decltype(1q_cm)>);
+static_assert(0q_m == 0q_ft_us);
+static_assert(std::equality_comparable_with<decltype(1q_m), decltype(1q_ft_us)>);
 
 // quantity_cast
 


### PR DESCRIPTION
quantity: add definite constraint on q* "scalar" fixes https://github.com/mpusz/units/issues/88.

So the `is_arithmetic` constraint is too strong as is, rather should be a `numeric` concept ( allowing UDT number types as well), but showing that a multiply function needs strong constraints to avaoid ambiguity.
How to decide what to define in your librray?
Generally is the result  in your domain  e.g   quantity * numeric -> quantity. but quantity * vector -> vector so that is the domain of vector. And behold  it works ; -)