### PR TITLE
Rename Scalar concept to Value.

### DIFF
--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -201,10 +201,10 @@ void matrix_of_quantity_tests()
   matrix_of_quantity_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Value Rep = double>
+template<units::Unit U = si::metre, units::NumericValue Rep = double>
 using length_v = si::length<U, vector<Rep>>;
 
-template<units::Unit U = si::newton, units::Value Rep = double>
+template<units::Unit U = si::newton, units::NumericValue Rep = double>
 using force_v = si::force<U, vector<Rep>>;
 
 void quantity_of_vector_add()
@@ -274,7 +274,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Value Rep = double>
+template<units::Unit U = si::metre, units::NumericValue Rep = double>
 using length_m = si::length<U, matrix<Rep>>;
 
 void quantity_of_matrix_add()

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -201,10 +201,10 @@ void matrix_of_quantity_tests()
   matrix_of_quantity_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Scalar Rep = double>
+template<units::Unit U = si::metre, units::Value Rep = double>
 using length_v = si::length<U, vector<Rep>>;
 
-template<units::Unit U = si::newton, units::Scalar Rep = double>
+template<units::Unit U = si::newton, units::Value Rep = double>
 using force_v = si::force<U, vector<Rep>>;
 
 void quantity_of_vector_add()
@@ -274,7 +274,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Scalar Rep = double>
+template<units::Unit U = si::metre, units::Value Rep = double>
 using length_m = si::length<U, matrix<Rep>>;
 
 void quantity_of_matrix_add()

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -146,7 +146,7 @@ private:
   value_type uncertainty_{};
 };
 
-static_assert(units::Scalar<measurement<double>>);
+static_assert(units::Value<measurement<double>>);
 
 }  // namespace
 

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -146,7 +146,7 @@ private:
   value_type uncertainty_{};
 };
 
-static_assert(units::Value<measurement<double>>);
+static_assert(units::NumericValue<measurement<double>>);
 
 }  // namespace
 

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -26,7 +26,7 @@
 
 namespace units {
 
-template<Dimension D, UnitOf<D> U, Value Rep>
+template<Dimension D, UnitOf<D> U, NumericValue Rep>
 class quantity;
 
 namespace detail {
@@ -59,7 +59,7 @@ struct common_quantity_impl<quantity<D1, U1, Rep1>, quantity<D2, U2, Rep2>, Rep>
 
 }  // namespace detail
 
-template<Quantity Q1, Quantity Q2, Value Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
+template<Quantity Q1, Quantity Q2, NumericValue Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
   requires equivalent_dim<typename Q1::dimension, typename Q2::dimension>
 using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -26,7 +26,7 @@
 
 namespace units {
 
-template<Dimension D, UnitOf<D> U, Scalar Rep>
+template<Dimension D, UnitOf<D> U, Value Rep>
 class quantity;
 
 namespace detail {
@@ -59,7 +59,7 @@ struct common_quantity_impl<quantity<D1, U1, Rep1>, quantity<D2, U2, Rep2>, Rep>
 
 }  // namespace detail
 
-template<Quantity Q1, Quantity Q2, Scalar Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
+template<Quantity Q1, Quantity Q2, Value Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
   requires equivalent_dim<typename Q1::dimension, typename Q2::dimension>
 using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -253,7 +253,7 @@ inline constexpr bool is_wrapped_quantity<T> = Quantity<typename T::value_type> 
 template<typename T>
 concept WrappedQuantity = detail::is_wrapped_quantity<T>;
 
-// Value
+// NumericValue
 
 namespace detail {
 
@@ -283,7 +283,7 @@ concept not_constructible_from_integral =
  * Satisfied by types that satisfy `(!Quantity<T>) && (!WrappedQuantity<T>) && std::regular<T>`.
  */
 template<typename T>
-concept Value =
+concept NumericValue =
   (!Quantity<T>) &&
   (!WrappedQuantity<T>) &&
   std::regular<T> &&

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -253,7 +253,7 @@ inline constexpr bool is_wrapped_quantity<T> = Quantity<typename T::value_type> 
 template<typename T>
 concept WrappedQuantity = detail::is_wrapped_quantity<T>;
 
-// Scalar
+// Value
 
 namespace detail {
 
@@ -283,7 +283,7 @@ concept not_constructible_from_integral =
  * Satisfied by types that satisfy `(!Quantity<T>) && (!WrappedQuantity<T>) && std::regular<T>`.
  */
 template<typename T>
-concept Scalar =
+concept Value =
   (!Quantity<T>) &&
   (!WrappedQuantity<T>) &&
   std::regular<T> &&

--- a/src/include/units/customization_points.h
+++ b/src/include/units/customization_points.h
@@ -37,7 +37,7 @@ namespace units {
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Value Rep>
+template<NumericValue Rep>
 inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
 
 /**
@@ -49,7 +49,7 @@ inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Value Rep>
+template<NumericValue Rep>
 struct quantity_values {
   static constexpr Rep zero() noexcept { return Rep(0); }
   static constexpr Rep one() noexcept { return Rep(1); }

--- a/src/include/units/customization_points.h
+++ b/src/include/units/customization_points.h
@@ -37,7 +37,7 @@ namespace units {
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Scalar Rep>
+template<Value Rep>
 inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
 
 /**
@@ -49,7 +49,7 @@ inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Scalar Rep>
+template<Value Rep>
 struct quantity_values {
   static constexpr Rep zero() noexcept { return Rep(0); }
   static constexpr Rep one() noexcept { return Rep(1); }

--- a/src/include/units/data/bitrate.h
+++ b/src/include/units/data/bitrate.h
@@ -41,7 +41,7 @@ struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibi
 template<typename T>
 concept Bitrate = QuantityOf<T, dim_bitrate>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using bitrate = quantity<dim_bitrate, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/bitrate.h
+++ b/src/include/units/data/bitrate.h
@@ -41,7 +41,7 @@ struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibi
 template<typename T>
 concept Bitrate = QuantityOf<T, dim_bitrate>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using bitrate = quantity<dim_bitrate, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -48,7 +48,7 @@ struct dim_information : base_dimension<"information", bit> {};
 template<typename T>
 concept Information = QuantityOf<T, dim_information>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using information = quantity<dim_information, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -48,7 +48,7 @@ struct dim_information : base_dimension<"information", bit> {};
 template<typename T>
 concept Information = QuantityOf<T, dim_information>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using information = quantity<dim_information, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/acceleration.h
+++ b/src/include/units/physical/cgs/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::cgs {
 struct gal : named_unit<gal, "Gal", si::prefix> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gal, dim_length, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/acceleration.h
+++ b/src/include/units/physical/cgs/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::cgs {
 struct gal : named_unit<gal, "Gal", si::prefix> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gal, dim_length, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/area.h
+++ b/src/include/units/physical/cgs/area.h
@@ -33,7 +33,7 @@ using si::square_centimetre;
 
 struct dim_area : physical::dim_area<dim_area, square_centimetre, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/area.h
+++ b/src/include/units/physical/cgs/area.h
@@ -33,7 +33,7 @@ using si::square_centimetre;
 
 struct dim_area : physical::dim_area<dim_area, square_centimetre, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/energy.h
+++ b/src/include/units/physical/cgs/energy.h
@@ -33,7 +33,7 @@ struct erg : named_unit<erg, "erg", si::prefix> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, erg, dim_force, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/energy.h
+++ b/src/include/units/physical/cgs/energy.h
@@ -33,7 +33,7 @@ struct erg : named_unit<erg, "erg", si::prefix> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, erg, dim_force, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/force.h
+++ b/src/include/units/physical/cgs/force.h
@@ -34,7 +34,7 @@ struct dyne : named_unit<dyne, "dyn", si::prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, dyne, dim_mass, dim_acceleration> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/force.h
+++ b/src/include/units/physical/cgs/force.h
@@ -34,7 +34,7 @@ struct dyne : named_unit<dyne, "dyn", si::prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, dyne, dim_mass, dim_acceleration> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/length.h
+++ b/src/include/units/physical/cgs/length.h
@@ -32,7 +32,7 @@ using si::centimetre;
 
 struct dim_length : physical::dim_length<centimetre> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/length.h
+++ b/src/include/units/physical/cgs/length.h
@@ -32,7 +32,7 @@ using si::centimetre;
 
 struct dim_length : physical::dim_length<centimetre> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/mass.h
+++ b/src/include/units/physical/cgs/mass.h
@@ -32,7 +32,7 @@ using si::gram;
 
 struct dim_mass : physical::dim_mass<gram> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/mass.h
+++ b/src/include/units/physical/cgs/mass.h
@@ -32,7 +32,7 @@ using si::gram;
 
 struct dim_mass : physical::dim_mass<gram> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/power.h
+++ b/src/include/units/physical/cgs/power.h
@@ -33,7 +33,7 @@ struct erg_per_second : unit<erg_per_second> {};
 
 struct dim_power : physical::dim_power<dim_power, erg_per_second, dim_energy, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/power.h
+++ b/src/include/units/physical/cgs/power.h
@@ -33,7 +33,7 @@ struct erg_per_second : unit<erg_per_second> {};
 
 struct dim_power : physical::dim_power<dim_power, erg_per_second, dim_energy, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/pressure.h
+++ b/src/include/units/physical/cgs/pressure.h
@@ -34,7 +34,7 @@ struct barye : named_unit<barye, "Ba", si::prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, barye, dim_force, dim_area> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/pressure.h
+++ b/src/include/units/physical/cgs/pressure.h
@@ -34,7 +34,7 @@ struct barye : named_unit<barye, "Ba", si::prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, barye, dim_force, dim_area> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/speed.h
+++ b/src/include/units/physical/cgs/speed.h
@@ -32,7 +32,7 @@ namespace units::physical::cgs {
 struct centimetre_per_second : unit<centimetre_per_second> {};
 struct dim_speed : physical::dim_speed<dim_speed, centimetre_per_second, dim_length, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/speed.h
+++ b/src/include/units/physical/cgs/speed.h
@@ -32,7 +32,7 @@ namespace units::physical::cgs {
 struct centimetre_per_second : unit<centimetre_per_second> {};
 struct dim_speed : physical::dim_speed<dim_speed, centimetre_per_second, dim_length, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/natural/constants.h
+++ b/src/include/units/physical/natural/constants.h
@@ -26,7 +26,7 @@
 
 namespace units::physical::natural {
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto speed_of_light = speed<unitless, Rep>(1);
 
 }  // namespace units::physical::natural

--- a/src/include/units/physical/natural/constants.h
+++ b/src/include/units/physical/natural/constants.h
@@ -26,7 +26,7 @@
 
 namespace units::physical::natural {
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto speed_of_light = speed<unitless, Rep>(1);
 
 }  // namespace units::physical::natural

--- a/src/include/units/physical/natural/dimensions.h
+++ b/src/include/units/physical/natural/dimensions.h
@@ -29,35 +29,35 @@
 namespace units::physical::natural {
 
 struct dim_length : physical::dim_length<inverted_gigaelectronvolt> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 struct dim_time : physical::dim_time<inverted_gigaelectronvolt> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 struct dim_mass : physical::dim_mass<gigaelectronvolt> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 struct dim_speed : physical::dim_speed<dim_speed, unitless, dim_length, dim_time> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gigaelectronvolt, dim_length, dim_time> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 struct dim_force : physical::dim_force<dim_force, square_gigaelectronvolt, dim_mass, dim_acceleration> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 struct dim_momentum : physical::dim_momentum<dim_momentum, gigaelectronvolt, dim_mass, dim_speed> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 struct dim_energy : physical::dim_energy<dim_energy, gigaelectronvolt, dim_force, dim_length> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using energy = quantity<dim_force, U, Rep>;
 
 // Typical UDLs will not work here as the same units are reused by many quantities.

--- a/src/include/units/physical/natural/dimensions.h
+++ b/src/include/units/physical/natural/dimensions.h
@@ -29,35 +29,35 @@
 namespace units::physical::natural {
 
 struct dim_length : physical::dim_length<inverted_gigaelectronvolt> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 struct dim_time : physical::dim_time<inverted_gigaelectronvolt> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 struct dim_mass : physical::dim_mass<gigaelectronvolt> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 struct dim_speed : physical::dim_speed<dim_speed, unitless, dim_length, dim_time> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gigaelectronvolt, dim_length, dim_time> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 struct dim_force : physical::dim_force<dim_force, square_gigaelectronvolt, dim_mass, dim_acceleration> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 struct dim_momentum : physical::dim_momentum<dim_momentum, gigaelectronvolt, dim_mass, dim_speed> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 struct dim_energy : physical::dim_energy<dim_energy, gigaelectronvolt, dim_force, dim_length> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using energy = quantity<dim_force, U, Rep>;
 
 // Typical UDLs will not work here as the same units are reused by many quantities.

--- a/src/include/units/physical/si/absorbed_dose.h
+++ b/src/include/units/physical/si/absorbed_dose.h
@@ -54,7 +54,7 @@ struct yottagray : prefixed_unit<yottagray, yotta, gray> {};
 
 struct dim_absorbed_dose : physical::dim_absorbed_dose<dim_absorbed_dose, gray, dim_energy, dim_mass> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using absorbed_dose = quantity<dim_absorbed_dose, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/absorbed_dose.h
+++ b/src/include/units/physical/si/absorbed_dose.h
@@ -54,7 +54,7 @@ struct yottagray : prefixed_unit<yottagray, yotta, gray> {};
 
 struct dim_absorbed_dose : physical::dim_absorbed_dose<dim_absorbed_dose, gray, dim_energy, dim_mass> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using absorbed_dose = quantity<dim_absorbed_dose, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/acceleration.h
+++ b/src/include/units/physical/si/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct metre_per_second_sq : unit<metre_per_second_sq> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, metre_per_second_sq, dim_length, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/acceleration.h
+++ b/src/include/units/physical/si/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct metre_per_second_sq : unit<metre_per_second_sq> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, metre_per_second_sq, dim_length, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/angle.h
+++ b/src/include/units/physical/si/angle.h
@@ -32,7 +32,7 @@ struct radian : named_unit<radian, "rad", prefix> {};
 
 struct dim_angle : physical::dim_angle<radian> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using angle = quantity<dim_angle, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/angle.h
+++ b/src/include/units/physical/si/angle.h
@@ -32,7 +32,7 @@ struct radian : named_unit<radian, "rad", prefix> {};
 
 struct dim_angle : physical::dim_angle<radian> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using angle = quantity<dim_angle, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -54,7 +54,7 @@ struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre>
 
 struct hectare : alias_unit<square_hectometre, "ha", no_prefix> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -54,7 +54,7 @@ struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre>
 
 struct hectare : alias_unit<square_hectometre, "ha", no_prefix> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -54,7 +54,7 @@ struct yottafarad : prefixed_unit<yottafarad, yotta, farad> {};
 
 struct dim_capacitance : physical::dim_capacitance<dim_capacitance, farad, dim_electric_charge, dim_voltage> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using capacitance = quantity<dim_capacitance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -54,7 +54,7 @@ struct yottafarad : prefixed_unit<yottafarad, yotta, farad> {};
 
 struct dim_capacitance : physical::dim_capacitance<dim_capacitance, farad, dim_electric_charge, dim_voltage> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using capacitance = quantity<dim_capacitance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/catalytic_activity.h
+++ b/src/include/units/physical/si/catalytic_activity.h
@@ -56,7 +56,7 @@ struct enzyme_unit : named_scaled_unit<enzyme_unit, "U", prefix, ratio<1, 60, -6
 
 struct dim_catalytic_activity : physical::dim_catalytic_activity<dim_catalytic_activity, katal, dim_time, dim_substance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using catalytic_activity = quantity<dim_catalytic_activity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/catalytic_activity.h
+++ b/src/include/units/physical/si/catalytic_activity.h
@@ -56,7 +56,7 @@ struct enzyme_unit : named_scaled_unit<enzyme_unit, "U", prefix, ratio<1, 60, -6
 
 struct dim_catalytic_activity : physical::dim_catalytic_activity<dim_catalytic_activity, katal, dim_time, dim_substance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using catalytic_activity = quantity<dim_catalytic_activity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/charge_density.h
+++ b/src/include/units/physical/si/charge_density.h
@@ -36,10 +36,10 @@ struct coulomb_per_metre_sq : unit<coulomb_per_metre_sq> {};
 struct dim_charge_density : physical::dim_charge_density<dim_charge_density, coulomb_per_metre_cub, dim_electric_charge, dim_length> {};
 struct dim_surface_charge_density : physical::dim_surface_charge_density<dim_surface_charge_density, coulomb_per_metre_sq, dim_electric_charge, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using charge_density = quantity<dim_charge_density, U, Rep>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using surface_charge_density = quantity<dim_surface_charge_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/charge_density.h
+++ b/src/include/units/physical/si/charge_density.h
@@ -36,10 +36,10 @@ struct coulomb_per_metre_sq : unit<coulomb_per_metre_sq> {};
 struct dim_charge_density : physical::dim_charge_density<dim_charge_density, coulomb_per_metre_cub, dim_electric_charge, dim_length> {};
 struct dim_surface_charge_density : physical::dim_surface_charge_density<dim_surface_charge_density, coulomb_per_metre_sq, dim_electric_charge, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using charge_density = quantity<dim_charge_density, U, Rep>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using surface_charge_density = quantity<dim_surface_charge_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/concentration.h
+++ b/src/include/units/physical/si/concentration.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct mol_per_metre_cub : unit<mol_per_metre_cub> {};
 struct dim_concentration : physical::dim_concentration<dim_concentration, mol_per_metre_cub, dim_substance, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using concentration = quantity<dim_concentration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/concentration.h
+++ b/src/include/units/physical/si/concentration.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct mol_per_metre_cub : unit<mol_per_metre_cub> {};
 struct dim_concentration : physical::dim_concentration<dim_concentration, mol_per_metre_cub, dim_substance, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using concentration = quantity<dim_concentration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/conductance.h
+++ b/src/include/units/physical/si/conductance.h
@@ -49,7 +49,7 @@ struct yottasiemens : prefixed_unit<yottasiemens, yotta, siemens> {};
 
 struct dim_conductance : physical::dim_conductance<dim_conductance, siemens, dim_resistance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using conductance = quantity<dim_conductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/conductance.h
+++ b/src/include/units/physical/si/conductance.h
@@ -49,7 +49,7 @@ struct yottasiemens : prefixed_unit<yottasiemens, yotta, siemens> {};
 
 struct dim_conductance : physical::dim_conductance<dim_conductance, siemens, dim_resistance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using conductance = quantity<dim_conductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/constants.h
+++ b/src/include/units/physical/si/constants.h
@@ -32,31 +32,31 @@
 
 namespace units::physical::si::si2019 {
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto planck_constant = energy<joule, Rep>(6.62607015e-34) * time<second, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto reduced_planck_constant = energy<gigaelectronvolt, Rep>(6.582119569e-10) * time<second, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto elementary_charge = electric_charge<coulomb, Rep>(1.602176634e-19);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto boltzmann_constant = energy<joule, Rep>(1.380649e-23) / temperature<kelvin, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto avogadro_constant = Rep(6.02214076e23) / substance<mole, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto speed_of_light = speed<metre_per_second, Rep>(299'792'458);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto hyperfine_structure_transition_frequency = frequency<hertz, Rep>(9'192'631'770);
 
-// template<Value Rep = double>
+// template<NumericValue Rep = double>
 // inline constexpr auto luminous_efficacy = 683q_lm / 1q_W;
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto standard_gravity = acceleration<metre_per_second_sq, Rep>(9.80665);
 
 }  // namespace units::physical::si::si2019

--- a/src/include/units/physical/si/constants.h
+++ b/src/include/units/physical/si/constants.h
@@ -32,31 +32,31 @@
 
 namespace units::physical::si::si2019 {
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto planck_constant = energy<joule, Rep>(6.62607015e-34) * time<second, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto reduced_planck_constant = energy<gigaelectronvolt, Rep>(6.582119569e-10) * time<second, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto elementary_charge = electric_charge<coulomb, Rep>(1.602176634e-19);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto boltzmann_constant = energy<joule, Rep>(1.380649e-23) / temperature<kelvin, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto avogadro_constant = Rep(6.02214076e23) / substance<mole, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto speed_of_light = speed<metre_per_second, Rep>(299'792'458);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto hyperfine_structure_transition_frequency = frequency<hertz, Rep>(9'192'631'770);
 
-// template<Scalar Rep = double>
+// template<Value Rep = double>
 // inline constexpr auto luminous_efficacy = 683q_lm / 1q_W;
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto standard_gravity = acceleration<metre_per_second_sq, Rep>(9.80665);
 
 }  // namespace units::physical::si::si2019

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -52,7 +52,7 @@ struct yottaampere : prefixed_unit<yottaampere, yotta, ampere> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using current = quantity<dim_electric_current, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -52,7 +52,7 @@ struct yottaampere : prefixed_unit<yottaampere, yotta, ampere> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using current = quantity<dim_electric_current, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current_density.h
+++ b/src/include/units/physical/si/current_density.h
@@ -34,7 +34,7 @@ struct ampere_per_metre_sq : unit<ampere_per_metre_sq> {};
 
 struct dim_current_density : physical::dim_current_density<dim_current_density, ampere_per_metre_sq, dim_electric_current, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using current_density = quantity<dim_current_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current_density.h
+++ b/src/include/units/physical/si/current_density.h
@@ -34,7 +34,7 @@ struct ampere_per_metre_sq : unit<ampere_per_metre_sq> {};
 
 struct dim_current_density : physical::dim_current_density<dim_current_density, ampere_per_metre_sq, dim_electric_current, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using current_density = quantity<dim_current_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/density.h
+++ b/src/include/units/physical/si/density.h
@@ -34,7 +34,7 @@ struct kilogram_per_metre_cub : unit<kilogram_per_metre_cub> {};
 
 struct dim_density : physical::dim_density<dim_density, kilogram_per_metre_cub, dim_mass, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using density = quantity<dim_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/density.h
+++ b/src/include/units/physical/si/density.h
@@ -34,7 +34,7 @@ struct kilogram_per_metre_cub : unit<kilogram_per_metre_cub> {};
 
 struct dim_density : physical::dim_density<dim_density, kilogram_per_metre_cub, dim_mass, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using density = quantity<dim_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/dynamic_viscosity.h
+++ b/src/include/units/physical/si/dynamic_viscosity.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct pascal_second : unit<pascal_second> {};
 struct dim_dynamic_viscosity : physical::dim_dynamic_viscosity<dim_dynamic_viscosity, pascal_second, dim_pressure, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using dynamic_viscosity = quantity<dim_dynamic_viscosity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/dynamic_viscosity.h
+++ b/src/include/units/physical/si/dynamic_viscosity.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct pascal_second : unit<pascal_second> {};
 struct dim_dynamic_viscosity : physical::dim_dynamic_viscosity<dim_dynamic_viscosity, pascal_second, dim_pressure, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using dynamic_viscosity = quantity<dim_dynamic_viscosity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_charge.h
+++ b/src/include/units/physical/si/electric_charge.h
@@ -33,7 +33,7 @@ struct coulomb : named_unit<coulomb, "C", prefix> {};
 
 struct dim_electric_charge : physical::dim_electric_charge<dim_electric_charge, coulomb, dim_time, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using electric_charge = quantity<dim_electric_charge, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_charge.h
+++ b/src/include/units/physical/si/electric_charge.h
@@ -33,7 +33,7 @@ struct coulomb : named_unit<coulomb, "C", prefix> {};
 
 struct dim_electric_charge : physical::dim_electric_charge<dim_electric_charge, coulomb, dim_time, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using electric_charge = quantity<dim_electric_charge, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_field_strength.h
+++ b/src/include/units/physical/si/electric_field_strength.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct volt_per_metre : unit<volt_per_metre> {};
 struct dim_electric_field_strength : physical::dim_electric_field_strength<dim_electric_field_strength, volt_per_metre, dim_voltage, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using electric_field_strength = quantity<dim_electric_field_strength, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_field_strength.h
+++ b/src/include/units/physical/si/electric_field_strength.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct volt_per_metre : unit<volt_per_metre> {};
 struct dim_electric_field_strength : physical::dim_electric_field_strength<dim_electric_field_strength, volt_per_metre, dim_voltage, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using electric_field_strength = quantity<dim_electric_field_strength, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -52,7 +52,7 @@ struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {}
 
 struct dim_energy : physical::dim_energy<dim_energy, joule, dim_force, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -52,7 +52,7 @@ struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {}
 
 struct dim_energy : physical::dim_energy<dim_energy, joule, dim_force, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -54,7 +54,7 @@ struct yottanewton : prefixed_unit<yottanewton, yotta, newton> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -54,7 +54,7 @@ struct yottanewton : prefixed_unit<yottanewton, yotta, newton> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -48,7 +48,7 @@ struct yottahertz : prefixed_unit<yottahertz, yotta, hertz> {};
 
 struct dim_frequency : physical::dim_frequency<dim_frequency, hertz, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using frequency = quantity<dim_frequency, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -48,7 +48,7 @@ struct yottahertz : prefixed_unit<yottahertz, yotta, hertz> {};
 
 struct dim_frequency : physical::dim_frequency<dim_frequency, hertz, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using frequency = quantity<dim_frequency, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/heat_capacity.h
+++ b/src/include/units/physical/si/heat_capacity.h
@@ -39,13 +39,13 @@ struct dim_heat_capacity : physical::dim_heat_capacity<dim_heat_capacity, joule_
 struct dim_specific_heat_capacity : physical::dim_specific_heat_capacity<dim_specific_heat_capacity, joule_per_kilogram_kelvin, dim_heat_capacity, dim_mass> {};
 struct dim_molar_heat_capacity : physical::dim_molar_heat_capacity<dim_molar_heat_capacity, joule_per_mole_kelvin, dim_heat_capacity, dim_substance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using heat_capacity = quantity<dim_heat_capacity, U, Rep>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using specific_heat_capacity = quantity<dim_specific_heat_capacity, U, Rep>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using molar_heat_capacity = quantity<dim_molar_heat_capacity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/heat_capacity.h
+++ b/src/include/units/physical/si/heat_capacity.h
@@ -39,13 +39,13 @@ struct dim_heat_capacity : physical::dim_heat_capacity<dim_heat_capacity, joule_
 struct dim_specific_heat_capacity : physical::dim_specific_heat_capacity<dim_specific_heat_capacity, joule_per_kilogram_kelvin, dim_heat_capacity, dim_mass> {};
 struct dim_molar_heat_capacity : physical::dim_molar_heat_capacity<dim_molar_heat_capacity, joule_per_mole_kelvin, dim_heat_capacity, dim_substance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using heat_capacity = quantity<dim_heat_capacity, U, Rep>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using specific_heat_capacity = quantity<dim_specific_heat_capacity, U, Rep>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using molar_heat_capacity = quantity<dim_molar_heat_capacity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/inductance.h
+++ b/src/include/units/physical/si/inductance.h
@@ -50,7 +50,7 @@ struct yottahenry : prefixed_unit<yottahenry, yotta, henry> {};
 
 struct dim_inductance : physical::dim_inductance<dim_inductance, henry, dim_magnetic_flux, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using inductance = quantity<dim_inductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/inductance.h
+++ b/src/include/units/physical/si/inductance.h
@@ -50,7 +50,7 @@ struct yottahenry : prefixed_unit<yottahenry, yotta, henry> {};
 
 struct dim_inductance : physical::dim_inductance<dim_inductance, henry, dim_magnetic_flux, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using inductance = quantity<dim_inductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -54,7 +54,7 @@ struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix,
 
 struct dim_length : physical::dim_length<metre> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -54,7 +54,7 @@ struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix,
 
 struct dim_length : physical::dim_length<metre> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminance.h
+++ b/src/include/units/physical/si/luminance.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct candela_per_metre_sq : unit<candela_per_metre_sq> {};
 struct dim_luminance : physical::dim_luminance<dim_luminance, candela_per_metre_sq, dim_luminous_intensity, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using luminance = quantity<dim_luminance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminance.h
+++ b/src/include/units/physical/si/luminance.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct candela_per_metre_sq : unit<candela_per_metre_sq> {};
 struct dim_luminance : physical::dim_luminance<dim_luminance, candela_per_metre_sq, dim_luminous_intensity, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using luminance = quantity<dim_luminance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -52,7 +52,7 @@ struct yottacandela : prefixed_unit<yottacandela, yotta, candela> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using luminous_intensity = quantity<dim_luminous_intensity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -52,7 +52,7 @@ struct yottacandela : prefixed_unit<yottacandela, yotta, candela> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using luminous_intensity = quantity<dim_luminous_intensity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_flux.h
+++ b/src/include/units/physical/si/magnetic_flux.h
@@ -50,7 +50,7 @@ struct yottaweber : prefixed_unit<yottaweber, yotta, weber> {};
 
 struct dim_magnetic_flux : physical::dim_magnetic_flux<dim_magnetic_flux, weber, dim_magnetic_induction, dim_area> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using magnetic_flux = quantity<dim_magnetic_flux, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_flux.h
+++ b/src/include/units/physical/si/magnetic_flux.h
@@ -50,7 +50,7 @@ struct yottaweber : prefixed_unit<yottaweber, yotta, weber> {};
 
 struct dim_magnetic_flux : physical::dim_magnetic_flux<dim_magnetic_flux, weber, dim_magnetic_induction, dim_area> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using magnetic_flux = quantity<dim_magnetic_flux, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_induction.h
+++ b/src/include/units/physical/si/magnetic_induction.h
@@ -54,7 +54,7 @@ struct gauss : named_scaled_unit<gauss, "G", prefix, ratio<1, 10'000>, tesla> {}
 
 struct dim_magnetic_induction : physical::dim_magnetic_induction<dim_magnetic_induction, tesla, dim_voltage, dim_time, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using magnetic_induction = quantity<dim_magnetic_induction, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_induction.h
+++ b/src/include/units/physical/si/magnetic_induction.h
@@ -54,7 +54,7 @@ struct gauss : named_scaled_unit<gauss, "G", prefix, ratio<1, 10'000>, tesla> {}
 
 struct dim_magnetic_induction : physical::dim_magnetic_induction<dim_magnetic_induction, tesla, dim_voltage, dim_time, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using magnetic_induction = quantity<dim_magnetic_induction, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -76,7 +76,7 @@ struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'
 
 struct dim_mass : physical::dim_mass<kilogram> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -76,7 +76,7 @@ struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'
 
 struct dim_mass : physical::dim_mass<kilogram> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/molar_energy.h
+++ b/src/include/units/physical/si/molar_energy.h
@@ -34,7 +34,7 @@ struct joule_per_mole : unit<joule_per_mole> {};
 
 struct dim_molar_energy : physical::dim_molar_energy<dim_molar_energy, joule_per_mole, dim_energy, dim_substance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using molar_energy = quantity<dim_molar_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/molar_energy.h
+++ b/src/include/units/physical/si/molar_energy.h
@@ -34,7 +34,7 @@ struct joule_per_mole : unit<joule_per_mole> {};
 
 struct dim_molar_energy : physical::dim_molar_energy<dim_molar_energy, joule_per_mole, dim_energy, dim_substance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using molar_energy = quantity<dim_molar_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/momentum.h
+++ b/src/include/units/physical/si/momentum.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct kilogram_metre_per_second : unit<kilogram_metre_per_second> {};
 struct dim_momentum : physical::dim_momentum<dim_momentum, kilogram_metre_per_second, dim_mass, dim_speed> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/momentum.h
+++ b/src/include/units/physical/si/momentum.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct kilogram_metre_per_second : unit<kilogram_metre_per_second> {};
 struct dim_momentum : physical::dim_momentum<dim_momentum, kilogram_metre_per_second, dim_mass, dim_speed> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permeability.h
+++ b/src/include/units/physical/si/permeability.h
@@ -33,7 +33,7 @@ struct henry_per_metre : unit<henry_per_metre> {};
 
 struct dim_permeability : physical::dim_permeability<dim_permeability, henry_per_metre, dim_inductance, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using permeability = quantity<dim_permeability, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permeability.h
+++ b/src/include/units/physical/si/permeability.h
@@ -33,7 +33,7 @@ struct henry_per_metre : unit<henry_per_metre> {};
 
 struct dim_permeability : physical::dim_permeability<dim_permeability, henry_per_metre, dim_inductance, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using permeability = quantity<dim_permeability, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permittivity.h
+++ b/src/include/units/physical/si/permittivity.h
@@ -33,7 +33,7 @@ struct farad_per_metre : unit<farad_per_metre> {};
 
 struct dim_permittivity : physical::dim_permittivity<dim_permittivity, farad_per_metre, dim_capacitance, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using permittivity = quantity<dim_permittivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permittivity.h
+++ b/src/include/units/physical/si/permittivity.h
@@ -33,7 +33,7 @@ struct farad_per_metre : unit<farad_per_metre> {};
 
 struct dim_permittivity : physical::dim_permittivity<dim_permittivity, farad_per_metre, dim_capacitance, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using permittivity = quantity<dim_permittivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -49,7 +49,7 @@ struct yottawatt : prefixed_unit<yottawatt, yotta, watt> {};
 
 struct dim_power : physical::dim_power<dim_power, watt, dim_energy, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -49,7 +49,7 @@ struct yottawatt : prefixed_unit<yottawatt, yotta, watt> {};
 
 struct dim_power : physical::dim_power<dim_power, watt, dim_energy, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -54,7 +54,7 @@ struct yottapascal : prefixed_unit<yottapascal, yotta, pascal> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -54,7 +54,7 @@ struct yottapascal : prefixed_unit<yottapascal, yotta, pascal> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -50,7 +50,7 @@ struct yottaohm : prefixed_unit<yottaohm, yotta, ohm> {};
 
 struct dim_resistance : physical::dim_resistance<dim_resistance, ohm, dim_voltage, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using resistance = quantity<dim_resistance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -50,7 +50,7 @@ struct yottaohm : prefixed_unit<yottaohm, yotta, ohm> {};
 
 struct dim_resistance : physical::dim_resistance<dim_resistance, ohm, dim_voltage, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using resistance = quantity<dim_resistance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/speed.h
+++ b/src/include/units/physical/si/speed.h
@@ -34,7 +34,7 @@ struct dim_speed : physical::dim_speed<dim_speed, metre_per_second, dim_length, 
 
 struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_speed, kilometre, hour> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/speed.h
+++ b/src/include/units/physical/si/speed.h
@@ -34,7 +34,7 @@ struct dim_speed : physical::dim_speed<dim_speed, metre_per_second, dim_length, 
 
 struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_speed, kilometre, hour> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -32,7 +32,7 @@ struct mole : named_unit<metre, "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using substance = quantity<dim_substance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -32,7 +32,7 @@ struct mole : named_unit<metre, "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using substance = quantity<dim_substance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/surface_tension.h
+++ b/src/include/units/physical/si/surface_tension.h
@@ -32,7 +32,7 @@ struct newton_per_metre : unit<newton_per_metre> {};
 
 struct dim_surface_tension : physical::dim_surface_tension<dim_surface_tension, newton_per_metre, dim_force, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using surface_tension = quantity<dim_surface_tension, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/surface_tension.h
+++ b/src/include/units/physical/si/surface_tension.h
@@ -32,7 +32,7 @@ struct newton_per_metre : unit<newton_per_metre> {};
 
 struct dim_surface_tension : physical::dim_surface_tension<dim_surface_tension, newton_per_metre, dim_force, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using surface_tension = quantity<dim_surface_tension, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/temperature.h
+++ b/src/include/units/physical/si/temperature.h
@@ -31,7 +31,7 @@ struct kelvin : named_unit<kelvin, "K", no_prefix> {};
 
 struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<kelvin> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using temperature = quantity<dim_thermodynamic_temperature, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/temperature.h
+++ b/src/include/units/physical/si/temperature.h
@@ -31,7 +31,7 @@ struct kelvin : named_unit<kelvin, "K", no_prefix> {};
 
 struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<kelvin> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using temperature = quantity<dim_thermodynamic_temperature, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/thermal_conductivity.h
+++ b/src/include/units/physical/si/thermal_conductivity.h
@@ -33,7 +33,7 @@ struct watt_per_metre_kelvin : unit<watt_per_metre_kelvin> {};
 
 struct dim_thermal_conductivity : physical::dim_thermal_conductivity<dim_thermal_conductivity, watt_per_metre_kelvin, dim_power, dim_length, dim_thermodynamic_temperature> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using thermal_conductivity = quantity<dim_thermal_conductivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/thermal_conductivity.h
+++ b/src/include/units/physical/si/thermal_conductivity.h
@@ -33,7 +33,7 @@ struct watt_per_metre_kelvin : unit<watt_per_metre_kelvin> {};
 
 struct dim_thermal_conductivity : physical::dim_thermal_conductivity<dim_thermal_conductivity, watt_per_metre_kelvin, dim_power, dim_length, dim_thermodynamic_temperature> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using thermal_conductivity = quantity<dim_thermal_conductivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -43,7 +43,7 @@ struct day : named_scaled_unit<hour, "d", no_prefix, ratio<24>, hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -43,7 +43,7 @@ struct day : named_scaled_unit<hour, "d", no_prefix, ratio<24>, hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/torque.h
+++ b/src/include/units/physical/si/torque.h
@@ -34,7 +34,7 @@ struct newton_metre : named_unit<newton_metre, "Nm", prefix> {};
 
 struct dim_torque : physical::dim_torque<dim_torque, newton_metre, dim_energy, dim_angle> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using torque = quantity<dim_torque, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/torque.h
+++ b/src/include/units/physical/si/torque.h
@@ -34,7 +34,7 @@ struct newton_metre : named_unit<newton_metre, "Nm", prefix> {};
 
 struct dim_torque : physical::dim_torque<dim_torque, newton_metre, dim_energy, dim_angle> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using torque = quantity<dim_torque, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -54,7 +54,7 @@ struct yottavolt : prefixed_unit<yottavolt, yotta, volt> {};
 
 struct dim_voltage : physical::dim_voltage<dim_voltage, volt, dim_power, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using voltage = quantity<dim_voltage, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -54,7 +54,7 @@ struct yottavolt : prefixed_unit<yottavolt, yotta, volt> {};
 
 struct dim_voltage : physical::dim_voltage<dim_voltage, volt, dim_power, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using voltage = quantity<dim_voltage, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -74,7 +74,7 @@ struct exalitre : prefixed_unit<petalitre, exa, litre> {};
 struct zettalitre : prefixed_alias_unit<cubic_megametre, zetta, litre> {};
 struct yottalitre : prefixed_unit<yottalitre, yotta, litre> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -74,7 +74,7 @@ struct exalitre : prefixed_unit<petalitre, exa, litre> {};
 struct zettalitre : prefixed_alias_unit<cubic_megametre, zetta, litre> {};
 struct yottalitre : prefixed_unit<yottalitre, yotta, litre> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -60,7 +60,7 @@ concept safe_divisible = // exposition only
  * @tparam U a measurement unit of the quantity
  * @tparam Rep a type to be used to represent values of a quantity
  */
-template<Dimension D, UnitOf<D> U, Scalar Rep = double>
+template<Dimension D, UnitOf<D> U, Value Rep = double>
 class quantity {
   Rep value_{};
 
@@ -73,9 +73,9 @@ public:
   quantity(const quantity&) = default;
   quantity(quantity&&) = default;
 
-  template<Scalar Value>
-    requires detail::safe_convertible<Value, rep>
-  constexpr explicit quantity(const Value& v) : value_{static_cast<rep>(v)} {}
+  template<Value Val>
+    requires detail::safe_convertible<Val, rep>
+  constexpr explicit quantity(const Val& v) : value_{static_cast<rep>(v)} {}
 
   template<Quantity Q2>
     requires equivalent_dim<D, typename Q2::dimension> &&
@@ -200,11 +200,11 @@ public:
     return *this;
   }
 
-  template<Scalar Value, typename T = Rep>
-  constexpr quantity& operator%=(const Value& rhs)
+  template<Value Val, typename T = Rep>
+  constexpr quantity& operator%=(const Val& rhs)
     requires (!treat_as_floating_point<rep>) &&
-             (!treat_as_floating_point<Value>) &&
-             requires(T v1, Value v2) { { v1 %= v2 } -> SAME_AS(T&); }
+             (!treat_as_floating_point<Val>) &&
+             requires(T v1, Val v2) { { v1 %= v2 } -> SAME_AS(T&); }
   //  requires(rep v1, Value v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
   {
     value_ %= rhs;
@@ -322,24 +322,24 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::multiplies<>, Rep, Value>
+template<typename D, typename U, typename Rep, Value Val>
+[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Val& v)
+  requires std::regular_invocable<std::multiplies<>, Rep, Val>
 {
   using common_rep = decltype(q.count() * v);
   using ret = quantity<D, U, common_rep>;
   return ret(q.count() * v);
 }
 
-template<Scalar Value, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::multiplies<>, Value, Rep>
+template<Value Val, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr Quantity AUTO operator*(const Val& v, const quantity<D, U, Rep>& q)
+  requires std::regular_invocable<std::multiplies<>, Val, Rep>
 {
   return q * v;
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Scalar AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr Value AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::multiplies<>, Rep1, Rep2> &&
            equivalent_dim<D1, dim_invert<D2>>
 {
@@ -366,9 +366,9 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() * rhs.count());
 }
 
-template<Scalar Value, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::divides<>, Value, Rep>
+template<Value Val, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr Quantity AUTO operator/(const Val& v, const quantity<D, U, Rep>& q)
+  requires std::regular_invocable<std::divides<>, Val, Rep>
 {
   Expects(q.count() != 0);
 
@@ -380,11 +380,11 @@ template<Scalar Value, typename D, typename U, typename Rep>
   return ret(v / q.count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::divides<>, Rep, Value>
+template<typename D, typename U, typename Rep, Value Val>
+[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Val& v)
+  requires std::regular_invocable<std::divides<>, Rep, Val>
 {
-  Expects(v != Value{0});
+  Expects(v != Val{0});
 
   using common_rep = decltype(q.count() / v);
   using ret = quantity<D, U, common_rep>;
@@ -392,7 +392,7 @@ template<typename D, typename U, typename Rep, Scalar Value>
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Scalar AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr Value AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::divides<>, Rep1, Rep2> &&
            equivalent_dim<D1, D2>
 {
@@ -419,11 +419,11 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() / rhs.count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Value& v)
+template<typename D, typename U, typename Rep, Value Val>
+[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Val& v)
   requires (!treat_as_floating_point<Rep>) &&
-           (!treat_as_floating_point<Value>) &&
-           std::regular_invocable<std::modulus<>, Rep, Value>
+           (!treat_as_floating_point<Val>) &&
+           std::regular_invocable<std::modulus<>, Rep, Val>
 {
   using common_rep = decltype(q.count() % v);
   using ret = quantity<D, U, common_rep>;

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -60,7 +60,7 @@ concept safe_divisible = // exposition only
  * @tparam U a measurement unit of the quantity
  * @tparam Rep a type to be used to represent values of a quantity
  */
-template<Dimension D, UnitOf<D> U, Value Rep = double>
+template<Dimension D, UnitOf<D> U, NumericValue Rep = double>
 class quantity {
   Rep value_{};
 
@@ -73,7 +73,7 @@ public:
   quantity(const quantity&) = default;
   quantity(quantity&&) = default;
 
-  template<Value Val>
+  template<NumericValue Val>
     requires detail::safe_convertible<Val, rep>
   constexpr explicit quantity(const Val& v) : value_{static_cast<rep>(v)} {}
 
@@ -200,12 +200,12 @@ public:
     return *this;
   }
 
-  template<Value Val, typename T = Rep>
+  template<NumericValue Val, typename T = Rep>
   constexpr quantity& operator%=(const Val& rhs)
     requires (!treat_as_floating_point<rep>) &&
              (!treat_as_floating_point<Val>) &&
              requires(T v1, Val v2) { { v1 %= v2 } -> SAME_AS(T&); }
-  //  requires(rep v1, Value v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
+  //  requires(rep v1, NumericValue v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
   {
     value_ %= rhs;
     return *this;
@@ -322,7 +322,7 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, Value Val>
+template<typename D, typename U, typename Rep, NumericValue Val>
 [[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Val& v)
   requires std::regular_invocable<std::multiplies<>, Rep, Val>
 {
@@ -331,7 +331,7 @@ template<typename D, typename U, typename Rep, Value Val>
   return ret(q.count() * v);
 }
 
-template<Value Val, typename D, typename U, typename Rep>
+template<NumericValue Val, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator*(const Val& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::multiplies<>, Val, Rep>
 {
@@ -339,7 +339,7 @@ template<Value Val, typename D, typename U, typename Rep>
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Value AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr NumericValue AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::multiplies<>, Rep1, Rep2> &&
            equivalent_dim<D1, dim_invert<D2>>
 {
@@ -366,7 +366,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() * rhs.count());
 }
 
-template<Value Val, typename D, typename U, typename Rep>
+template<NumericValue Val, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator/(const Val& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::divides<>, Val, Rep>
 {
@@ -380,7 +380,7 @@ template<Value Val, typename D, typename U, typename Rep>
   return ret(v / q.count());
 }
 
-template<typename D, typename U, typename Rep, Value Val>
+template<typename D, typename U, typename Rep, NumericValue Val>
 [[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Val& v)
   requires std::regular_invocable<std::divides<>, Rep, Val>
 {
@@ -392,7 +392,7 @@ template<typename D, typename U, typename Rep, Value Val>
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Value AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr NumericValue AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::divides<>, Rep1, Rep2> &&
            equivalent_dim<D1, D2>
 {
@@ -419,7 +419,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() / rhs.count());
 }
 
-template<typename D, typename U, typename Rep, Value Val>
+template<typename D, typename U, typename Rep, NumericValue Val>
 [[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Val& v)
   requires (!treat_as_floating_point<Rep>) &&
            (!treat_as_floating_point<Val>) &&

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -386,7 +386,7 @@ template<Unit ToU, typename D, typename U, typename Rep>
  *
  * @tparam ToRep a representation type to use for a target quantity
  */
-template<Value ToRep, typename D, typename U, typename Rep>
+template<NumericValue ToRep, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
 {
   return quantity_cast<quantity<D, U, ToRep>>(q);

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -386,7 +386,7 @@ template<Unit ToU, typename D, typename U, typename Rep>
  *
  * @tparam ToRep a representation type to use for a target quantity
  */
-template<Scalar ToRep, typename D, typename U, typename Rep>
+template<Value ToRep, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
 {
   return quantity_cast<quantity<D, U, ToRep>>(q);

--- a/test/unit_test/static/custom_rep_min_req_test.cpp
+++ b/test/unit_test/static/custom_rep_min_req_test.cpp
@@ -85,7 +85,7 @@ using impl_impl = impl_constructible_impl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_impl<float>>);
 static_assert(std::convertible_to<impl_impl<float>, float>);
-static_assert(units::Value<impl_impl<float>>);
+static_assert(units::NumericValue<impl_impl<float>>);
 
 template<typename T>
 struct expl_constructible_impl_convertible : scalar_ops<expl_constructible_impl_convertible<T>> {
@@ -100,7 +100,7 @@ using expl_impl = expl_constructible_impl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_impl<float>>);
 static_assert(std::convertible_to<expl_impl<float>, float>);
-static_assert(units::Value<expl_impl<float>>);
+static_assert(units::NumericValue<expl_impl<float>>);
 
 template<typename T>
 struct impl_constructible_expl_convertible : scalar_ops<impl_constructible_expl_convertible<T>> {
@@ -115,7 +115,7 @@ using impl_expl = impl_constructible_expl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_expl<float>>);
 static_assert(!std::convertible_to<impl_expl<float>, float>);
-static_assert(units::Value<impl_expl<float>>);
+static_assert(units::NumericValue<impl_expl<float>>);
 
 template<typename T>
 struct expl_constructible_expl_convertible : scalar_ops<expl_constructible_expl_convertible<T>> {
@@ -130,7 +130,7 @@ using expl_expl = expl_constructible_expl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_expl<float>>);
 static_assert(!std::convertible_to<expl_expl<float>, float>);
-static_assert(units::Value<expl_expl<float>>);
+static_assert(units::NumericValue<expl_expl<float>>);
 
 }  // namespace
 
@@ -169,7 +169,7 @@ using namespace units::physical::si;
 
 // constructors
 
-// Quantity from Value
+// Quantity from NumericValue
 // int <- int
 static_assert(length<metre, int>(expl_impl<int>(1)).count() == 1);
 // static_assert(length<metre, int>(impl_expl<int>(1)).count() == 1);  // should not compile (not convertible)

--- a/test/unit_test/static/custom_rep_min_req_test.cpp
+++ b/test/unit_test/static/custom_rep_min_req_test.cpp
@@ -85,7 +85,7 @@ using impl_impl = impl_constructible_impl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_impl<float>>);
 static_assert(std::convertible_to<impl_impl<float>, float>);
-static_assert(units::Scalar<impl_impl<float>>);
+static_assert(units::Value<impl_impl<float>>);
 
 template<typename T>
 struct expl_constructible_impl_convertible : scalar_ops<expl_constructible_impl_convertible<T>> {
@@ -100,7 +100,7 @@ using expl_impl = expl_constructible_impl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_impl<float>>);
 static_assert(std::convertible_to<expl_impl<float>, float>);
-static_assert(units::Scalar<expl_impl<float>>);
+static_assert(units::Value<expl_impl<float>>);
 
 template<typename T>
 struct impl_constructible_expl_convertible : scalar_ops<impl_constructible_expl_convertible<T>> {
@@ -115,7 +115,7 @@ using impl_expl = impl_constructible_expl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_expl<float>>);
 static_assert(!std::convertible_to<impl_expl<float>, float>);
-static_assert(units::Scalar<impl_expl<float>>);
+static_assert(units::Value<impl_expl<float>>);
 
 template<typename T>
 struct expl_constructible_expl_convertible : scalar_ops<expl_constructible_expl_convertible<T>> {
@@ -130,7 +130,7 @@ using expl_expl = expl_constructible_expl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_expl<float>>);
 static_assert(!std::convertible_to<expl_expl<float>, float>);
-static_assert(units::Scalar<expl_expl<float>>);
+static_assert(units::Value<expl_expl<float>>);
 
 }  // namespace
 
@@ -169,7 +169,7 @@ using namespace units::physical::si;
 
 // constructors
 
-// Quantity from Scalar
+// Quantity from Value
 // int <- int
 static_assert(length<metre, int>(expl_impl<int>(1)).count() == 1);
 // static_assert(length<metre, int>(impl_expl<int>(1)).count() == 1);  // should not compile (not convertible)

--- a/test/unit_test/static/custom_unit_test.cpp
+++ b/test/unit_test/static/custom_unit_test.cpp
@@ -35,14 +35,14 @@ using namespace units::physical::si;
 struct sq_volt_per_hertz : unit<sq_volt_per_hertz> {};
 struct dim_power_spectral_density : derived_dimension<dim_power_spectral_density, sq_volt_per_hertz, units::exp<dim_voltage, 2>, units::exp<dim_frequency, -1>> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using power_spectral_density = quantity<dim_power_spectral_density, U, Rep>;
 
 // amplitude spectral density
 struct volt_per_sqrt_hertz : unit<volt_per_sqrt_hertz> {};
 struct dim_amplitude_spectral_density : derived_dimension<dim_amplitude_spectral_density, volt_per_sqrt_hertz, units::exp<dim_voltage, 1>, units::exp<dim_frequency, -1, 2>> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using amplitude_spectral_density = quantity<dim_amplitude_spectral_density, U, Rep>;
 
 }

--- a/test/unit_test/static/custom_unit_test.cpp
+++ b/test/unit_test/static/custom_unit_test.cpp
@@ -35,14 +35,14 @@ using namespace units::physical::si;
 struct sq_volt_per_hertz : unit<sq_volt_per_hertz> {};
 struct dim_power_spectral_density : derived_dimension<dim_power_spectral_density, sq_volt_per_hertz, units::exp<dim_voltage, 2>, units::exp<dim_frequency, -1>> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using power_spectral_density = quantity<dim_power_spectral_density, U, Rep>;
 
 // amplitude spectral density
 struct volt_per_sqrt_hertz : unit<volt_per_sqrt_hertz> {};
 struct dim_amplitude_spectral_density : derived_dimension<dim_amplitude_spectral_density, volt_per_sqrt_hertz, units::exp<dim_voltage, 1>, units::exp<dim_frequency, -1, 2>> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using amplitude_spectral_density = quantity<dim_amplitude_spectral_density, U, Rep>;
 
 }


### PR DESCRIPTION
Fixes https://github.com/mpusz/units/issues/114

(Failing to build in Travis , but  that seems to be a regression in the linear algebra library)

EDIT : Looking through the code, the concept name `Value` seems to be a bit short; will presumably become  `value` in lowercase, so maybe not the end of this? ... but at least `Scalar` can be reclaimed.