### PR TITLE
Foot pound second system

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -36,6 +36,7 @@ add_example(clcpp_response)
 add_example(conversion_factor)
 add_example(kalman_filter-alpha_beta_filter_example2)
 add_example(experimental_angle)
+add_example(foot_pound_second)
 
 conan_check_testing(linear_algebra)
 add_example(linear_algebra)

--- a/example/foot_pound_second.cpp
+++ b/example/foot_pound_second.cpp
@@ -1,0 +1,104 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <units/format.h>
+#include <units/physical/fps/density.h>
+#include <units/physical/fps/length.h>
+#include <units/physical/fps/mass.h>
+#include <units/physical/fps/power.h>
+#include <units/physical/fps/speed.h>
+#include <units/physical/fps/volume.h>
+#include <units/physical/si/length.h>
+#include <units/physical/si/mass.h>
+#include <units/physical/si/power.h>
+#include <units/physical/si/speed.h>
+#include <units/physical/si/volume.h>
+
+#include <units/concepts.h>
+#include <units/quantity.h>
+
+#include <iostream>
+
+using namespace units::physical;
+
+
+// Some basic specs for the warship   
+struct Ship {
+  fps::length<fps::foot> length;
+  fps::length<fps::foot> draft;
+  fps::length<fps::foot> beam;
+
+  fps::speed<fps::foot_per_second> speed;
+  fps::mass<fps::pound> mass;
+
+  fps::length<fps::inch> mainGuns; 
+  fps::mass<fps::pound> shellMass;
+  fps::speed<fps::foot_per_second> shellSpeed;
+  fps::power<fps::foot_poundal_per_second> power;
+
+
+};
+
+// Print 'a' in its current units and print its value cast to the units in each of Args
+template<class ...Args, units::Quantity Q>
+auto fmt_line(const Q a) {
+  return fmt::format("{:22}",a) + (fmt::format(",{:20}", units::quantity_cast<Args>(a)) + ...);
+}
+
+// Print the ship details in the units as defined in the Ship struct, in other imperial units, and in SI
+std::ostream& print_details(std::string_view description, const Ship& ship) {
+  using namespace units::physical::fps::literals;
+  const auto waterDensity = 62.4q_lb_per_ft3;
+  std::cout << fmt::format("{}\n", description);
+  std::cout << fmt::format("{:20} : {}\n", "length",    fmt_line<fps::length<fps::yard>, si::length<si::metre>>(ship.length))
+            << fmt::format("{:20} : {}\n", "draft",     fmt_line<fps::length<fps::yard>, si::length<si::metre>>(ship.draft))
+            << fmt::format("{:20} : {}\n", "beam",      fmt_line<fps::length<fps::yard>, si::length<si::metre>>(ship.beam))
+            << fmt::format("{:20} : {}\n", "mass",      fmt_line<fps::mass<fps::long_ton>, si::mass<si::tonne>>(ship.mass))
+            << fmt::format("{:20} : {}\n", "speed",     fmt_line<fps::speed<fps::knot>, si::speed<si::kilometre_per_hour>>(ship.speed))
+            << fmt::format("{:20} : {}\n", "power",     fmt_line<fps::power<fps::horse_power>, si::power<si::kilowatt>>(ship.power))
+            << fmt::format("{:20} : {}\n", "main guns", fmt_line<fps::length<fps::inch>, si::length<si::millimetre>>(ship.mainGuns))
+            << fmt::format("{:20} : {}\n", "fire shells weighing",fmt_line<fps::mass<fps::long_ton>, si::mass<si::kilogram>>(ship.shellMass))
+            << fmt::format("{:20} : {}\n", "fire shells at",fmt_line<fps::speed<fps::mile_per_hour>, si::speed<si::kilometre_per_hour>>(ship.shellSpeed))
+            << fmt::format("{:20} : {}\n", "volume underwater", fmt_line<si::volume<si::cubic_metre>, si::volume<si::litre>>(ship.mass / waterDensity));
+  return std::cout;
+}
+
+int main()
+{
+  using namespace units::physical::si::literals;
+  using namespace units::physical::fps::literals;
+  
+
+  // KMS Bismark, using the units the Germans would use, taken from Wiki
+  auto bismark = Ship{.length{251.q_m}, .draft{9.3q_m}, .beam{36q_m}, .speed{56q_km_per_h}, .mass{50.3q_t}, .mainGuns{380q_mm}, .shellMass{800q_kg}, .shellSpeed{820.q_m_per_s}, .power{110.45q_kW}};
+
+  // USS Iowa, using units from the foot-pound-second system
+  auto iowa = Ship{.length{860.q_ft}, .draft{37.q_ft + 2.q_in}, .beam{108.q_ft + 2.q_in}, .speed{33q_knot}, .mass{57'540q_lton}, .mainGuns{16q_in}, .shellMass{2700q_lb}, .shellSpeed{2690.q_ft_per_s}, .power{212'000q_hp}};
+
+  // HMS King George V, using units from the foot-pound-second system
+  auto kgv = Ship{.length{745.1q_ft}, .draft{33.q_ft + 7.5q_in}, .beam{103.2q_ft + 2.5q_in}, .speed{28.3q_knot}, .mass{42'245q_lton}, .mainGuns{14q_in}, .shellMass{1'590q_lb}, .shellSpeed{2483.q_ft_per_s}, .power{110'000q_hp}};
+
+  print_details("KMS Bismark, defined in appropriate units from the SI system", bismark) << "\n\n";
+  print_details("USS Iowa, defined in appropriate units foot-pound-second system", iowa) << "\n\n";
+  print_details("HMS King George V, defined in appropriate units foot-pound-second system", kgv);
+
+}

--- a/src/include/units/physical/fps/acceleration.h
+++ b/src/include/units/physical/fps/acceleration.h
@@ -1,0 +1,45 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/fps/speed.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+struct foot_per_second_sq : unit<foot_per_second_sq> {};
+struct dim_acceleration : physical::dim_acceleration<dim_acceleration, foot_per_second_sq, dim_length, dim_time> {};
+
+template<Unit U, Scalar Rep = double>
+using acceleration = quantity<dim_acceleration, U, Rep>;
+
+inline namespace literals {
+
+// ft_per_s2
+constexpr auto operator"" q_ft_per_s2(unsigned long long l) { return acceleration<foot_per_second_sq, std::int64_t>(l); }
+constexpr auto operator"" q_ft_per_s2(long double l) { return acceleration<foot_per_second_sq, long double>(l); }
+
+}  // namespace literals
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/area.h
+++ b/src/include/units/physical/fps/area.h
@@ -38,7 +38,7 @@ using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {
 
-// fm2
+// ft2
 constexpr auto operator"" q_ft2(unsigned long long l) { return area<square_foot, std::int64_t>(l); }
 constexpr auto operator"" q_ft2(long double l) { return area<square_foot, long double>(l); }
 

--- a/src/include/units/physical/fps/area.h
+++ b/src/include/units/physical/fps/area.h
@@ -1,0 +1,47 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/fps/length.h>
+// #include <units/physical/si/area.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+struct square_foot : unit<square_foot> {};
+struct dim_area : physical::dim_area<dim_area, square_foot, dim_length> {};
+
+
+template<Unit U, Scalar Rep = double>
+using area = quantity<dim_area, U, Rep>;
+
+inline namespace literals {
+
+// fm2
+constexpr auto operator"" q_ft2(unsigned long long l) { return area<square_foot, std::int64_t>(l); }
+constexpr auto operator"" q_ft2(long double l) { return area<square_foot, long double>(l); }
+
+}
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/density.h
+++ b/src/include/units/physical/fps/density.h
@@ -23,31 +23,23 @@
 #pragma once
 
 #include <units/physical/dimensions.h>
-#include <units/physical/fps/energy.h>
-#include <units/physical/si/prefixes.h>
+#include <units/physical/fps/mass.h>
+#include <units/physical/fps/length.h>
 #include <units/quantity.h>
 
 namespace units::physical::fps {
 
-struct foot_poundal_per_second : unit<foot_poundal_per_second> {};
+struct pound_per_foot_cub : unit<pound_per_foot_cub> {};
 
-struct dim_power : physical::dim_power<dim_power, foot_poundal_per_second, dim_energy, dim_time> {};
-
-struct foot_pound_force_per_second : deduced_unit<foot_pound_force_per_second, dim_power, foot_pound_force, second> {};
+struct dim_density : physical::dim_density<dim_density, pound_per_foot_cub, dim_mass, dim_length> {};
 
 template<Unit U, Scalar Rep = double>
-using power = quantity<dim_power, U, Rep>;
+using density = quantity<dim_density, U, Rep>;
 
 inline namespace literals {
 
-// foot pound force per second
-constexpr auto operator"" q_ft_pdl_per_s(unsigned long long l) { return power<foot_poundal_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_pdl_per_s(long double l) { return power<foot_poundal_per_second, long double>(l); }
-
-
-// foot pound force per second
-constexpr auto operator"" q_ft_lbf_per_s(unsigned long long l) { return power<foot_pound_force_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_lbf_per_s(long double l) { return power<foot_pound_force_per_second, long double>(l); }
+constexpr auto operator"" q_lb_per_ft3(unsigned long long l) { return density<pound_per_foot_cub, std::int64_t>(l); }
+constexpr auto operator"" q_lb_per_ft3(long double l) { return density<pound_per_foot_cub, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/fps/energy.h
+++ b/src/include/units/physical/fps/energy.h
@@ -1,0 +1,54 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/fps/force.h>
+#include <units/physical/si/prefixes.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+// https://en.wikipedia.org/wiki/Foot-poundal
+struct foot_poundal : unit<foot_poundal> {};
+
+// https://en.wikipedia.org/wiki/Foot-pound_(energy)
+struct foot_pound_force : named_scaled_unit<foot_poundal, "lbf", no_prefix, ratio<32'174'049, 1'000'000>, foot_poundal> {};
+
+struct dim_energy : physical::dim_energy<dim_energy, foot_poundal, dim_force, dim_length> {};
+
+template<Unit U, Scalar Rep = double>
+using energy = quantity<dim_energy, U, Rep>;
+
+inline namespace literals {
+
+constexpr auto operator"" q_ft_pdl(unsigned long long l) { return energy<foot_poundal, std::int64_t>(l); }
+constexpr auto operator"" q_ft_pdl(long double l) { return energy<foot_poundal, long double>(l); }
+
+// foot_pound force
+constexpr auto operator"" q_ft_lbf(unsigned long long l) { return energy<foot_pound_force, std::int64_t>(l); }
+constexpr auto operator"" q_ft_lbf(long double l) { return energy<foot_pound_force, long double>(l); }
+
+}  // namespace literals
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/energy.h
+++ b/src/include/units/physical/fps/energy.h
@@ -32,13 +32,16 @@ namespace units::physical::fps {
 // https://en.wikipedia.org/wiki/Foot-poundal
 struct foot_poundal : unit<foot_poundal> {};
 
-// https://en.wikipedia.org/wiki/Foot-pound_(energy)
-struct foot_pound_force : named_scaled_unit<foot_poundal, "lbf", no_prefix, ratio<32'174'049, 1'000'000>, foot_poundal> {};
-
 struct dim_energy : physical::dim_energy<dim_energy, foot_poundal, dim_force, dim_length> {};
+
+// https://en.wikipedia.org/wiki/Foot-pound_(energy)
+struct foot_pound_force : named_deduced_unit<foot_pound_force, dim_energy, pound_force, foot> {};
+
+
 
 template<Unit U, Scalar Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
+
 
 inline namespace literals {
 

--- a/src/include/units/physical/fps/energy.h
+++ b/src/include/units/physical/fps/energy.h
@@ -35,7 +35,7 @@ struct foot_poundal : unit<foot_poundal> {};
 struct dim_energy : physical::dim_energy<dim_energy, foot_poundal, dim_force, dim_length> {};
 
 // https://en.wikipedia.org/wiki/Foot-pound_(energy)
-struct foot_pound_force : named_deduced_unit<foot_pound_force, dim_energy, pound_force, foot> {};
+struct foot_pound_force : noble_deduced_unit<foot_pound_force, dim_energy, pound_force, foot> {};
 
 
 

--- a/src/include/units/physical/fps/force.h
+++ b/src/include/units/physical/fps/force.h
@@ -34,7 +34,7 @@ namespace units::physical::fps {
 struct poundal : named_unit<poundal, "pdl", no_prefix> {};
 
 // https://en.wikipedia.org/wiki/Pound_(force)
-struct pound_force : named_scaled_unit<pound_force, "ftlbf", no_prefix, ratio<32'174'049, 1'000'000>, poundal> {};
+struct pound_force : named_scaled_unit<pound_force, "lbf", no_prefix, ratio<32'174'049, 1'000'000>, poundal> {};
 
 
 

--- a/src/include/units/physical/fps/force.h
+++ b/src/include/units/physical/fps/force.h
@@ -1,0 +1,58 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/fps/acceleration.h>
+#include <units/physical/fps/mass.h>
+#include <units/physical/si/prefixes.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+// https://en.wikipedia.org/wiki/Poundal
+struct poundal : named_unit<poundal, "pdl", no_prefix> {};
+
+// https://en.wikipedia.org/wiki/Pound_(force)
+struct pound_force : named_scaled_unit<pound_force, "ftlbf", no_prefix, ratio<32'174'049, 1'000'000>, poundal> {};
+
+
+
+struct dim_force : physical::dim_force<dim_force, poundal, dim_mass, dim_acceleration> {};
+
+template<Unit U, Scalar Rep = double>
+using force = quantity<dim_force, U, Rep>;
+
+inline namespace literals {
+
+// poundal
+constexpr auto operator"" q_pdl(unsigned long long l) { return force<poundal, std::int64_t>(l); }
+constexpr auto operator"" q_pdl(long double l) { return force<poundal, long double>(l); }
+
+// pound force
+constexpr auto operator"" q_lbf(unsigned long long l) { return force<pound_force, std::int64_t>(l); }
+constexpr auto operator"" q_lbf(long double l) { return force<pound_force, long double>(l); }
+
+}  // namespace literals
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/length.h
+++ b/src/include/units/physical/fps/length.h
@@ -31,6 +31,16 @@ namespace units::physical::fps {
 // https://en.wikipedia.org/wiki/Foot_(unit)
 struct foot : named_scaled_unit<foot, "ft", no_prefix, ratio<3'048, 1'000, -1>, si::metre> {};
 
+struct yard : named_scaled_unit<yard, "yd", no_prefix, ratio<3, 1>, foot> {};
+
+struct inch : named_scaled_unit<inch, "in", no_prefix, ratio<1, 12>, foot> {};
+
+struct mile : named_scaled_unit<mile, "mile", no_prefix, ratio<5'280>, foot> {};
+
+struct nautical_mile : named_scaled_unit<nautical_mile, "mi(naut)", no_prefix, ratio<2000>, yard> {};
+
+
+
 struct dim_length : physical::dim_length<foot> {};
 
 template<Unit U, Scalar Rep = double>
@@ -38,9 +48,22 @@ using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {
 
+constexpr auto operator"" q_in(unsigned long long l) { return length<inch, std::int64_t>(l); }
+constexpr auto operator"" q_in(long double l) { return length<inch, long double>(l); }
+
 // ft
 constexpr auto operator"" q_ft(unsigned long long l) { return length<foot, std::int64_t>(l); }
 constexpr auto operator"" q_ft(long double l) { return length<foot, long double>(l); }
+
+constexpr auto operator"" q_yd(unsigned long long l) { return length<yard, std::int64_t>(l); }
+constexpr auto operator"" q_yd(long double l) { return length<yard, long double>(l); }
+
+constexpr auto operator"" q_mile(unsigned long long l) { return length<mile, std::int64_t>(l); }
+constexpr auto operator"" q_mile(long double l) { return length<mile, long double>(l); }
+
+constexpr auto operator"" q_naut_mi(unsigned long long l) { return length<nautical_mile, std::int64_t>(l); }
+constexpr auto operator"" q_naut_mi(long double l) { return length<nautical_mile, long double>(l); }
+
 
 }
 

--- a/src/include/units/physical/fps/length.h
+++ b/src/include/units/physical/fps/length.h
@@ -1,0 +1,47 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/si/length.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+// https://en.wikipedia.org/wiki/Foot_(unit)
+struct foot : named_scaled_unit<foot, "ft", no_prefix, ratio<3'048, 1'000, -1>, si::metre> {};
+
+struct dim_length : physical::dim_length<foot> {};
+
+template<Unit U, Scalar Rep = double>
+using length = quantity<dim_length, U, Rep>;
+
+inline namespace literals {
+
+// ft
+constexpr auto operator"" q_ft(unsigned long long l) { return length<foot, std::int64_t>(l); }
+constexpr auto operator"" q_ft(long double l) { return length<foot, long double>(l); }
+
+}
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/mass.h
+++ b/src/include/units/physical/fps/mass.h
@@ -1,0 +1,47 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/si/mass.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+// https://en.wikipedia.org/wiki/Pound_(mass)
+struct pound : named_scaled_unit<pound, "lb", no_prefix, ratio<45'359'237, 100'000'000>, si::kilogram> {};
+
+struct dim_mass : physical::dim_mass<pound> {};
+
+template<Unit U, Scalar Rep = double>
+using mass = quantity<dim_mass, U, Rep>;
+
+inline namespace literals {
+
+// g
+constexpr auto operator"" q_lb(unsigned long long l) { return mass<pound, std::int64_t>(l); }
+constexpr auto operator"" q_lb(long double l) { return mass<pound, long double>(l); }
+
+}
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/mass.h
+++ b/src/include/units/physical/fps/mass.h
@@ -36,11 +36,31 @@ struct dim_mass : physical::dim_mass<pound> {};
 template<Unit U, Scalar Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
+struct ounce : named_scaled_unit<ounce, "oz", no_prefix, ratio<1, 16>, pound>{};
+
+struct short_ton : named_scaled_unit<short_ton, "ton (short)", no_prefix, ratio<2'000, 1>, pound>{};
+
+struct long_ton : named_scaled_unit<long_ton, "ton (long)", no_prefix, ratio<2'240, 1>, pound>{};
+
 inline namespace literals {
 
-// g
+
+constexpr auto operator"" q_oz(unsigned long long l) { return mass<ounce, std::int64_t>(l); }
+constexpr auto operator"" q_oz(long double l) { return mass<ounce, long double>(l); }
+
+
+// lb
 constexpr auto operator"" q_lb(unsigned long long l) { return mass<pound, std::int64_t>(l); }
 constexpr auto operator"" q_lb(long double l) { return mass<pound, long double>(l); }
+
+
+constexpr auto operator"" q_ston(unsigned long long l) { return mass<short_ton, std::int64_t>(l); }
+constexpr auto operator"" q_ston(long double l) { return mass<short_ton, long double>(l); }
+
+
+constexpr auto operator"" q_lton(unsigned long long l) { return mass<long_ton, std::int64_t>(l); }
+constexpr auto operator"" q_lton(long double l) { return mass<long_ton, long double>(l); }
+
 
 }
 

--- a/src/include/units/physical/fps/power.h
+++ b/src/include/units/physical/fps/power.h
@@ -1,0 +1,55 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/fps/energy.h>
+#include <units/physical/si/prefixes.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+struct foot_poundal_per_second : unit<foot_poundal_per_second> {};
+
+struct foot_pound_force_per_second : scaled_unit<ratio<32'174'049, 1'000'000>, foot_poundal_per_second> {};
+
+
+struct dim_power : physical::dim_power<dim_power, foot_poundal_per_second, dim_energy, dim_time> {};
+
+template<Unit U, Scalar Rep = double>
+using power = quantity<dim_power, U, Rep>;
+
+inline namespace literals {
+
+// foot pound force per second
+constexpr auto operator"" q_ft_pdl_per_s(unsigned long long l) { return power<foot_poundal_per_second, std::int64_t>(l); }
+constexpr auto operator"" q_ft_pdl_per_s(long double l) { return power<foot_poundal_per_second, long double>(l); }
+
+
+// foot pound force per second
+constexpr auto operator"" q_ft_lbf_per_s(unsigned long long l) { return power<foot_pound_force_per_second, std::int64_t>(l); }
+constexpr auto operator"" q_ft_lbf_per_s(long double l) { return power<foot_pound_force_per_second, long double>(l); }
+
+}  // namespace literals
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/power.h
+++ b/src/include/units/physical/fps/power.h
@@ -35,6 +35,8 @@ struct dim_power : physical::dim_power<dim_power, foot_poundal_per_second, dim_e
 
 struct foot_pound_force_per_second : deduced_unit<foot_pound_force_per_second, dim_power, foot_pound_force, second> {};
 
+struct horse_power : named_scaled_unit<horse_power, "hp", no_prefix, ratio<550>, foot_pound_force_per_second> {};
+
 template<Unit U, Scalar Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
@@ -48,6 +50,10 @@ constexpr auto operator"" q_ft_pdl_per_s(long double l) { return power<foot_poun
 // foot pound force per second
 constexpr auto operator"" q_ft_lbf_per_s(unsigned long long l) { return power<foot_pound_force_per_second, std::int64_t>(l); }
 constexpr auto operator"" q_ft_lbf_per_s(long double l) { return power<foot_pound_force_per_second, long double>(l); }
+
+
+constexpr auto operator"" q_hp(unsigned long long l) { return power<horse_power, std::int64_t>(l); }
+constexpr auto operator"" q_hp(long double l) { return power<horse_power, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/physical/fps/pressure.h
+++ b/src/include/units/physical/fps/pressure.h
@@ -39,7 +39,7 @@ using pressure = quantity<dim_pressure, U, Rep>;
 
 struct pound_force_per_foot_sq : named_scaled_unit<pound_force_per_foot_sq, "lbf ft2", si::prefix, ratio<32'174'049, 1'000'000>, poundal_per_foot_sq> {};
 
-// struct pound_force_per_foot_sq : named_deduced_unit<pound_force_per_foot_sq, dim_pressure, pound_force, square_ft> {};
+// struct pound_force_per_foot_sq : noble_deduced_unit<pound_force_per_foot_sq, dim_pressure, pound_force, square_ft> {};
 
 struct pound_force_per_inch_sq : named_scaled_unit<pound_force_per_inch_sq, "psi", si::prefix, ratio<1, 144>, pound_force_per_foot_sq> {};
 

--- a/src/include/units/physical/fps/pressure.h
+++ b/src/include/units/physical/fps/pressure.h
@@ -1,0 +1,56 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/fps/area.h>
+#include <units/physical/fps/force.h>
+#include <units/physical/si/prefixes.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+struct poundal_per_foot_sq : unit<poundal_per_foot_sq> {};
+
+struct pound_force_per_foot_sq : named_scaled_unit<pound_force_per_foot_sq, "lbf ft2", si::prefix, ratio<32'174'049, 1'000'000>, poundal_per_foot_sq> {};
+
+
+struct dim_pressure : physical::dim_pressure<dim_pressure, poundal_per_foot_sq, dim_force, dim_area> {};
+
+template<Unit U, Scalar Rep = double>
+using pressure = quantity<dim_pressure, U, Rep>;
+
+struct pound_force_per_inch_sq : named_scaled_unit<pound_force_per_inch_sq, "psi", si::prefix, ratio<1, 144>, pound_force_per_foot_sq> {};
+
+inline namespace literals {
+// Poundal per square foot
+constexpr auto operator"" q_pdl_per_ft2(unsigned long long l) { return pressure<poundal_per_foot_sq, std::int64_t>(l); }
+constexpr auto operator"" q_pdl_per_ft2(long double l) { return pressure<poundal_per_foot_sq, long double>(l); }
+
+// Pounds per square inch
+constexpr auto operator"" q_psi(unsigned long long l) { return pressure<pound_force_per_inch_sq, std::int64_t>(l); }
+constexpr auto operator"" q_psi(long double l) { return pressure<pound_force_per_inch_sq, long double>(l); }
+
+}  // namespace literals
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/pressure.h
+++ b/src/include/units/physical/fps/pressure.h
@@ -32,13 +32,14 @@ namespace units::physical::fps {
 
 struct poundal_per_foot_sq : unit<poundal_per_foot_sq> {};
 
-struct pound_force_per_foot_sq : named_scaled_unit<pound_force_per_foot_sq, "lbf ft2", si::prefix, ratio<32'174'049, 1'000'000>, poundal_per_foot_sq> {};
-
-
 struct dim_pressure : physical::dim_pressure<dim_pressure, poundal_per_foot_sq, dim_force, dim_area> {};
 
 template<Unit U, Scalar Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
+
+struct pound_force_per_foot_sq : named_scaled_unit<pound_force_per_foot_sq, "lbf ft2", si::prefix, ratio<32'174'049, 1'000'000>, poundal_per_foot_sq> {};
+
+// struct pound_force_per_foot_sq : named_deduced_unit<pound_force_per_foot_sq, dim_pressure, pound_force, square_ft> {};
 
 struct pound_force_per_inch_sq : named_scaled_unit<pound_force_per_inch_sq, "psi", si::prefix, ratio<1, 144>, pound_force_per_foot_sq> {};
 

--- a/src/include/units/physical/fps/speed.h
+++ b/src/include/units/physical/fps/speed.h
@@ -37,9 +37,9 @@ using speed = quantity<dim_speed, U, Rep>;
 
 struct mile_per_hour : deduced_unit<mile_per_hour, dim_speed, mile, hour>{};
 
-struct nautical_mile_per_hour : deduced_unit<nautical_mile_per_hour, dim_speed, nautical_mile, hour>{};
+struct nautical_mile_per_hour :named_deduced_derived_unit<nautical_mile_per_hour, dim_speed, "knot", no_prefix, nautical_mile, hour>{};
 
-struct knot : alias_unit<nautical_mile_per_hour, "knot", si::prefix> {};
+struct knot : alias_unit<nautical_mile_per_hour, "knot", no_prefix> {};
 
 
 inline namespace literals {

--- a/src/include/units/physical/fps/speed.h
+++ b/src/include/units/physical/fps/speed.h
@@ -35,11 +35,24 @@ struct dim_speed : physical::dim_speed<dim_speed, foot_per_second, dim_length, d
 template<Unit U, Scalar Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
+struct mile_per_hour : deduced_unit<mile_per_hour, dim_speed, mile, hour>{};
+
+struct nautical_mile_per_hour : deduced_unit<nautical_mile_per_hour, dim_speed, nautical_mile, hour>{};
+
+struct knot : alias_unit<nautical_mile_per_hour, "knot", si::prefix> {};
+
+
 inline namespace literals {
 
-// cmps
 constexpr auto operator"" q_ft_per_s(unsigned long long l) { return speed<foot_per_second, std::int64_t>(l); }
 constexpr auto operator"" q_ft_per_s(long double l) { return speed<foot_per_second, long double>(l); }
+
+constexpr auto operator"" q_mph(unsigned long long l) { return speed<mile_per_hour, std::int64_t>(l); }
+constexpr auto operator"" q_mph(long double l) { return speed<mile_per_hour, long double>(l); }
+
+constexpr auto operator"" q_knot(unsigned long long l) { return speed<knot, std::int64_t>(l); }
+constexpr auto operator"" q_knot(long double l) { return speed<knot, long double>(l); }
+
 
 }  // namespace literals
 

--- a/src/include/units/physical/fps/speed.h
+++ b/src/include/units/physical/fps/speed.h
@@ -1,0 +1,46 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/fps/length.h>
+#include <units/physical/fps/time.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+struct foot_per_second : unit<foot_per_second> {};
+struct dim_speed : physical::dim_speed<dim_speed, foot_per_second, dim_length, dim_time> {};
+
+template<Unit U, Scalar Rep = double>
+using speed = quantity<dim_speed, U, Rep>;
+
+inline namespace literals {
+
+// cmps
+constexpr auto operator"" q_ft_per_s(unsigned long long l) { return speed<foot_per_second, std::int64_t>(l); }
+constexpr auto operator"" q_ft_per_s(long double l) { return speed<foot_per_second, long double>(l); }
+
+}  // namespace literals
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/time.h
+++ b/src/include/units/physical/fps/time.h
@@ -29,6 +29,8 @@
 namespace units::physical::fps {
 
 using si::second;
+using si::minute;
+using si::hour;
 
 using si::dim_time;
 using si::time;

--- a/src/include/units/physical/fps/time.h
+++ b/src/include/units/physical/fps/time.h
@@ -1,0 +1,42 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/dimensions.h>
+#include <units/physical/si/time.h>
+#include <units/quantity.h>
+
+namespace units::physical::fps {
+
+using si::second;
+
+using si::dim_time;
+using si::time;
+
+inline namespace literals {
+
+using si::literals::operator"" q_s;
+
+}
+
+}  // namespace units::physical::fps

--- a/src/include/units/physical/fps/volume.h
+++ b/src/include/units/physical/fps/volume.h
@@ -23,31 +23,28 @@
 #pragma once
 
 #include <units/physical/dimensions.h>
-#include <units/physical/fps/energy.h>
-#include <units/physical/si/prefixes.h>
+#include <units/physical/fps/length.h>
 #include <units/quantity.h>
 
 namespace units::physical::fps {
 
-struct foot_poundal_per_second : unit<foot_poundal_per_second> {};
+struct cubic_foot : unit<cubic_foot> {};
+struct dim_volume : physical::dim_volume<dim_volume, cubic_foot, dim_length> {};
 
-struct dim_power : physical::dim_power<dim_power, foot_poundal_per_second, dim_energy, dim_time> {};
-
-struct foot_pound_force_per_second : deduced_unit<foot_pound_force_per_second, dim_power, foot_pound_force, second> {};
+struct cubic_yard : deduced_unit<cubic_yard, dim_volume, yard> {};
 
 template<Unit U, Scalar Rep = double>
-using power = quantity<dim_power, U, Rep>;
+using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {
 
-// foot pound force per second
-constexpr auto operator"" q_ft_pdl_per_s(unsigned long long l) { return power<foot_poundal_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_pdl_per_s(long double l) { return power<foot_poundal_per_second, long double>(l); }
+// ft3
+constexpr auto operator"" q_ft3(unsigned long long l) { return volume<cubic_foot, std::int64_t>(l); }
+constexpr auto operator"" q_ft3(long double l) { return volume<cubic_foot, long double>(l); }
 
-
-// foot pound force per second
-constexpr auto operator"" q_ft_lbf_per_s(unsigned long long l) { return power<foot_pound_force_per_second, std::int64_t>(l); }
-constexpr auto operator"" q_ft_lbf_per_s(long double l) { return power<foot_pound_force_per_second, long double>(l); }
+// yard3
+constexpr auto operator"" q_yd3(unsigned long long l) { return volume<cubic_yard, std::int64_t>(l); }
+constexpr auto operator"" q_yd3(long double l) { return volume<cubic_yard, long double>(l); }
 
 }  // namespace literals
 

--- a/src/include/units/unit.h
+++ b/src/include/units/unit.h
@@ -165,6 +165,29 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
   using prefix_family = no_prefix;
 };
 
+
+/**
+ * @brief A unit with a deduced ratio and symbol that can be used as a named unit for children 
+ *
+ * Defines a new unit with a deduced ratio and symbol based on the recipe from the provided
+ * derived dimension. The number and order of provided units should match the recipe of the
+ * derived dimension. All of the units provided should also be a named ones so it is possible
+ * to create a deduced symbol text.
+ *
+ * @tparam Child inherited class type used by the downcasting facility (CRTP Idiom)
+ * @tparam Dim a derived dimension recipe to use for deduction
+ * @tparam U the unit of the first composite dimension from provided derived dimension's recipe
+ * @tparam URest the units for the rest of dimensions from the recipe
+ */
+template<typename Child, DerivedDimension Dim, Unit U, Unit... URest>
+  requires detail::same_scaled_units<typename Dim::recipe, U, URest...> &&
+           (U::is_named && (URest::is_named && ... && true))
+struct named_deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest...>> {
+  static constexpr bool is_named = true;
+  static constexpr auto symbol = detail::deduced_symbol_text<Dim, U, URest...>();
+  using prefix_family = no_prefix;
+};
+
 // template<typename Child, Dimension Dim, basic_fixed_string Symbol, PrefixFamily PF, Unit U, Unit... Us>
 // struct named_deduced_derived_unit : downcast_child<Child, detail::deduced_derived_unit<Dim, U, Us...>> {
 //   static constexpr bool is_named = true;

--- a/src/include/units/unit.h
+++ b/src/include/units/unit.h
@@ -182,18 +182,36 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
 template<typename Child, DerivedDimension Dim, Unit U, Unit... URest>
   requires detail::same_scaled_units<typename Dim::recipe, U, URest...> &&
            (U::is_named && (URest::is_named && ... && true))
-struct named_deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest...>> {
+// TODO - 'noble' is placeholder to sort of mean can pass its name on to other deduced units
+struct noble_deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest...>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = detail::deduced_symbol_text<Dim, U, URest...>();
   using prefix_family = no_prefix;
 };
 
-// template<typename Child, Dimension Dim, basic_fixed_string Symbol, PrefixFamily PF, Unit U, Unit... Us>
-// struct named_deduced_derived_unit : downcast_child<Child, detail::deduced_derived_unit<Dim, U, Us...>> {
-//   static constexpr bool is_named = true;
-//   static constexpr auto symbol = Symbol;
-//   using prefix_family = PF;
-// };
+
+/**
+ * @brief A named unit with a deduced ratio 
+ *
+ * Defines a new unit with a deduced ratio and the given symbol based on the recipe from the provided
+ * derived dimension. The number and order of provided units should match the recipe of the
+ * derived dimension. All of the units provided should also be a named ones so it is possible
+ * to create a deduced symbol text.
+ *
+ * @tparam Child inherited class type used by the downcasting facility (CRTP Idiom)
+ * @tparam Dim a derived dimension recipe to use for deduction
+ * @tparam Symbol a short text representation of the unit
+ * @tparam PF no_prefix or a type of prefix family
+ * @tparam U the unit of the first composite dimension from provided derived dimension's recipe
+ * @tparam URest the units for the rest of dimensions from the recipe
+ */
+template<typename Child, DerivedDimension Dim, basic_symbol_text Symbol, PrefixFamily PF, Unit U, Unit... URest>
+  requires detail::same_scaled_units<typename Dim::recipe, U, URest...>
+struct named_deduced_derived_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest...>> {
+  static constexpr bool is_named = true;
+  static constexpr auto symbol = Symbol;
+  using prefix_family = PF;
+};
 
 /**
  * @brief An aliased named unit

--- a/test/unit_test/static/CMakeLists.txt
+++ b/test/unit_test/static/CMakeLists.txt
@@ -28,11 +28,13 @@ add_library(unit_tests_static
     dimension_op_test.cpp
     dimensions_concepts_test.cpp
     fixed_string_test.cpp
+    fps_test.cpp
     math_test.cpp
     quantity_test.cpp
     ratio_test.cpp
     si_test.cpp
     si_cgs_test.cpp
+    si_fps_test.cpp
     symbol_text_test.cpp
     type_list_test.cpp
     unit_test.cpp

--- a/test/unit_test/static/fps_test.cpp
+++ b/test/unit_test/static/fps_test.cpp
@@ -1,0 +1,102 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+#include <units/physical/fps/acceleration.h>
+#include <units/physical/fps/energy.h>
+#include <units/physical/fps/force.h>
+#include <units/physical/fps/length.h>
+#include <units/physical/fps/mass.h>
+#include <units/physical/fps/power.h>
+#include <units/physical/fps/pressure.h>
+#include <units/physical/fps/time.h>
+#include <units/physical/fps/speed.h>
+
+namespace {
+
+using namespace units;
+using namespace units::physical::fps;
+
+/* ************** BASE DIMENSIONS **************** */
+
+// length
+
+static_assert(foot::symbol == "ft");
+
+// mass
+
+// time
+
+/* ************** DERIVED DIMENSIONS IN TERMS OF BASE UNITS **************** */
+
+// speed
+
+static_assert(10q_ft / 5q_s == 2q_ft_per_s);
+static_assert(10q_ft / 2q_ft_per_s == 5q_s);
+static_assert(10q_ft == 2q_ft_per_s * 5q_s);
+
+static_assert(detail::unit_text<dim_speed, foot_per_second>() == "ft/s");
+
+// area
+static_assert(std::is_same_v<ratio_divide<foot::ratio, dimension_unit<dim_length>::ratio>, ratio<1>>);
+
+static_assert(1q_ft * 1q_ft == 1q_ft2);
+static_assert(100q_ft2 / 10q_ft == 10q_ft);
+
+static_assert(detail::unit_text<dim_area, square_foot>() == basic_symbol_text("ft²", "ft^2"));
+
+/* ************** DERIVED DIMENSIONS WITH NAMED UNITS **************** */
+
+// acceleration
+
+static_assert(10q_ft_per_s / 10q_s == 1q_ft_per_s2);
+static_assert(10q_ft_per_s / 1q_ft_per_s2 == 10q_s);
+static_assert(1q_ft_per_s2 * 10q_s == 10q_ft_per_s);
+
+// force
+
+static_assert(10q_lb * 10q_ft_per_s2 == 100q_pdl);
+static_assert(100q_pdl / 10q_lb == 10q_ft_per_s2);
+static_assert(100q_pdl / 10q_ft_per_s2 == 10q_lb);
+
+// pressure
+static_assert(10q_pdl / 10q_ft2 == 1q_pdl_per_ft2);
+static_assert(10q_pdl / 1q_pdl_per_ft2 == 10q_ft2);
+static_assert(1q_pdl_per_ft2 * 10q_ft2 == 10q_pdl);
+
+// energy
+
+static_assert(10q_pdl * 10q_ft == 100q_ft_pdl);
+static_assert(100q_ft_pdl / 10q_ft == 10q_pdl);
+static_assert(100q_ft_pdl / 10q_pdl == 10q_ft);
+
+/* ************** DERIVED DIMENSIONS IN TERMS OF OTHER UNITS **************** */
+
+// power
+
+static_assert(10q_ft_pdl / 10q_s == 1q_ft_pdl_per_s);
+static_assert(1q_ft_pdl_per_s * 10q_s == 10q_ft_pdl);
+static_assert(10q_ft_pdl / 1q_ft_pdl_per_s == 10q_s);
+
+// static_assert(detail::unit_text<dim_power, foot_pound_force_per_second>() == "ft_lbf/s");
+
+}

--- a/test/unit_test/static/si_fps_test.cpp
+++ b/test/unit_test/static/si_fps_test.cpp
@@ -1,0 +1,165 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+
+#include <units/physical/fps/acceleration.h>
+#include <units/physical/fps/area.h>
+#include <units/physical/fps/energy.h>
+#include <units/physical/fps/force.h>
+#include <units/physical/fps/length.h>
+#include <units/physical/fps/mass.h>
+#include <units/physical/fps/power.h>
+#include <units/physical/fps/pressure.h>
+#include <units/physical/fps/time.h>
+#include <units/physical/fps/speed.h>
+#include <units/physical/si/acceleration.h>
+#include <units/physical/si/area.h>
+#include <units/physical/si/energy.h>
+#include <units/physical/si/force.h>
+#include <units/physical/si/length.h>
+#include <units/physical/si/mass.h>
+#include <units/physical/si/power.h>
+#include <units/physical/si/pressure.h>
+#include <units/physical/si/time.h>
+#include <units/physical/si/speed.h>
+
+namespace {
+
+using namespace units::physical;
+
+static_assert(fps::length<fps::foot>(1) == si::length<si::metre>(0.3048));
+static_assert(fps::mass<fps::pound>(1) == si::mass<si::kilogram>(0.45359237));
+static_assert(fps::time<fps::second>(1) == si::time<si::second>(1));
+static_assert(fps::speed<fps::foot_per_second>(1) == si::speed<si::metre_per_second>(0.3048));
+static_assert(fps::area<fps::square_foot>(1) == si::area<si::square_metre>(0.09290304));
+static_assert(fps::acceleration<fps::foot_per_second_sq>(1) == si::acceleration<si::metre_per_second_sq>(0.3048));
+static_assert(fps::force<fps::poundal>(1) >= si::force<si::newton>(0.138254) && 
+              fps::force<fps::poundal>(1) <= si::force<si::newton>(0.138256));
+static_assert(fps::energy<fps::foot_poundal>(1) >= si::energy<si::joule>(0.042140110093804) && 
+              fps::energy<fps::foot_poundal>(1) <= si::energy<si::joule>(0.042140110093806));
+static_assert(fps::power<fps::foot_poundal_per_second>(1) >= si::power<si::watt>(0.042140110093804) && 
+              fps::power<fps::foot_poundal_per_second>(1) <= si::power<si::watt>(0.042140110093806));
+static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >= si::pressure<si::pascal>(1.4881639435) &&
+              fps::pressure<fps::poundal_per_foot_sq>(1) <= si::pressure<si::pascal>(1.4881639437));
+
+namespace si_literals {
+
+using namespace units::physical::si::literals;
+
+static_assert(fps::length<fps::foot>(1) == 0.3048q_m);
+static_assert(fps::mass<fps::pound>(1) == 0.45359237q_kg);
+static_assert(fps::time<fps::second>(1) == 1q_s);
+static_assert(fps::speed<fps::foot_per_second>(1) == 0.3048q_m_per_s);
+static_assert(fps::area<fps::square_foot>(1) == 0.09290304q_m2);
+static_assert(fps::acceleration<fps::foot_per_second_sq>(1) == 0.3048q_m_per_s2);
+static_assert(fps::force<fps::poundal>(1) >= 0.138254q_N && 
+              fps::force<fps::poundal>(1) <= 0.138256q_N);
+static_assert(fps::energy<fps::foot_poundal>(1) >= 0.042140110093804q_J && 
+              fps::energy<fps::foot_poundal>(1) <= 0.042140110093806q_J);
+static_assert(fps::power<fps::foot_poundal_per_second>(1) >= 0.042140110093804q_W && 
+              fps::power<fps::foot_poundal_per_second>(1) <= 0.042140110093806q_W);
+static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >=  1.4881639435q_Pa &&
+              fps::pressure<fps::poundal_per_foot_sq>(1) <=  1.4881639437q_Pa);
+}
+
+namespace fps_literals {
+
+using namespace units::physical::fps::literals;
+
+static_assert(1q_ft == si::length<si::metre>(0.3048));
+static_assert(1q_lb == si::mass<si::kilogram>(0.45359237));
+static_assert(1q_s == si::time<si::second>(1));
+static_assert(1q_ft_per_s == si::speed<si::metre_per_second>(0.3048));
+static_assert(1q_ft2 == si::area<si::square_metre>(0.09290304));
+static_assert(1q_ft_per_s2 == si::acceleration<si::metre_per_second_sq>(0.3048));
+static_assert(1q_pdl >= si::force<si::newton>(0.138254) && 
+              1q_pdl <= si::force<si::newton>(0.138256));
+static_assert(1q_ft_pdl >= si::energy<si::joule>(0.042140110093804) && 
+              1q_ft_pdl <= si::energy<si::joule>(0.042140110093806));
+static_assert(1q_ft_pdl_per_s >= si::power<si::watt>(0.042140110093804) && 
+              1q_ft_pdl_per_s <= si::power<si::watt>(0.042140110093806));
+static_assert(1q_pdl_per_ft2>= si::pressure<si::pascal>(1.4881639435) &&
+              1q_pdl_per_ft2 <= si::pressure<si::pascal>(1.4881639437));
+}
+
+namespace fps_plus_si_literals {
+
+using namespace units::physical::si::literals;
+using namespace units::physical::fps::literals;
+
+// static_assert(100q_cm == 1q_m);   // ambiguous
+// static_assert(1'000q_g == 1q_kg); // ambiguous
+static_assert(1q_ft == 0.3048q_m);
+static_assert(1q_lb == 0.45359237q_kg);
+static_assert(1q_s  == 1q_s);
+static_assert(1q_ft_per_s == 0.3048q_m_per_s);
+static_assert(1q_ft2 == 0.09290304q_m2);
+static_assert(1q_ft_per_s2 == 0.3048q_m_per_s2);
+static_assert(1q_pdl >= 0.138254q_N && 
+              1q_pdl <= 0.138256q_N);
+static_assert(1q_ft_pdl >= 0.042140110093804q_J && 
+              1q_ft_pdl <= 0.042140110093806q_J);
+static_assert(1q_ft_pdl_per_s >= 0.042140110093804q_W && 
+              1q_ft_pdl_per_s <= 0.042140110093806q_W);
+static_assert(1q_pdl_per_ft2>= 1.4881639435q_Pa &&
+              1q_pdl_per_ft2 <=1.4881639437q_Pa);
+
+}
+
+namespace cgs_test {
+
+using namespace units::physical::fps::literals;
+
+// addition
+
+// static_assert(si::length<si::metre>(1) + 1q_ft == si::length<si::metre>(1.3048)); // should not compile (different dimensions)
+// static_assert(1q_ft / 0.3048 + si::length<si::metre>(1) == si::length<si::metre>(1.3048)); // should not compile (different dimensions)
+static_assert(quantity_cast<si::length<si::metre>>(1q_ft / 0.3048) + si::length<si::metre>(1) == si::length<si::metre>(2));   // 1 m in ft + 1 m
+static_assert(si::length<si::metre>(1) + quantity_cast<si::length<si::metre>>(1q_ft / 0.3048) == si::length<si::metre>(2));   // 1 m + 1 m in ft
+static_assert(1q_ft + quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) == 2q_ft);                         // 1 ft + 1 ft in m
+static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) + 1q_ft == 2q_ft);                         // 1 ft in m + 1 ft
+
+// substraction
+
+// static_assert(1q_ft - si::length<si::metre>(1) == -si::length<si::metre>(0.6952)); // should not compile (different dimensions)
+// static_assert(si::length<si::metre>(1) - 1q_ft == si::length<si::metre>(0.6952)); // should not compile (different dimensions)
+static_assert(quantity_cast<si::length<si::metre>>(6.q_ft) - si::length<si::metre>(1) == si::length<si::metre>(0.8288));      // 6 ft in m - 1 m  = ... m
+static_assert(si::length<si::metre>(5) - quantity_cast<si::length<si::metre>>(6q_ft) == si::length<si::metre>(3.1712));       // 5 m - 6 ft in m  = ...
+static_assert(6.q_ft - quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) == 5.q_ft);                       // 6 ft - 1 ft in m = 5 ft
+static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(1.8288)) - 1.q_ft == 5.q_ft);                       // 6 ft in m - 1 ft = 5 ft
+
+// multiplication
+
+// static_assert(2q_ft * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); // should not compile (unknown dimension)
+// static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); 
+static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(0.6096) == si::area<si::square_metre>(0.371612160));  // 2 ft * 2 ft == 4 sq ft
+static_assert(2.q_ft * quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.6096)) == 4.q_ft2);
+
+// division
+
+// static_assert(si::area<si::square_metre>(4) / 200q_cm == si::length<si::metre>(2)); // should not compile (unknown dimension)
+static_assert(si::area<si::square_metre>(1.48644864) / quantity_cast<si::length<si::metre>>(4q_ft) == si::length<si::metre>(1.2192)); // 16 ft2 / 4 ft = 4 ft
+static_assert(quantity_cast<fps::area<fps::square_foot>>(si::area<si::square_metre>(1.48644864)) / 4.q_ft == 4.q_ft);                 // 16 ft2 / 4 ft = 4 ft
+
+}
+
+}


### PR DESCRIPTION
Created the foot-pound-second system, based on the setup of the CGS system.

Involved some messing about with units.h to help with symbols:
1) 'noble_deduced_units' - same as deduced units but can create children (placeholder name, the idea is that they can pass on their titles)
2) 'named_deduced_derived_units' - deduced units that have a supplied symbol, used to deduce the ratio for nautical miles per hour but set the symbol to 'knot' instead of 'mi(naut) / h'

SI tonnes are used in the example, but are displayed as Mg so don't seem to pick up the symbol 't'.
