### PR TITLE
Kwikius concepts to lower case

### DIFF
--- a/example/alternative_namespaces/conversion_factor.cpp
+++ b/example/alternative_namespaces/conversion_factor.cpp
@@ -27,7 +27,7 @@
 
 namespace {
 
-template<units::Quantity Target, units::Quantity Source>
+template<units::in_quantity Target, units::in_quantity Source>
   requires units::equivalent_dim<typename Source::dimension, typename Target::dimension>
 inline constexpr std::common_type_t<typename Target::rep, typename Source::rep> conversion_factor(Target, Source)
 {

--- a/example/alternative_namespaces/units_str.h
+++ b/example/alternative_namespaces/units_str.h
@@ -4,7 +4,7 @@
 #include <units/physical/si/prefixes.h>
 #include <units/quantity.h>
 // get at the units text of the quantity, without its numeric value
-inline auto constexpr units_str(const units::Quantity AUTO& q)
+inline auto constexpr units_str(const units::in_quantity AUTO& q)
 {
   typedef std::remove_cvref_t<decltype(q)> qtype;
   return units::detail::unit_text<typename qtype::dimension, typename qtype::unit>();

--- a/example/avg_speed.cpp
+++ b/example/avg_speed.cpp
@@ -44,18 +44,18 @@ fixed_double_si_avg_speed(si::length<si::metre> d,
 }
 
 template<typename U1, typename R1, typename U2, typename R2>
-constexpr Speed AUTO si_avg_speed(si::length<U1, R1> d,
+constexpr in_speed AUTO si_avg_speed(si::length<U1, R1> d,
                                      si::time<U2, R2> t)
 {
   return d / t;
 }
 
-constexpr Speed AUTO avg_speed(Length AUTO d, Time AUTO t)
+constexpr in_speed AUTO avg_speed(in_length AUTO d, in_time AUTO t)
 {
   return d / t;
 }
 
-template<Length D, Time T, Speed V>
+template<in_length D, in_time T, in_speed V>
 void print_result(D distance, T duration, V speed)
 {
   const auto result_in_kmph = units::quantity_cast<si::speed<si::kilometre_per_hour>>(speed);
@@ -68,7 +68,7 @@ void example()
   // SI (int)
   {
     using namespace units::physical::si::literals;
-    constexpr Length AUTO distance = 220q_km;      // constructed from a UDL
+    constexpr in_length AUTO distance = 220q_km;      // constructed from a UDL
     constexpr si::time<si::hour, int> duration(2); // constructed from a value
 
     std::cout << "SI units with 'int' as representation\n";
@@ -82,7 +82,7 @@ void example()
   // SI (double)
   {
     using namespace units::physical::si::literals;
-    constexpr Length AUTO distance = 220.q_km;  // constructed from a UDL
+    constexpr in_length AUTO distance = 220.q_km;  // constructed from a UDL
     constexpr si::time<si::hour> duration(2);   // constructed from a value
 
     std::cout << "\nSI units with 'double' as representation\n";
@@ -98,7 +98,7 @@ void example()
   // Customary Units (int)
   {
     using namespace units::physical::international::literals;
-    constexpr Length AUTO distance = 140q_mi;      // constructed from a UDL
+    constexpr in_length AUTO distance = 140q_mi;      // constructed from a UDL
     constexpr si::time<si::hour, int> duration(2); // constructed from a value
 
     std::cout << "\nUS Customary Units with 'int' as representation\n";
@@ -114,7 +114,7 @@ void example()
   // Customary Units (double)
   {
     using namespace units::physical::international::literals;
-    constexpr Length AUTO distance = 140q_mi; // constructed from a UDL
+    constexpr in_length AUTO distance = 140q_mi; // constructed from a UDL
     constexpr si::time<si::hour> duration(2); // constructed from a value
 
     std::cout << "\nUS Customary Units with 'double' as representation\n";
@@ -132,7 +132,7 @@ void example()
   // CGS (int)
   {
     using namespace units::physical::cgs::literals;
-    constexpr Length AUTO distance = 22'000'000q_cm;  // constructed from a UDL
+    constexpr in_length AUTO distance = 22'000'000q_cm;  // constructed from a UDL
     constexpr cgs::time<si::hour, int> duration(2);   // constructed from a value
 
     std::cout << "\nCGS units with 'int' as representation\n";
@@ -151,7 +151,7 @@ void example()
   // CGS (double)
   {
     using namespace units::physical::cgs::literals;
-    constexpr Length AUTO distance = 22'000'000q_cm; // constructed from a UDL
+    constexpr in_length AUTO distance = 22'000'000q_cm; // constructed from a UDL
     constexpr cgs::time<si::hour> duration(2);       // constructed from a value
 
     std::cout << "\nCGS units with 'double' as representation\n";

--- a/example/capacitor_time_curve.cpp
+++ b/example/capacitor_time_curve.cpp
@@ -41,7 +41,7 @@ int main()
   constexpr auto R = 4.7q_kR;
 
   for (auto t = 0q_ms; t <= 50q_ms; ++t) {
-    const Voltage AUTO Vt = V0 * std::exp(-t / (R * C));
+    const in_voltage AUTO Vt = V0 * std::exp(-t / (R * C));
 
     std::cout << "at " << t << " voltage is ";
 

--- a/example/conversion_factor.cpp
+++ b/example/conversion_factor.cpp
@@ -26,7 +26,7 @@
 
 namespace {
 
-template<units::Quantity Target, units::Quantity Source>
+template<units::in_quantity Target, units::in_quantity Source>
   requires units::equivalent_dim<typename Source::dimension, typename Target::dimension>
 inline constexpr std::common_type_t<typename Target::rep, typename Source::rep> conversion_factor(Target, Source)
 {

--- a/example/experimental_angle.cpp
+++ b/example/experimental_angle.cpp
@@ -34,7 +34,7 @@ int main()
   auto torque = 20.0q_Nm;
   auto energy = 20.0q_J;
 
-  physical::Angle AUTO angle = torque / energy;
+  physical::in_angle AUTO angle = torque / energy;
 
   std::cout << angle << '\n';
 }

--- a/example/hello_units.cpp
+++ b/example/hello_units.cpp
@@ -27,7 +27,7 @@
 
 using namespace units::physical;
 
-constexpr Speed AUTO avg_speed(Length AUTO d, Time AUTO t)
+constexpr in_speed AUTO avg_speed(in_length AUTO d, in_time AUTO t)
 {
   return d / t;
 }
@@ -35,10 +35,10 @@ constexpr Speed AUTO avg_speed(Length AUTO d, Time AUTO t)
 int main()
 {
   using namespace units::physical::si::literals;
-  Speed AUTO v1 = avg_speed(220q_km, 2q_h);
-  Speed AUTO v2 = avg_speed(si::length<international::mile>(140), si::time<si::hour>(2));
-  Speed AUTO v3 = quantity_cast<si::metre_per_second>(v2);
-  Speed AUTO v4 = quantity_cast<int>(v3);
+  in_speed AUTO v1 = avg_speed(220q_km, 2q_h);
+  in_speed AUTO v2 = avg_speed(si::length<international::mile>(140), si::time<si::hour>(2));
+  in_speed AUTO v3 = quantity_cast<si::metre_per_second>(v2);
+  in_speed AUTO v4 = quantity_cast<int>(v3);
 
   std::cout << v1 << '\n';                             // 110 km/h
   std::cout << fmt::format("{}", v2) << '\n';          // 70 mi/h

--- a/example/kalman_filter-alpha_beta_filter_example2.cpp
+++ b/example/kalman_filter-alpha_beta_filter_example2.cpp
@@ -12,7 +12,7 @@
 
 namespace {
 
-template<units::Quantity Q>
+template<units::in_quantity Q>
 struct state_variable {
   Q estimated_current_state;
   Q predicted_next_state;

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -201,10 +201,10 @@ void matrix_of_quantity_tests()
   matrix_of_quantity_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Value Rep = double>
+template<units::Unit U = si::metre, units::NumericValue Rep = double>
 using length_v = si::length<U, vector<Rep>>;
 
-template<units::Unit U = si::newton, units::Value Rep = double>
+template<units::Unit U = si::newton, units::NumericValue Rep = double>
 using force_v = si::force<U, vector<Rep>>;
 
 void quantity_of_vector_add()
@@ -274,7 +274,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Value Rep = double>
+template<units::Unit U = si::metre, units::NumericValue Rep = double>
 using length_m = si::length<U, matrix<Rep>>;
 
 void quantity_of_matrix_add()

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -201,10 +201,10 @@ void matrix_of_quantity_tests()
   matrix_of_quantity_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Scalar Rep = double>
+template<units::Unit U = si::metre, units::Value Rep = double>
 using length_v = si::length<U, vector<Rep>>;
 
-template<units::Unit U = si::newton, units::Scalar Rep = double>
+template<units::Unit U = si::newton, units::Value Rep = double>
 using force_v = si::force<U, vector<Rep>>;
 
 void quantity_of_vector_add()
@@ -274,7 +274,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::Scalar Rep = double>
+template<units::Unit U = si::metre, units::Value Rep = double>
 using length_m = si::length<U, matrix<Rep>>;
 
 void quantity_of_matrix_add()

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -201,10 +201,10 @@ void matrix_of_quantity_tests()
   matrix_of_quantity_divide_by_scalar();
 }
 
-template<units::in_unit U = si::metre, units::NumericValue Rep = double>
+template<units::in_unit U = si::metre, units::in_numeric_value Rep = double>
 using length_v = si::length<U, vector<Rep>>;
 
-template<units::in_unit U = si::newton, units::NumericValue Rep = double>
+template<units::in_unit U = si::newton, units::in_numeric_value Rep = double>
 using force_v = si::force<U, vector<Rep>>;
 
 void quantity_of_vector_add()
@@ -274,7 +274,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_divide_by_scalar();
 }
 
-template<units::in_unit U = si::metre, units::NumericValue Rep = double>
+template<units::in_unit U = si::metre, units::in_numeric_value Rep = double>
 using length_m = si::length<U, matrix<Rep>>;
 
 void quantity_of_matrix_add()

--- a/example/linear_algebra.cpp
+++ b/example/linear_algebra.cpp
@@ -201,10 +201,10 @@ void matrix_of_quantity_tests()
   matrix_of_quantity_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::NumericValue Rep = double>
+template<units::in_unit U = si::metre, units::NumericValue Rep = double>
 using length_v = si::length<U, vector<Rep>>;
 
-template<units::Unit U = si::newton, units::NumericValue Rep = double>
+template<units::in_unit U = si::newton, units::NumericValue Rep = double>
 using force_v = si::force<U, vector<Rep>>;
 
 void quantity_of_vector_add()
@@ -274,7 +274,7 @@ void quantity_of_vector_tests()
   quantity_of_vector_divide_by_scalar();
 }
 
-template<units::Unit U = si::metre, units::NumericValue Rep = double>
+template<units::in_unit U = si::metre, units::NumericValue Rep = double>
 using length_m = si::length<U, matrix<Rep>>;
 
 void quantity_of_matrix_add()

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -146,7 +146,7 @@ private:
   value_type uncertainty_{};
 };
 
-static_assert(units::NumericValue<measurement<double>>);
+static_assert(units::in_numeric_value<measurement<double>>);
 
 }  // namespace
 

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -146,7 +146,7 @@ private:
   value_type uncertainty_{};
 };
 
-static_assert(units::Scalar<measurement<double>>);
+static_assert(units::Value<measurement<double>>);
 
 }  // namespace
 

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -162,7 +162,7 @@ void example()
   const auto a = si::acceleration<si::metre_per_second_sq, measurement<double>>(measurement(9.8, 0.1));
   const auto t = si::time<si::second, measurement<double>>(measurement(1.2, 0.1));
 
-  const Speed AUTO v1 = a * t;
+  const in_speed AUTO v1 = a * t;
   std::cout << a << " * " << t << " = " << v1 << " = " << quantity_cast<si::kilometre_per_hour>(v1) << '\n';
 
   si::length<si::metre, measurement<double>> length(measurement(123., 1.));

--- a/example/measurement.cpp
+++ b/example/measurement.cpp
@@ -146,7 +146,7 @@ private:
   value_type uncertainty_{};
 };
 
-static_assert(units::Value<measurement<double>>);
+static_assert(units::NumericValue<measurement<double>>);
 
 }  // namespace
 

--- a/example/total_energy.cpp
+++ b/example/total_energy.cpp
@@ -32,7 +32,7 @@ namespace {
 
 using namespace units::physical;
 
-Energy AUTO total_energy(Momentum AUTO p, Mass AUTO m, Speed AUTO c)
+in_energy AUTO total_energy(in_momentum AUTO p, in_mass AUTO m, in_speed AUTO c)
 {
   return sqrt(pow<2>(p * c) + pow<2>(m * pow<2>(c)));
 }
@@ -42,13 +42,13 @@ void si_example()
   using namespace units::physical::si;
   using GeV = gigaelectronvolt;
 
-  constexpr Speed AUTO c = si2019::speed_of_light<>;
+  constexpr in_speed AUTO c = si2019::speed_of_light<>;
 
   std::cout << "\n*** SI units (c = " << c << ") ***\n";
 
-  const Momentum AUTO p = 4.q_GeV / c;
-  const Mass AUTO m = 3.q_GeV / pow<2>(c);
-  const Energy AUTO E = total_energy(p, m, c);
+  const in_momentum AUTO p = 4.q_GeV / c;
+  const in_mass AUTO m = 3.q_GeV / pow<2>(c);
+  const in_energy AUTO E = total_energy(p, m, c);
 
   std::cout << "[in GeV]\n"
             << "p = " << p << "\n"
@@ -73,10 +73,10 @@ void natural_example()
   using namespace units::physical::natural;
   using GeV = gigaelectronvolt;
 
-  constexpr Speed AUTO c = speed_of_light<>;
+  constexpr in_speed AUTO c = speed_of_light<>;
   const momentum<GeV> p(4);
   const mass<GeV> m(3);
-  const Energy AUTO E = total_energy(p, m, c);
+  const in_energy AUTO E = total_energy(p, m, c);
 
   std::cout << "\n*** Natural units (c = " << c << ") ***\n"
             << "p = " << p << "\n"

--- a/example/unknown_dimension.cpp
+++ b/example/unknown_dimension.cpp
@@ -25,8 +25,8 @@
 
 namespace {
 
-template<units::physical::Length D, units::physical::Time T>
-constexpr units::physical::Speed AUTO avg_speed(D d, T t)
+template<units::physical::in_length D, units::physical::in_time T>
+constexpr units::physical::in_speed AUTO avg_speed(D d, T t)
 {
   return d / t;
 }
@@ -36,13 +36,13 @@ void example()
   using namespace units::physical;
   using namespace units::physical::si::literals;
 
-  Length AUTO d1 = 123q_m;
-  Time AUTO t1 = 10q_s;
-  Speed AUTO v1 = avg_speed(d1, t1);
+  in_length AUTO d1 = 123q_m;
+  in_time AUTO t1 = 10q_s;
+  in_speed AUTO v1 = avg_speed(d1, t1);
 
   auto temp1 = v1 * 50q_m;  // produces intermediate unknown dimension with 'unknown_coherent_unit' as its 'coherent_unit'
-  Speed AUTO v2 = temp1 / 100q_m; // back to known dimensions again
-  Length AUTO d2 = v2 * 60q_s;
+  in_speed AUTO v2 = temp1 / 100q_m; // back to known dimensions again
+  in_length AUTO d2 = v2 * 60q_s;
 
   std::cout << "d1 = " << d1 << '\n';
   std::cout << "t1 = " << t1 << '\n';

--- a/src/include/units/base_dimension.h
+++ b/src/include/units/base_dimension.h
@@ -38,16 +38,16 @@ namespace units {
  * 
  * Base unit is a measurement unit that is adopted by convention for a base quantity in a specific system of units.
  *
- * Pair of Symbol and Unit template parameters form an unique identifier of the base dimension. The same identifiers can
- * be multiplied and divided which will result with an adjustment of its factor in an Exponent of a DerivedDimension
+ * Pair of Symbol and in_unit template parameters form an unique identifier of the base dimension. The same identifiers can
+ * be multiplied and divided which will result with an adjustment of its factor in an in_exponent of a in_derived_dimension
  * (in case of zero the dimension will be simplified and removed from further analysis of current expresion). In case
- * the Symbol is the same but the Unit differs (i.e. mixing SI and CGS length), there is no automatic simplification but
+ * the Symbol is the same but the in_unit differs (i.e. mixing SI and CGS length), there is no automatic simplification but
  * is possible to force it with a quantity_cast.
  *
  * @tparam Symbol an unique identifier of the base dimension used to provide dimensional analysis support
  * @tparam U a base unit to be used for this base dimension
  */
-template<basic_fixed_string Symbol, Unit U>
+template<basic_fixed_string Symbol, in_unit U>
   requires U::is_named
 struct base_dimension {
   using base_type_workaround = base_dimension; // TODO Replace with is_base_dimension when fixed
@@ -56,7 +56,7 @@ struct base_dimension {
 };
 
 // base_dimension_less
-template<BaseDimension D1, BaseDimension D2>
+template<in_base_dimension D1, in_base_dimension D2>
 struct base_dimension_less :
     std::bool_constant<(D1::symbol < D2::symbol) ||
                        (D1::symbol == D2::symbol && D1::base_unit::symbol < D1::base_unit::symbol)> {

--- a/src/include/units/bits/base_units_ratio.h
+++ b/src/include/units/bits/base_units_ratio.h
@@ -28,7 +28,7 @@
 
 namespace units::detail {
 
-template<Exponent E>
+template<in_exponent E>
   requires (E::den == 1 || E::den == 2) // TODO provide support for any den
 struct exp_ratio {
   using base_ratio = E::dimension::base_unit::ratio;

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -26,7 +26,7 @@
 
 namespace units {
 
-template<Dimension D, UnitOf<D> U, Value Rep>
+template<Dimension D, UnitOf<D> U, NumericValue Rep>
 class quantity;
 
 namespace detail {
@@ -59,7 +59,7 @@ struct common_quantity_impl<quantity<D1, U1, Rep1>, quantity<D2, U2, Rep2>, Rep>
 
 }  // namespace detail
 
-template<Quantity Q1, Quantity Q2, Value Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
+template<Quantity Q1, Quantity Q2, NumericValue Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
   requires equivalent_dim<typename Q1::dimension, typename Q2::dimension>
 using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -26,7 +26,7 @@
 
 namespace units {
 
-template<Dimension D, UnitOf<D> U, NumericValue Rep>
+template<in_dimension D, UnitOf<D> U, in_numeric_value Rep>
 class quantity;
 
 namespace detail {
@@ -59,7 +59,7 @@ struct common_quantity_impl<quantity<D1, U1, Rep1>, quantity<D2, U2, Rep2>, Rep>
 
 }  // namespace detail
 
-template<Quantity Q1, Quantity Q2, NumericValue Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
+template<in_quantity Q1, in_quantity Q2, in_numeric_value Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
   requires equivalent_dim<typename Q1::dimension, typename Q2::dimension>
 using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 
@@ -75,7 +75,7 @@ namespace concepts {
 
 #endif
 
-template<units::Quantity Q1, units::Quantity Q2>
+template<units::in_quantity Q1, units::in_quantity Q2>
   requires units::equivalent_dim<typename Q1::dimension, typename Q2::dimension>
 struct common_type<Q1, Q2> {
   using type = units::common_quantity<Q1, Q2>;

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -26,7 +26,7 @@
 
 namespace units {
 
-template<Dimension D, UnitOf<D> U, Scalar Rep>
+template<Dimension D, UnitOf<D> U, Value Rep>
 class quantity;
 
 namespace detail {
@@ -59,7 +59,7 @@ struct common_quantity_impl<quantity<D1, U1, Rep1>, quantity<D2, U2, Rep2>, Rep>
 
 }  // namespace detail
 
-template<Quantity Q1, Quantity Q2, Scalar Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
+template<Quantity Q1, Quantity Q2, Value Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
   requires equivalent_dim<typename Q1::dimension, typename Q2::dimension>
 using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 

--- a/src/include/units/bits/deduced_symbol_text.h
+++ b/src/include/units/bits/deduced_symbol_text.h
@@ -86,7 +86,7 @@ constexpr auto deduced_symbol_text(exp_list<Es...>, std::index_sequence<Idxs...>
   return (exp_text<Es, Us::symbol, neg_exp, Idxs>() + ...);
 }
 
-template<DerivedDimension Dim, Unit... Us>
+template<in_derived_dimension Dim, in_unit... Us>
 constexpr auto deduced_symbol_text()
 {
   return deduced_symbol_text<Us...>(typename Dim::recipe(), std::index_sequence_for<Us...>());

--- a/src/include/units/bits/deduced_unit.h
+++ b/src/include/units/bits/deduced_unit.h
@@ -27,45 +27,45 @@
 namespace units::detail {
 
 // same_scaled_units
-template<typename ExpList, Unit... Us>
+template<typename ExpList, in_unit... Us>
 inline constexpr bool same_scaled_units = false;
 
-template<typename... Es, Unit... Us>
+template<typename... Es, in_unit... Us>
 inline constexpr bool same_scaled_units<exp_list<Es...>, Us...> = (UnitOf<Us, typename Es::dimension> && ...);
 
 // deduced_unit
-template<typename Result, int UnitExpNum, int UnitExpDen, typename UnitRatio>
+template<typename Result, int UnitExpNum, int UnitExpDen, typename in_unit_ratio>
 struct ratio_op;
 
-template<typename Result, int UnitExpDen, typename UnitRatio>
-struct ratio_op<Result, 0, UnitExpDen, UnitRatio> {
+template<typename Result, int UnitExpDen, typename in_unit_ratio>
+struct ratio_op<Result, 0, UnitExpDen, in_unit_ratio> {
   using ratio = Result;
 };
 
-template<typename Result, int UnitExpNum, int UnitExpDen, typename UnitRatio>
+template<typename Result, int UnitExpNum, int UnitExpDen, typename in_unit_ratio>
 struct ratio_op {
   using calc_ratio =
-      conditional<(UnitExpNum * UnitExpDen > 0), ratio_multiply<Result, UnitRatio>, ratio_divide<Result, UnitRatio>>;
+      conditional<(UnitExpNum * UnitExpDen > 0), ratio_multiply<Result, in_unit_ratio>, ratio_divide<Result, in_unit_ratio>>;
   static constexpr int value = (UnitExpNum * UnitExpDen > 0) ? (UnitExpNum - UnitExpDen) : (UnitExpNum + UnitExpDen);
-  using ratio = ratio_op<calc_ratio, value, UnitExpDen, UnitRatio>::ratio;
+  using ratio = ratio_op<calc_ratio, value, UnitExpDen, in_unit_ratio>::ratio;
 };
 
-template<typename ExpList, Unit... Us>
+template<typename ExpList, in_unit... Us>
 struct derived_ratio;
 
-template<Unit... Us>
+template<in_unit... Us>
 struct derived_ratio<exp_list<>, Us...> {
   using ratio = ::units::ratio<1>;
 };
 
-template<typename E, typename... ERest, Unit U, Unit... URest>
+template<typename E, typename... ERest, in_unit U, in_unit... URest>
 struct derived_ratio<exp_list<E, ERest...>, U, URest...> {
   using rest_ratio = derived_ratio<exp_list<ERest...>, URest...>::ratio;
   using unit_ratio = ratio_op<rest_ratio, E::num, E::den, typename U::ratio>::ratio;
   using ratio = ratio_divide<unit_ratio, typename dimension_unit<typename E::dimension>::ratio>;
 };
 
-template<DerivedDimension D, Unit... Us>
+template<in_derived_dimension D, in_unit... Us>
 using deduced_unit =
     scaled_unit<typename detail::derived_ratio<typename D::recipe, Us...>::ratio, typename D::coherent_unit::reference>;
 

--- a/src/include/units/bits/derived_dimension_base.h
+++ b/src/include/units/bits/derived_dimension_base.h
@@ -44,8 +44,8 @@ namespace units::detail {
  * @tparam E a first exponent of a derived dimension
  * @tparam ERest zero or more following exponents of a derived dimension
  */
-template<Exponent E, Exponent... ERest>
-  requires (BaseDimension<typename E::dimension> && ... && BaseDimension<typename ERest::dimension>)
+template<in_exponent E, in_exponent... ERest>
+  requires (in_base_dimension<typename E::dimension> && ... && in_base_dimension<typename ERest::dimension>)
 struct derived_dimension_base : downcast_base<derived_dimension_base<E, ERest...>> {
   using exponents = exp_list<E, ERest...>;
 };
@@ -53,7 +53,7 @@ struct derived_dimension_base : downcast_base<derived_dimension_base<E, ERest...
 template<typename T>
 struct to_derived_dimension_base;
 
-template<Exponent... Es>
+template<in_exponent... Es>
 struct to_derived_dimension_base<exp_list<Es...>> {
   using type = derived_dimension_base<Es...>;
 };

--- a/src/include/units/bits/dim_consolidate.h
+++ b/src/include/units/bits/dim_consolidate.h
@@ -54,7 +54,7 @@ struct dim_consolidate<exp_list<E1, ERest...>> {
   using type = type_list_push_front<typename dim_consolidate<exp_list<ERest...>>::type, E1>;
 };
 
-template<BaseDimension Dim, std::intmax_t Num1, std::intmax_t Den1, std::intmax_t Num2, std::intmax_t Den2, typename... ERest>
+template<in_base_dimension Dim, std::intmax_t Num1, std::intmax_t Den1, std::intmax_t Num2, std::intmax_t Den2, typename... ERest>
 struct dim_consolidate<exp_list<exp<Dim, Num1, Den1>, exp<Dim, Num2, Den2>, ERest...>> {
   // TODO: we have ration_add now, but dim_consolidate etc, now need to cope with our new ratio
   using r1 = std::ratio<Num1, Den1>;

--- a/src/include/units/bits/dim_unpack.h
+++ b/src/include/units/bits/dim_unpack.h
@@ -33,7 +33,7 @@ namespace units::detail {
  * 
  * @tparam Es Exponents of potentially derived dimensions 
  */
-template<Exponent... Es>
+template<in_exponent... Es>
 struct dim_unpack;
 
 template<>
@@ -41,17 +41,17 @@ struct dim_unpack<> {
   using type = exp_list<>;
 };
 
-template<BaseDimension Dim, std::intmax_t Num, std::intmax_t Den, Exponent... ERest>
+template<in_base_dimension Dim, std::intmax_t Num, std::intmax_t Den, in_exponent... ERest>
 struct dim_unpack<exp<Dim, Num, Den>, ERest...> {
   using type = type_list_push_front<typename dim_unpack<ERest...>::type, exp<Dim, Num, Den>>;
 };
 
-template<DerivedDimension Dim, std::intmax_t Num, std::intmax_t Den, Exponent... ERest>
+template<in_derived_dimension Dim, std::intmax_t Num, std::intmax_t Den, in_exponent... ERest>
 struct dim_unpack<exp<Dim, Num, Den>, ERest...> {
   using type = dim_unpack<exp<downcast_base_t<Dim>, Num, Den>, ERest...>::type;
 };
 
-template<Exponent... Es, std::intmax_t Num, std::intmax_t Den, Exponent... ERest>
+template<in_exponent... Es, std::intmax_t Num, std::intmax_t Den, in_exponent... ERest>
 struct dim_unpack<exp<derived_dimension_base<Es...>, Num, Den>, ERest...> {
   using type = type_list_push_front<typename dim_unpack<ERest...>::type, exp_multiply<Es, Num, Den>...>;
 };

--- a/src/include/units/bits/dimension_op.h
+++ b/src/include/units/bits/dimension_op.h
@@ -30,7 +30,7 @@ namespace units {
 // equivalent_dim
 namespace detail {
 
-template<Dimension D1, Dimension D2>
+template<in_dimension D1, in_dimension D2>
 struct equivalent_dim_impl : std::false_type {};
 
 template<in_base_dimension D1, in_base_dimension D2>
@@ -58,7 +58,7 @@ struct equivalent_dim_impl<D1, D2> : std::disjunction<std::is_same<D1, D2>, equi
 
 } // namespace detail
 
-template<Dimension D1, Dimension D2>
+template<in_dimension D1, in_dimension D2>
 inline constexpr bool equivalent_dim = detail::equivalent_dim_impl<D1, D2>::value;
 
 /**
@@ -89,7 +89,7 @@ struct check_unknown<derived_dimension_base<Es...>> {
   using type = unknown_dimension<Es...>;
 };
 
-template<Dimension D>
+template<in_dimension D>
 struct downcast_dimension_impl;
 
 template<in_base_dimension D>
@@ -104,13 +104,13 @@ struct downcast_dimension_impl<D> {
 
 } // namespace detail
 
-template<Dimension D>
+template<in_dimension D>
 using downcast_dimension = detail::downcast_dimension_impl<D>::type;
 
 // dim_invert
 namespace detail {
 
-template<Dimension D>
+template<in_dimension D>
 struct dim_invert_impl;
 
 template<in_base_dimension D>
@@ -134,7 +134,7 @@ struct dim_invert_impl<D> : dim_invert_impl<downcast_base_t<D>> {
 
 }  // namespace detail
 
-template<Dimension D>
+template<in_dimension D>
 using dim_invert = detail::dim_invert_impl<D>::type;
 
 // dimension_multiply
@@ -162,10 +162,10 @@ struct to_dimension<exp_list<exp<D, 1>>> {
  * one element being a base dimension with exponent 1. In such a case the final dimension should be the base
  * dimension itself.
  */
-template<Dimension D1, Dimension D2>
+template<in_dimension D1, in_dimension D2>
 using merge_dimension = to_dimension<typename dim_consolidate<type_list_merge_sorted<typename D1::exponents, typename D2::exponents, exp_less>>::type>::type;
 
-template<Dimension D1, Dimension D2>
+template<in_dimension D1, in_dimension D2>
 struct dimension_multiply_impl;
 
 template<in_base_dimension D1, in_base_dimension D2>
@@ -190,16 +190,16 @@ struct dimension_multiply_impl<D1, D2> {
 
 }  // namespace detail
 
-template<Dimension D1, Dimension D2>
+template<in_dimension D1, in_dimension D2>
 using dimension_multiply = detail::dimension_multiply_impl<D1, D2>::type;
 
-template<Dimension D1, Dimension D2>
+template<in_dimension D1, in_dimension D2>
 using dimension_divide = detail::dimension_multiply_impl<D1, dim_invert<D2>>::type;
 
 // dimension_sqrt
 namespace detail {
 
-template<Dimension D>
+template<in_dimension D>
 struct dimension_sqrt_impl;
 
 template<in_base_dimension D>
@@ -224,13 +224,13 @@ struct dimension_sqrt_impl<derived_dimension_base<Es...>> {
 
 }  // namespace detail
 
-template<Dimension D>
+template<in_dimension D>
 using dimension_sqrt = detail::dimension_sqrt_impl<D>::type;
 
 // dimension_pow
 namespace detail {
 
-template<Dimension D, std::intmax_t N>
+template<in_dimension D, std::intmax_t N>
 struct dimension_pow_impl;
 
 template<in_base_dimension D, std::intmax_t N>
@@ -260,7 +260,7 @@ struct dimension_pow_impl<derived_dimension_base<Es...>, N> {
 
 }  // namespace detail
 
-template<Dimension D, std::intmax_t N>
+template<in_dimension D, std::intmax_t N>
 using dimension_pow = detail::dimension_pow_impl<D, N>::type;
 
 }  // namespace units

--- a/src/include/units/bits/dimension_op.h
+++ b/src/include/units/bits/dimension_op.h
@@ -33,27 +33,27 @@ namespace detail {
 template<Dimension D1, Dimension D2>
 struct equivalent_dim_impl : std::false_type {};
 
-template<BaseDimension D1, BaseDimension D2>
+template<in_base_dimension D1, in_base_dimension D2>
 struct equivalent_base_dim : std::conjunction<std::bool_constant<D1::symbol == D2::symbol>,
                                         same_unit_reference<typename D1::base_unit, typename D2::base_unit>> {};
 
-template<BaseDimension D1, BaseDimension D2>
+template<in_base_dimension D1, in_base_dimension D2>
 struct equivalent_dim_impl<D1, D2> : std::disjunction<std::is_same<D1, D2>, equivalent_base_dim<D1, D2>> {};
 
-template<Exponent E1, Exponent E2>
+template<in_exponent E1, in_exponent E2>
 struct equivalent_exp : std::false_type {};
 
-template<BaseDimension Dim1, std::intmax_t Num, std::intmax_t Den, BaseDimension Dim2>
+template<in_base_dimension Dim1, std::intmax_t Num, std::intmax_t Den, in_base_dimension Dim2>
 struct equivalent_exp<exp<Dim1, Num, Den>, exp<Dim2, Num, Den>> : equivalent_dim_impl<Dim1, Dim2> {};
 
-template<DerivedDimension D1, DerivedDimension D2>
+template<in_derived_dimension D1, in_derived_dimension D2>
 struct equivalent_derived_dim : std::false_type {};
 
 template<typename... Es1, typename... Es2>
   requires (sizeof...(Es1) == sizeof...(Es2))
 struct equivalent_derived_dim<derived_dimension_base<Es1...>, derived_dimension_base<Es2...>> : std::conjunction<equivalent_exp<Es1, Es2>...> {};
 
-template<DerivedDimension D1, DerivedDimension D2>
+template<in_derived_dimension D1, in_derived_dimension D2>
 struct equivalent_dim_impl<D1, D2> : std::disjunction<std::is_same<D1, D2>, equivalent_derived_dim<downcast_base_t<D1>, downcast_base_t<D2>>> {};
 
 } // namespace detail
@@ -71,14 +71,14 @@ inline constexpr bool equivalent_dim = detail::equivalent_dim_impl<D1, D2>::valu
  * @tparam E the list of exponents of ingredient dimensions
  * @tparam ERest the list of exponents of ingredient dimensions
  */
-template<Exponent E, Exponent... ERest>
+template<in_exponent E, in_exponent... ERest>
 struct unknown_dimension : derived_dimension<unknown_dimension<E, ERest...>, scaled_unit<ratio<1>, unknown_coherent_unit>, E, ERest...> {
   using coherent_unit = scaled_unit<ratio<1>, unknown_coherent_unit>;
 };
 
 namespace detail {
 
-template<DerivedDimension D>
+template<in_derived_dimension D>
 struct check_unknown {
   using type = D;
 };
@@ -92,12 +92,12 @@ struct check_unknown<derived_dimension_base<Es...>> {
 template<Dimension D>
 struct downcast_dimension_impl;
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct downcast_dimension_impl<D> {
   using type = D;
 };
 
-template<DerivedDimension D>
+template<in_derived_dimension D>
 struct downcast_dimension_impl<D> {
   using type = check_unknown<downcast<D>>::type;
 };
@@ -113,12 +113,12 @@ namespace detail {
 template<Dimension D>
 struct dim_invert_impl;
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct dim_invert_impl<D> {
   using type = downcast_dimension<derived_dimension_base<exp<D, -1>>>;
 };
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct dim_invert_impl<derived_dimension_base<exp<D, -1>>> {
   using type = D;
 };
@@ -128,7 +128,7 @@ struct dim_invert_impl<derived_dimension_base<Es...>> {
   using type = downcast_dimension<derived_dimension_base<exp_invert<Es>...>>;
 };
 
-template<DerivedDimension D>
+template<in_derived_dimension D>
 struct dim_invert_impl<D> : dim_invert_impl<downcast_base_t<D>> {
 };
 
@@ -143,12 +143,12 @@ namespace detail {
 template<typename T>
 struct to_dimension;
 
-template<Exponent... Es>
+template<in_exponent... Es>
 struct to_dimension<exp_list<Es...>> {
   using type = derived_dimension_base<Es...>;
 };
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct to_dimension<exp_list<exp<D, 1>>> {
   using type = D;
 };
@@ -168,22 +168,22 @@ using merge_dimension = to_dimension<typename dim_consolidate<type_list_merge_so
 template<Dimension D1, Dimension D2>
 struct dimension_multiply_impl;
 
-template<BaseDimension D1, BaseDimension D2>
+template<in_base_dimension D1, in_base_dimension D2>
 struct dimension_multiply_impl<D1, D2> {
   using type = downcast_dimension<merge_dimension<derived_dimension_base<exp<D1, 1>>, derived_dimension_base<exp<D2, 1>>>>;
 };
 
-template<BaseDimension D1, DerivedDimension D2>
+template<in_base_dimension D1, in_derived_dimension D2>
 struct dimension_multiply_impl<D1, D2> {
   using type = downcast_dimension<merge_dimension<derived_dimension_base<exp<D1, 1>>, typename D2::downcast_base_type>>;
 };
 
-template<DerivedDimension D1, BaseDimension D2>
+template<in_derived_dimension D1, in_base_dimension D2>
 struct dimension_multiply_impl<D1, D2> {
   using type = dimension_multiply_impl<D2, D1>::type;
 };
 
-template<DerivedDimension D1, DerivedDimension D2>
+template<in_derived_dimension D1, in_derived_dimension D2>
 struct dimension_multiply_impl<D1, D2> {
   using type = downcast_dimension<merge_dimension<typename D1::downcast_base_type, typename D2::downcast_base_type>>;
 };
@@ -202,17 +202,17 @@ namespace detail {
 template<Dimension D>
 struct dimension_sqrt_impl;
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct dimension_sqrt_impl<D> {
   using type = downcast_dimension<derived_dimension_base<exp<D, 1, 2>>>;
 };
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct dimension_sqrt_impl<derived_dimension_base<exp<D, 2>>> {
   using type = D;
 };
 
-template<DerivedDimension D>
+template<in_derived_dimension D>
 struct dimension_sqrt_impl<D> {
   using type = dimension_sqrt_impl<typename D::downcast_base_type>::type;
 };
@@ -233,22 +233,22 @@ namespace detail {
 template<Dimension D, std::intmax_t N>
 struct dimension_pow_impl;
 
-template<BaseDimension D, std::intmax_t N>
+template<in_base_dimension D, std::intmax_t N>
 struct dimension_pow_impl<D, N> {
   using type = downcast_dimension<derived_dimension_base<exp<D, N>>>;
 };
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct dimension_pow_impl<D, 1> {
   using type = D;
 };
 
-template<BaseDimension D, std::intmax_t N>
+template<in_base_dimension D, std::intmax_t N>
 struct dimension_pow_impl<derived_dimension_base<exp<D, 1, N>>, N> {
   using type = D;
 };
 
-template<DerivedDimension D, std::intmax_t N>
+template<in_derived_dimension D, std::intmax_t N>
 struct dimension_pow_impl<D, N> {
   using type = dimension_pow_impl<downcast_base_t<D>, N>::type;
 };

--- a/src/include/units/bits/to_string.h
+++ b/src/include/units/bits/to_string.h
@@ -129,7 +129,7 @@ constexpr auto exp_list_with_named_units(exp_list<Es...>)
   return type_list_join<decltype(exp_list_with_named_units(Es()))...>();
 }
 
-template<Dimension Dim>
+template<in_dimension Dim>
 constexpr auto derived_dimension_unit_text()
 {
   using recipe = Dim::recipe;
@@ -140,7 +140,7 @@ constexpr auto derived_dimension_unit_text()
 template<typename T>
 concept has_symbol = requires{ T::symbol; };
 
-template<Dimension Dim, in_unit U>
+template<in_dimension Dim, in_unit U>
 constexpr auto unit_text()
 {
   if constexpr(has_symbol<U>) {
@@ -164,7 +164,7 @@ constexpr auto unit_text()
   }
 }
 
-template<typename CharT, class Traits, Quantity Q>
+template<typename CharT, class Traits, in_quantity Q>
 std::basic_string<CharT> to_string(const Q& q)
 {
   std::basic_ostringstream<CharT, Traits> s;

--- a/src/include/units/bits/to_string.h
+++ b/src/include/units/bits/to_string.h
@@ -107,10 +107,10 @@ constexpr auto derived_dimension_unit_text(exp_list<Es...> list)
   return derived_dimension_unit_text(list, std::index_sequence_for<Es...>());
 }
 
-template<Exponent... Es>
+template<in_exponent... Es>
 constexpr auto exp_list_with_named_units(exp_list<Es...>);
 
-template<Exponent Exp>
+template<in_exponent Exp>
 constexpr auto exp_list_with_named_units(Exp)
 {
   using dim = Exp::dimension;
@@ -123,7 +123,7 @@ constexpr auto exp_list_with_named_units(Exp)
   }
 }
 
-template<Exponent... Es>
+template<in_exponent... Es>
 constexpr auto exp_list_with_named_units(exp_list<Es...>)
 {
   return type_list_join<decltype(exp_list_with_named_units(Es()))...>();
@@ -140,7 +140,7 @@ constexpr auto derived_dimension_unit_text()
 template<typename T>
 concept has_symbol = requires{ T::symbol; };
 
-template<Dimension Dim, Unit U>
+template<Dimension Dim, in_unit U>
 constexpr auto unit_text()
 {
   if constexpr(has_symbol<U>) {

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -253,7 +253,7 @@ inline constexpr bool is_wrapped_quantity<T> = Quantity<typename T::value_type> 
 template<typename T>
 concept WrappedQuantity = detail::is_wrapped_quantity<T>;
 
-// Value
+// NumericValue
 
 namespace detail {
 
@@ -283,7 +283,7 @@ concept not_constructible_from_integral =
  * Satisfied by types that satisfy `(!Quantity<T>) && (!WrappedQuantity<T>) && std::regular<T>`.
  */
 template<typename T>
-concept Value =
+concept NumericValue =
   (!Quantity<T>) &&
   (!WrappedQuantity<T>) &&
   std::regular<T> &&

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -29,7 +29,7 @@
 
 namespace units {
 
-// PrefixFamily
+// in_prefix_family
 struct prefix_family;
 
 /**
@@ -38,9 +38,9 @@ struct prefix_family;
  * Satisfied by all types derived from `prefix_family`
  */
 template<typename T>
-concept PrefixFamily = std::derived_from<T, prefix_family>;
+concept in_prefix_family = std::derived_from<T, prefix_family>;
 
-// Prefix
+// in_prefix
 // TODO gcc:92150
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=92150
 // namespace detail {
@@ -48,8 +48,8 @@ concept PrefixFamily = std::derived_from<T, prefix_family>;
 //   template<typename T>
 //   inline constexpr bool is_prefix = false;
 
-//   template<typename PrefixFamily, Ratio R, basic_fixed_string Symbol>
-//   inline constexpr bool is_prefix<prefix<PrefixFamily, R, Symbol>> = true;
+//   template<typename in_prefix_family, in_ratio R, basic_fixed_string Symbol>
+//   inline constexpr bool is_prefix<prefix<in_prefix_family, R, Symbol>> = true;
 
 // }  // namespace detail
 
@@ -59,8 +59,8 @@ concept PrefixFamily = std::derived_from<T, prefix_family>;
  * Satisfied by all instantiations of `prefix`.
  */
 template<typename T>
-//  concept Prefix = detail::is_prefix<T>;
-concept Prefix = true;
+//  concept in_prefix = detail::is_prefix<T>;
+concept in_prefix = true;
 
 
 namespace detail {
@@ -76,18 +76,18 @@ inline constexpr bool is_ratio = false;
  * Satisfied by all instantiations of `ratio`.
  */
 template<typename T>
-concept Ratio = detail::is_ratio<T>;
+concept in_ratio = detail::is_ratio<T>;
 
 /**
  * @brief A concept matching unit's ratio
  * 
- * Satisfied by all types that satisfy `Ratio<R>` and for which `R::num > 0` and `R::den > 0`
+ * Satisfied by all types that satisfy `in_ratio<R>` and for which `R::num > 0` and `R::den > 0`
  */
 template<typename R>
-concept UnitRatio = Ratio<R> && R::num > 0 && R::den > 0; // double negatives not allowed
+concept in_unit_ratio = in_ratio<R> && R::num > 0 && R::den > 0; // double negatives not allowed
 
-// Unit
-template<UnitRatio R, typename U>
+// in_unit
+template<in_unit_ratio R, typename U>
 struct scaled_unit;
 
 /**
@@ -96,9 +96,9 @@ struct scaled_unit;
  * Satisfied by all unit types derived from the instantiation of :class:`scaled_unit`.
  */
 template<typename T>
-concept Unit = is_derived_from_instantiation<T, scaled_unit>;
+concept in_unit = is_derived_from_instantiation<T, scaled_unit>;
 
-template<basic_fixed_string Symbol, Unit U>
+template<basic_fixed_string Symbol, in_unit U>
   requires U::is_named
 struct base_dimension;
 
@@ -127,9 +127,9 @@ inline constexpr bool is_base_dimension<base_dimension<Name, Params...>> = true;
  * Satisfied by all dimension types derived from the instantiation of `base_dimension`.
  */
 template<typename T>
-concept BaseDimension = detail::is_base_dimension<typename T::base_type_workaround>;
+concept in_base_dimension = detail::is_base_dimension<typename T::base_type_workaround>;
 
-// Exponent
+// in_exponent
 namespace detail {
 
 template<typename T>
@@ -143,13 +143,13 @@ inline constexpr bool is_exp = false;
  * Satisfied by all instantiations of :class:`exp`.
  */
 template<typename T>
-concept Exponent = detail::is_exp<T>;
+concept in_exponent = detail::is_exp<T>;
 
-// DerivedDimension
+// in_derived_dimension
 namespace detail {
 
-template<Exponent E, Exponent... ERest>
-  requires (BaseDimension<typename E::dimension> && ... && BaseDimension<typename ERest::dimension>)
+template<in_exponent E, in_exponent... ERest>
+  requires (in_base_dimension<typename E::dimension> && ... && in_base_dimension<typename ERest::dimension>)
 struct derived_dimension_base;
 
 } // namespace detail
@@ -160,16 +160,16 @@ struct derived_dimension_base;
  * Satisfied by all dimension types derived from the instantiation of `detail::derived_dimension_base`.
  */
 template<typename T>
-concept DerivedDimension = is_instantiation<downcast_base_t<T>, detail::derived_dimension_base>;
+concept in_derived_dimension = is_instantiation<downcast_base_t<T>, detail::derived_dimension_base>;
 
 // Dimension
 /**
  * @brief A concept matching all dimensions in the library. 
  * 
- * Satisfied by all dimension types for which either `BaseDimension<T>` or `DerivedDimension<T>` is `true`.
+ * Satisfied by all dimension types for which either `in_base_dimension<T>` or `in_derived_dimension<T>` is `true`.
  */
 template<typename T>
-concept Dimension = BaseDimension<T> || DerivedDimension<T>;
+concept Dimension = in_base_dimension<T> || in_derived_dimension<T>;
 
 // UnitOf
 namespace detail {
@@ -177,12 +177,12 @@ namespace detail {
 template<Dimension D>
 struct dimension_unit_impl;
 
-template<BaseDimension D>
+template<in_base_dimension D>
 struct dimension_unit_impl<D> {
   using type = D::base_unit;
 };
 
-template<DerivedDimension D>
+template<in_derived_dimension D>
 struct dimension_unit_impl<D> {
   using type = D::coherent_unit;
 };
@@ -203,7 +203,7 @@ using dimension_unit = detail::dimension_unit_impl<D>::type;
 /**
  * @brief A concept matching only units of a specified dimension.
  * 
- * Satisfied by all unit types that satisfy `Unit<U>`, `Dimension<D>`, and for which
+ * Satisfied by all unit types that satisfy `in_unit<U>`, `Dimension<D>`, and for which
  * `U::reference` and @c dimension_unit<D>::reference denote the same unit type.
  * 
  * @tparam U Type to verify.
@@ -211,7 +211,7 @@ using dimension_unit = detail::dimension_unit_impl<D>::type;
  */
 template<typename U, typename D>
 concept UnitOf =
-  Unit<U> &&
+  in_unit<U> &&
   Dimension<D> &&
   std::same_as<typename U::reference, typename dimension_unit<D>::reference>;
 

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -253,7 +253,7 @@ inline constexpr bool is_wrapped_quantity<T> = Quantity<typename T::value_type> 
 template<typename T>
 concept WrappedQuantity = detail::is_wrapped_quantity<T>;
 
-// Scalar
+// Value
 
 namespace detail {
 
@@ -283,7 +283,7 @@ concept not_constructible_from_integral =
  * Satisfied by types that satisfy `(!Quantity<T>) && (!WrappedQuantity<T>) && std::regular<T>`.
  */
 template<typename T>
-concept Scalar =
+concept Value =
   (!Quantity<T>) &&
   (!WrappedQuantity<T>) &&
   std::regular<T> &&

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -162,19 +162,19 @@ struct derived_dimension_base;
 template<typename T>
 concept in_derived_dimension = is_instantiation<downcast_base_t<T>, detail::derived_dimension_base>;
 
-// Dimension
+// in_dimension
 /**
  * @brief A concept matching all dimensions in the library. 
  * 
  * Satisfied by all dimension types for which either `in_base_dimension<T>` or `in_derived_dimension<T>` is `true`.
  */
 template<typename T>
-concept Dimension = in_base_dimension<T> || in_derived_dimension<T>;
+concept in_dimension = in_base_dimension<T> || in_derived_dimension<T>;
 
 // UnitOf
 namespace detail {
 
-template<Dimension D>
+template<in_dimension D>
 struct dimension_unit_impl;
 
 template<in_base_dimension D>
@@ -195,27 +195,27 @@ struct dimension_unit_impl<D> {
  * Depending on the dimension type it returns a base unit (for base dimensions)
  * or a coherent unit (in case of derived dimensions).
  * 
- * @tparam D Dimension type to get the unit from.
+ * @tparam D in_dimension type to get the unit from.
  */
-template<Dimension D>
+template<in_dimension D>
 using dimension_unit = detail::dimension_unit_impl<D>::type;
 
 /**
  * @brief A concept matching only units of a specified dimension.
  * 
- * Satisfied by all unit types that satisfy `in_unit<U>`, `Dimension<D>`, and for which
+ * Satisfied by all unit types that satisfy `in_unit<U>`, `in_dimension<D>`, and for which
  * `U::reference` and @c dimension_unit<D>::reference denote the same unit type.
  * 
  * @tparam U Type to verify.
- * @tparam D Dimension type to use for verification.
+ * @tparam D in_dimension type to use for verification.
  */
 template<typename U, typename D>
 concept UnitOf =
   in_unit<U> &&
-  Dimension<D> &&
+  in_dimension<D> &&
   std::same_as<typename U::reference, typename dimension_unit<D>::reference>;
 
-// Quantity
+// in_quantity
 namespace detail {
 
 template<typename T>
@@ -229,10 +229,10 @@ inline constexpr bool is_quantity = false;
  * Satisfied by all instantiations of :class:`quantity`.
  */
 template<typename T>
-concept Quantity = detail::is_quantity<T>;
+concept in_quantity = detail::is_quantity<T>;
 
 
-// WrappedQuantity
+// in_wrapped_quantity
 namespace detail {
 
 template<typename T>
@@ -240,20 +240,20 @@ inline constexpr bool is_wrapped_quantity = false;
 
 template<typename T>
   requires requires { typename T::value_type; }
-inline constexpr bool is_wrapped_quantity<T> = Quantity<typename T::value_type> || is_wrapped_quantity<typename T::value_type>;
+inline constexpr bool is_wrapped_quantity<T> = in_quantity<typename T::value_type> || is_wrapped_quantity<typename T::value_type>;
 
 }  // namespace detail
 
 /**
  * @brief A concept matching types that wrap quantity objects.
  * 
- * Satisfied by all wrapper types that satisfy `Quantity<typename T::value_type>`
+ * Satisfied by all wrapper types that satisfy `in_quantity<typename T::value_type>`
  * recursively (i.e. `std::optional<si::length<si::metre>>`).
  */
 template<typename T>
-concept WrappedQuantity = detail::is_wrapped_quantity<T>;
+concept in_wrapped_quantity = detail::is_wrapped_quantity<T>;
 
-// NumericValue
+// in_numeric_value
 
 namespace detail {
 
@@ -278,14 +278,14 @@ concept not_constructible_from_integral =
 }  // namespace detail
 
 /**
- * @brief A concept matching non-Quantity types.
+ * @brief A concept matching non-in_quantity types.
  * 
- * Satisfied by types that satisfy `(!Quantity<T>) && (!WrappedQuantity<T>) && std::regular<T>`.
+ * Satisfied by types that satisfy `(!in_quantity<T>) && (!in_wrapped_quantity<T>) && std::regular<T>`.
  */
 template<typename T>
-concept NumericValue =
-  (!Quantity<T>) &&
-  (!WrappedQuantity<T>) &&
+concept in_numeric_value =
+  (!in_quantity<T>) &&
+  (!in_wrapped_quantity<T>) &&
   std::regular<T> &&
   (detail::constructible_from_integral<T> || detail::not_constructible_from_integral<T>);
 

--- a/src/include/units/customization_points.h
+++ b/src/include/units/customization_points.h
@@ -37,7 +37,7 @@ namespace units {
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Value Rep>
+template<NumericValue Rep>
 inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
 
 /**
@@ -49,7 +49,7 @@ inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Value Rep>
+template<NumericValue Rep>
 struct quantity_values {
   static constexpr Rep zero() noexcept { return Rep(0); }
   static constexpr Rep one() noexcept { return Rep(1); }

--- a/src/include/units/customization_points.h
+++ b/src/include/units/customization_points.h
@@ -37,7 +37,7 @@ namespace units {
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Scalar Rep>
+template<Value Rep>
 inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
 
 /**
@@ -49,7 +49,7 @@ inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<Scalar Rep>
+template<Value Rep>
 struct quantity_values {
   static constexpr Rep zero() noexcept { return Rep(0); }
   static constexpr Rep one() noexcept { return Rep(1); }

--- a/src/include/units/customization_points.h
+++ b/src/include/units/customization_points.h
@@ -37,7 +37,7 @@ namespace units {
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<NumericValue Rep>
+template<in_numeric_value Rep>
 inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
 
 /**
@@ -49,7 +49,7 @@ inline constexpr bool treat_as_floating_point = std::is_floating_point_v<Rep>;
  * 
  * @tparam Rep a representation type for which a type trait is defined
  */
-template<NumericValue Rep>
+template<in_numeric_value Rep>
 struct quantity_values {
   static constexpr Rep zero() noexcept { return Rep(0); }
   static constexpr Rep one() noexcept { return Rep(1); }

--- a/src/include/units/data/bitrate.h
+++ b/src/include/units/data/bitrate.h
@@ -41,7 +41,7 @@ struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibi
 template<typename T>
 concept Bitrate = QuantityOf<T, dim_bitrate>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using bitrate = quantity<dim_bitrate, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/bitrate.h
+++ b/src/include/units/data/bitrate.h
@@ -41,7 +41,7 @@ struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibi
 template<typename T>
 concept Bitrate = QuantityOf<T, dim_bitrate>;
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using bitrate = quantity<dim_bitrate, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/bitrate.h
+++ b/src/include/units/data/bitrate.h
@@ -41,7 +41,7 @@ struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibi
 template<typename T>
 concept Bitrate = QuantityOf<T, dim_bitrate>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using bitrate = quantity<dim_bitrate, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/bitrate.h
+++ b/src/include/units/data/bitrate.h
@@ -41,7 +41,7 @@ struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibi
 template<typename T>
 concept Bitrate = QuantityOf<T, dim_bitrate>;
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using bitrate = quantity<dim_bitrate, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/bitrate.h
+++ b/src/include/units/data/bitrate.h
@@ -39,7 +39,7 @@ struct tebibit_per_second : deduced_unit<tebibit_per_second, dim_bitrate, tebibi
 struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibit, physical::si::second> {};
 
 template<typename T>
-concept Bitrate = QuantityOf<T, dim_bitrate>;
+concept in_bitrate = in_quantity_of<T, dim_bitrate>;
 
 template<in_unit U, in_numeric_value Rep = double>
 using bitrate = quantity<dim_bitrate, U, Rep>;

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -48,7 +48,7 @@ struct dim_information : base_dimension<"information", bit> {};
 template<typename T>
 concept Information = QuantityOf<T, dim_information>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using information = quantity<dim_information, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -46,7 +46,7 @@ struct pebibyte : prefixed_unit<pebibyte, pebi, byte> {};
 struct dim_information : base_dimension<"information", bit> {};
 
 template<typename T>
-concept Information = QuantityOf<T, dim_information>;
+concept in_information = in_quantity_of<T, dim_information>;
 
 template<in_unit U, in_numeric_value Rep = double>
 using information = quantity<dim_information, U, Rep>;

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -48,7 +48,7 @@ struct dim_information : base_dimension<"information", bit> {};
 template<typename T>
 concept Information = QuantityOf<T, dim_information>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using information = quantity<dim_information, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -48,7 +48,7 @@ struct dim_information : base_dimension<"information", bit> {};
 template<typename T>
 concept Information = QuantityOf<T, dim_information>;
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using information = quantity<dim_information, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/data/information.h
+++ b/src/include/units/data/information.h
@@ -48,7 +48,7 @@ struct dim_information : base_dimension<"information", bit> {};
 template<typename T>
 concept Information = QuantityOf<T, dim_information>;
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using information = quantity<dim_information, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/derived_dimension.h
+++ b/src/include/units/derived_dimension.h
@@ -45,7 +45,7 @@ namespace detail {
  * 3. Consolidate contiguous range of exponents of the same base dimensions to a one (or possibly zero) exponent for
  *    this base dimension.
  */
-template<Exponent... Es>
+template<in_exponent... Es>
 using make_dimension = to_derived_dimension_base<typename dim_consolidate<type_list_sort<typename dim_unpack<Es...>::type, exp_less>>::type>::type;
 
 }  // namespace detail
@@ -78,7 +78,7 @@ using make_dimension = to_derived_dimension_base<typename dim_consolidate<type_l
  * @tparam E the list of exponents of ingredient dimensions
  * @tparam ERest the list of exponents of ingredient dimensions
  */
-template<typename Child, Unit U, Exponent E, Exponent... ERest>
+template<typename Child, in_unit U, in_exponent E, in_exponent... ERest>
 struct derived_dimension : downcast_child<Child, typename detail::make_dimension<E, ERest...>> {
   using recipe = exp_list<E, ERest...>;
   using coherent_unit = U;

--- a/src/include/units/exp.h
+++ b/src/include/units/exp.h
@@ -34,7 +34,7 @@ namespace units {
  * @tparam Num numinator of the factor
  * @tparam Den denominator of the factor
  */
-template<Dimension Dim, std::intmax_t Num, std::intmax_t Den = 1>
+template<in_dimension Dim, std::intmax_t Num, std::intmax_t Den = 1>
 struct exp {
   using dimension = Dim;
   static constexpr int num = Num;

--- a/src/include/units/exp.h
+++ b/src/include/units/exp.h
@@ -50,8 +50,8 @@ inline constexpr bool is_exp<exp<Dim, Num, Den>> = true;
 }  // namespace detail
 
 // exp_less
-template<Exponent E1, Exponent E2>
-  requires BaseDimension<typename E1::dimension> && BaseDimension<typename E2::dimension>
+template<in_exponent E1, in_exponent E2>
+  requires in_base_dimension<typename E1::dimension> && in_base_dimension<typename E2::dimension>
 struct exp_less : base_dimension_less<typename E1::dimension, typename E2::dimension> {};
 
 // exp_invert
@@ -62,13 +62,13 @@ constexpr exp<Dim, -Num, Den> exp_invert_impl(exp<Dim, Num, Den>);
 
 }  // namespace detail
 
-template<Exponent E>
+template<in_exponent E>
 using exp_invert = decltype(detail::exp_invert_impl(E()));
 
 // exp_multiply
 namespace detail {
 
-template<Exponent E, std::intmax_t Num, std::intmax_t Den>
+template<in_exponent E, std::intmax_t Num, std::intmax_t Den>
 struct exp_multiply_impl {
   using r1 = ratio<E::num, E::den>;
   using r2 = ratio<Num, Den>;
@@ -78,10 +78,10 @@ struct exp_multiply_impl {
 
 }  // namespace detail
 
-template<Exponent E, std::intmax_t Num, std::intmax_t Den>
+template<in_exponent E, std::intmax_t Num, std::intmax_t Den>
 using exp_multiply = detail::exp_multiply_impl<E, Num, Den>::type;
 
-template<Exponent... Es>
+template<in_exponent... Es>
 struct exp_list {};
 
 }  // namespace units

--- a/src/include/units/format.h
+++ b/src/include/units/format.h
@@ -233,7 +233,7 @@ namespace units {
       return format_to(out, fmt::to_string(buffer), val);
     }
 
-    template<typename OutputIt, typename Dimension, typename in_unit, typename Rep, typename CharT>
+    template<typename OutputIt, typename in_dimension, typename in_unit, typename Rep, typename CharT>
     struct units_formatter {
       OutputIt out;
       Rep val;
@@ -242,7 +242,7 @@ namespace units {
       unit_format_specs const & unit_specs;
 
       explicit units_formatter(
-        OutputIt o, quantity<Dimension, in_unit, Rep> q,
+        OutputIt o, quantity<in_dimension, in_unit, Rep> q,
         global_format_specs<CharT> const & gspecs,
         rep_format_specs const & rspecs, unit_format_specs const & uspecs
       ):
@@ -263,7 +263,7 @@ namespace units {
 
       void on_quantity_unit([[maybe_unused]] const CharT)
       {
-        auto txt = unit_text<Dimension, in_unit>();
+        auto txt = unit_text<in_dimension, in_unit>();
         auto txt_c_str = unit_specs.modifier == 'A' ? txt.ascii().c_str() : txt.standard().c_str();
         format_to(out, "{}", txt_c_str);
       }
@@ -273,10 +273,10 @@ namespace units {
 
 }  // namespace units
 
-template<typename Dimension, typename in_unit, typename Rep, typename CharT>
-struct fmt::formatter<units::quantity<Dimension, in_unit, Rep>, CharT> {
+template<typename in_dimension, typename in_unit, typename Rep, typename CharT>
+struct fmt::formatter<units::quantity<in_dimension, in_unit, Rep>, CharT> {
 private:
-  using quantity = units::quantity<Dimension, in_unit, Rep>;
+  using quantity = units::quantity<in_dimension, in_unit, Rep>;
   using iterator = fmt::basic_format_parse_context<CharT>::iterator;
   using arg_ref_type = fmt::internal::arg_ref<CharT>;
 
@@ -414,7 +414,7 @@ public:
   }
 
   template<typename FormatContext>
-  auto format(const units::quantity<Dimension, in_unit, Rep>& q, FormatContext& ctx)
+  auto format(const units::quantity<in_dimension, in_unit, Rep>& q, FormatContext& ctx)
   {
     auto begin = format_str.begin(), end = format_str.end();
 
@@ -461,7 +461,7 @@ public:
     if(begin == end || *begin == '}') {
       // default format should print value followed by the unit separated with 1 space
       to_quantity_buffer = units::detail::format_units_quantity_value<CharT>(to_quantity_buffer, q.count(), rep_specs);
-      constexpr auto symbol = units::detail::unit_text<Dimension, in_unit>();
+      constexpr auto symbol = units::detail::unit_text<in_dimension, in_unit>();
       if(symbol.standard().size()) {
         *to_quantity_buffer++ = CharT(' ');
         format_to(to_quantity_buffer, "{}", symbol.standard().c_str());

--- a/src/include/units/format.h
+++ b/src/include/units/format.h
@@ -233,7 +233,7 @@ namespace units {
       return format_to(out, fmt::to_string(buffer), val);
     }
 
-    template<typename OutputIt, typename Dimension, typename Unit, typename Rep, typename CharT>
+    template<typename OutputIt, typename Dimension, typename in_unit, typename Rep, typename CharT>
     struct units_formatter {
       OutputIt out;
       Rep val;
@@ -242,7 +242,7 @@ namespace units {
       unit_format_specs const & unit_specs;
 
       explicit units_formatter(
-        OutputIt o, quantity<Dimension, Unit, Rep> q,
+        OutputIt o, quantity<Dimension, in_unit, Rep> q,
         global_format_specs<CharT> const & gspecs,
         rep_format_specs const & rspecs, unit_format_specs const & uspecs
       ):
@@ -263,7 +263,7 @@ namespace units {
 
       void on_quantity_unit([[maybe_unused]] const CharT)
       {
-        auto txt = unit_text<Dimension, Unit>();
+        auto txt = unit_text<Dimension, in_unit>();
         auto txt_c_str = unit_specs.modifier == 'A' ? txt.ascii().c_str() : txt.standard().c_str();
         format_to(out, "{}", txt_c_str);
       }
@@ -273,10 +273,10 @@ namespace units {
 
 }  // namespace units
 
-template<typename Dimension, typename Unit, typename Rep, typename CharT>
-struct fmt::formatter<units::quantity<Dimension, Unit, Rep>, CharT> {
+template<typename Dimension, typename in_unit, typename Rep, typename CharT>
+struct fmt::formatter<units::quantity<Dimension, in_unit, Rep>, CharT> {
 private:
-  using quantity = units::quantity<Dimension, Unit, Rep>;
+  using quantity = units::quantity<Dimension, in_unit, Rep>;
   using iterator = fmt::basic_format_parse_context<CharT>::iterator;
   using arg_ref_type = fmt::internal::arg_ref<CharT>;
 
@@ -414,7 +414,7 @@ public:
   }
 
   template<typename FormatContext>
-  auto format(const units::quantity<Dimension, Unit, Rep>& q, FormatContext& ctx)
+  auto format(const units::quantity<Dimension, in_unit, Rep>& q, FormatContext& ctx)
   {
     auto begin = format_str.begin(), end = format_str.end();
 
@@ -461,7 +461,7 @@ public:
     if(begin == end || *begin == '}') {
       // default format should print value followed by the unit separated with 1 space
       to_quantity_buffer = units::detail::format_units_quantity_value<CharT>(to_quantity_buffer, q.count(), rep_specs);
-      constexpr auto symbol = units::detail::unit_text<Dimension, Unit>();
+      constexpr auto symbol = units::detail::unit_text<Dimension, in_unit>();
       if(symbol.standard().size()) {
         *to_quantity_buffer++ = CharT(' ');
         format_to(to_quantity_buffer, "{}", symbol.standard().c_str());

--- a/src/include/units/math.h
+++ b/src/include/units/math.h
@@ -35,12 +35,12 @@ namespace units {
  * Both the quantity value and its dimension are the base of the operation.
  * 
  * @tparam N in_exponent
- * @param q Quantity being the base of the operation
- * @return Quantity The result of computation 
+ * @param q in_quantity being the base of the operation
+ * @return in_quantity The result of computation 
  */
-template<std::intmax_t N, Quantity Q>
+template<std::intmax_t N, in_quantity Q>
   requires(N != 0)
-inline Quantity AUTO pow(const Q& q) noexcept
+inline in_quantity AUTO pow(const Q& q) noexcept
   requires requires { std::pow(q.count(), N); }
 {
   using dim = dimension_pow<typename Q::dimension, N>;
@@ -55,7 +55,7 @@ inline Quantity AUTO pow(const Q& q) noexcept
  * 
  * @return Rep A scalar value of @c 1. 
  */
-template<std::intmax_t N, Quantity Q>
+template<std::intmax_t N, in_quantity Q>
   requires(N == 0)
 inline Q::rep pow(const Q&) noexcept
 {
@@ -67,11 +67,11 @@ inline Q::rep pow(const Q&) noexcept
  * 
  * Both the quantity value and its dimension are the base of the operation.
  * 
- * @param q Quantity being the base of the operation
- * @return Quantity The result of computation 
+ * @param q in_quantity being the base of the operation
+ * @return in_quantity The result of computation 
  */
-template<Quantity Q>
-inline Quantity AUTO sqrt(const Q& q) noexcept
+template<in_quantity Q>
+inline in_quantity AUTO sqrt(const Q& q) noexcept
   requires requires { std::sqrt(q.count()); }
 {
   using dim = dimension_sqrt<typename Q::dimension>;
@@ -84,11 +84,11 @@ inline Quantity AUTO sqrt(const Q& q) noexcept
 /**
  * @brief Computes the absolute value of a quantity
  * 
- * @param q Quantity being the base of the operation
- * @return Quantity The absolute value of a provided quantity
+ * @param q in_quantity being the base of the operation
+ * @return in_quantity The absolute value of a provided quantity
  */
-template<Quantity Q>
-constexpr Quantity AUTO abs(const Q& q) noexcept
+template<in_quantity Q>
+constexpr in_quantity AUTO abs(const Q& q) noexcept
   requires requires { std::abs(q.count()); }
 {
   return Q(std::abs(q.count()));
@@ -99,12 +99,12 @@ constexpr Quantity AUTO abs(const Q& q) noexcept
  * 
  * The returned value is defined by a <tt>std::numeric_limits<typename Q::rep>::epsilon()</tt>.
  * 
- * @tparam Q Quantity type being the base of the operation
- * @return Quantity The epsilon value for quantity's representation type
+ * @tparam Q in_quantity type being the base of the operation
+ * @return in_quantity The epsilon value for quantity's representation type
  */
-template<Quantity Q>
+template<in_quantity Q>
   requires requires { std::numeric_limits<typename Q::rep>::epsilon(); }
-constexpr Quantity AUTO epsilon() noexcept
+constexpr in_quantity AUTO epsilon() noexcept
 {
   return Q(std::numeric_limits<typename Q::rep>::epsilon());
 }

--- a/src/include/units/math.h
+++ b/src/include/units/math.h
@@ -34,7 +34,7 @@ namespace units {
  * 
  * Both the quantity value and its dimension are the base of the operation.
  * 
- * @tparam N Exponent
+ * @tparam N in_exponent
  * @param q Quantity being the base of the operation
  * @return Quantity The result of computation 
  */

--- a/src/include/units/physical/cgs/acceleration.h
+++ b/src/include/units/physical/cgs/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::cgs {
 struct gal : named_unit<gal, "Gal", si::prefix> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gal, dim_length, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/acceleration.h
+++ b/src/include/units/physical/cgs/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::cgs {
 struct gal : named_unit<gal, "Gal", si::prefix> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gal, dim_length, dim_time> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/acceleration.h
+++ b/src/include/units/physical/cgs/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::cgs {
 struct gal : named_unit<gal, "Gal", si::prefix> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gal, dim_length, dim_time> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/acceleration.h
+++ b/src/include/units/physical/cgs/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::cgs {
 struct gal : named_unit<gal, "Gal", si::prefix> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gal, dim_length, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/area.h
+++ b/src/include/units/physical/cgs/area.h
@@ -33,7 +33,7 @@ using si::square_centimetre;
 
 struct dim_area : physical::dim_area<dim_area, square_centimetre, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/area.h
+++ b/src/include/units/physical/cgs/area.h
@@ -33,7 +33,7 @@ using si::square_centimetre;
 
 struct dim_area : physical::dim_area<dim_area, square_centimetre, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/area.h
+++ b/src/include/units/physical/cgs/area.h
@@ -33,7 +33,7 @@ using si::square_centimetre;
 
 struct dim_area : physical::dim_area<dim_area, square_centimetre, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/area.h
+++ b/src/include/units/physical/cgs/area.h
@@ -33,7 +33,7 @@ using si::square_centimetre;
 
 struct dim_area : physical::dim_area<dim_area, square_centimetre, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/energy.h
+++ b/src/include/units/physical/cgs/energy.h
@@ -33,7 +33,7 @@ struct erg : named_unit<erg, "erg", si::prefix> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, erg, dim_force, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/energy.h
+++ b/src/include/units/physical/cgs/energy.h
@@ -33,7 +33,7 @@ struct erg : named_unit<erg, "erg", si::prefix> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, erg, dim_force, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/energy.h
+++ b/src/include/units/physical/cgs/energy.h
@@ -33,7 +33,7 @@ struct erg : named_unit<erg, "erg", si::prefix> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, erg, dim_force, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/energy.h
+++ b/src/include/units/physical/cgs/energy.h
@@ -33,7 +33,7 @@ struct erg : named_unit<erg, "erg", si::prefix> {};
 
 struct dim_energy : physical::dim_energy<dim_energy, erg, dim_force, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/force.h
+++ b/src/include/units/physical/cgs/force.h
@@ -34,7 +34,7 @@ struct dyne : named_unit<dyne, "dyn", si::prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, dyne, dim_mass, dim_acceleration> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/force.h
+++ b/src/include/units/physical/cgs/force.h
@@ -34,7 +34,7 @@ struct dyne : named_unit<dyne, "dyn", si::prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, dyne, dim_mass, dim_acceleration> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/force.h
+++ b/src/include/units/physical/cgs/force.h
@@ -34,7 +34,7 @@ struct dyne : named_unit<dyne, "dyn", si::prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, dyne, dim_mass, dim_acceleration> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/force.h
+++ b/src/include/units/physical/cgs/force.h
@@ -34,7 +34,7 @@ struct dyne : named_unit<dyne, "dyn", si::prefix> {};
 
 struct dim_force : physical::dim_force<dim_force, dyne, dim_mass, dim_acceleration> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/length.h
+++ b/src/include/units/physical/cgs/length.h
@@ -32,7 +32,7 @@ using si::centimetre;
 
 struct dim_length : physical::dim_length<centimetre> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/length.h
+++ b/src/include/units/physical/cgs/length.h
@@ -32,7 +32,7 @@ using si::centimetre;
 
 struct dim_length : physical::dim_length<centimetre> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/length.h
+++ b/src/include/units/physical/cgs/length.h
@@ -32,7 +32,7 @@ using si::centimetre;
 
 struct dim_length : physical::dim_length<centimetre> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/length.h
+++ b/src/include/units/physical/cgs/length.h
@@ -32,7 +32,7 @@ using si::centimetre;
 
 struct dim_length : physical::dim_length<centimetre> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/mass.h
+++ b/src/include/units/physical/cgs/mass.h
@@ -32,7 +32,7 @@ using si::gram;
 
 struct dim_mass : physical::dim_mass<gram> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/mass.h
+++ b/src/include/units/physical/cgs/mass.h
@@ -32,7 +32,7 @@ using si::gram;
 
 struct dim_mass : physical::dim_mass<gram> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/mass.h
+++ b/src/include/units/physical/cgs/mass.h
@@ -32,7 +32,7 @@ using si::gram;
 
 struct dim_mass : physical::dim_mass<gram> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/mass.h
+++ b/src/include/units/physical/cgs/mass.h
@@ -32,7 +32,7 @@ using si::gram;
 
 struct dim_mass : physical::dim_mass<gram> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/power.h
+++ b/src/include/units/physical/cgs/power.h
@@ -33,7 +33,7 @@ struct erg_per_second : unit<erg_per_second> {};
 
 struct dim_power : physical::dim_power<dim_power, erg_per_second, dim_energy, dim_time> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/power.h
+++ b/src/include/units/physical/cgs/power.h
@@ -33,7 +33,7 @@ struct erg_per_second : unit<erg_per_second> {};
 
 struct dim_power : physical::dim_power<dim_power, erg_per_second, dim_energy, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/power.h
+++ b/src/include/units/physical/cgs/power.h
@@ -33,7 +33,7 @@ struct erg_per_second : unit<erg_per_second> {};
 
 struct dim_power : physical::dim_power<dim_power, erg_per_second, dim_energy, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/power.h
+++ b/src/include/units/physical/cgs/power.h
@@ -33,7 +33,7 @@ struct erg_per_second : unit<erg_per_second> {};
 
 struct dim_power : physical::dim_power<dim_power, erg_per_second, dim_energy, dim_time> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/pressure.h
+++ b/src/include/units/physical/cgs/pressure.h
@@ -34,7 +34,7 @@ struct barye : named_unit<barye, "Ba", si::prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, barye, dim_force, dim_area> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/pressure.h
+++ b/src/include/units/physical/cgs/pressure.h
@@ -34,7 +34,7 @@ struct barye : named_unit<barye, "Ba", si::prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, barye, dim_force, dim_area> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/pressure.h
+++ b/src/include/units/physical/cgs/pressure.h
@@ -34,7 +34,7 @@ struct barye : named_unit<barye, "Ba", si::prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, barye, dim_force, dim_area> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/pressure.h
+++ b/src/include/units/physical/cgs/pressure.h
@@ -34,7 +34,7 @@ struct barye : named_unit<barye, "Ba", si::prefix> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, barye, dim_force, dim_area> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/speed.h
+++ b/src/include/units/physical/cgs/speed.h
@@ -32,7 +32,7 @@ namespace units::physical::cgs {
 struct centimetre_per_second : unit<centimetre_per_second> {};
 struct dim_speed : physical::dim_speed<dim_speed, centimetre_per_second, dim_length, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/speed.h
+++ b/src/include/units/physical/cgs/speed.h
@@ -32,7 +32,7 @@ namespace units::physical::cgs {
 struct centimetre_per_second : unit<centimetre_per_second> {};
 struct dim_speed : physical::dim_speed<dim_speed, centimetre_per_second, dim_length, dim_time> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/speed.h
+++ b/src/include/units/physical/cgs/speed.h
@@ -32,7 +32,7 @@ namespace units::physical::cgs {
 struct centimetre_per_second : unit<centimetre_per_second> {};
 struct dim_speed : physical::dim_speed<dim_speed, centimetre_per_second, dim_length, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/cgs/speed.h
+++ b/src/include/units/physical/cgs/speed.h
@@ -32,7 +32,7 @@ namespace units::physical::cgs {
 struct centimetre_per_second : unit<centimetre_per_second> {};
 struct dim_speed : physical::dim_speed<dim_speed, centimetre_per_second, dim_length, dim_time> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/dimensions.h
+++ b/src/include/units/physical/dimensions.h
@@ -37,149 +37,149 @@ concept QuantityOf = Quantity<Q> && is_derived_from_instantiation<typename Q::di
 
 // ------------------------ base dimensions -----------------------------
 
-template<Unit U>
+template<in_unit U>
 struct dim_length : base_dimension<"L", U> {};
 
-template<Unit U>
+template<in_unit U>
 struct dim_mass : base_dimension<"M", U> {};
 
-template<Unit U>
+template<in_unit U>
 struct dim_time : base_dimension<"T", U> {};
 
-template<Unit U>
+template<in_unit U>
 struct dim_electric_current : base_dimension<"I", U> {};
 
-template<Unit U>
+template<in_unit U>
 struct dim_thermodynamic_temperature : base_dimension<"Θ", U> {};
 
-template<Unit U>
+template<in_unit U>
 struct dim_substance : base_dimension<"N", U> {};
 
-template<Unit U>
+template<in_unit U>
 struct dim_luminous_intensity : base_dimension<"J", U> {};
 
-template<Unit U>
+template<in_unit U>
 struct dim_angle : base_dimension<"A", U> {};
 
 // ------------------------ derived dimensions -----------------------------
 
-template<typename Child, Unit U, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, DimensionOf<dim_time> T>
 struct dim_frequency : derived_dimension<Child, U, exp<T, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_length> L>
 struct dim_area : derived_dimension<Child, U, exp<L, 2>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_length> L>
 struct dim_volume : derived_dimension<Child, U, exp<L, 3>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_length> L, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, DimensionOf<dim_length> L, DimensionOf<dim_time> T>
 struct dim_speed : derived_dimension<Child, U, exp<L, 1>, exp<T, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_length> L, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, DimensionOf<dim_length> L, DimensionOf<dim_time> T>
 struct dim_acceleration : derived_dimension<Child, U, exp<L, 1>, exp<T, -2>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_mass> M, DimensionOf<dim_acceleration> A>
+template<typename Child, in_unit U, DimensionOf<dim_mass> M, DimensionOf<dim_acceleration> A>
 struct dim_force : derived_dimension<Child, U, exp<M, 1>, exp<A, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_mass> M, DimensionOf<dim_speed> V>
+template<typename Child, in_unit U, DimensionOf<dim_mass> M, DimensionOf<dim_speed> V>
 struct dim_momentum : derived_dimension<Child, U, exp<M, 1>, exp<V, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_force> F, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_force> F, DimensionOf<dim_length> L>
 struct dim_energy : derived_dimension<Child, U, exp<F, 1>, exp<L, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_energy> E, DimensionOf<dim_angle> A>
+template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_angle> A>
 struct dim_torque : derived_dimension<Child, U, exp<E, 1>, exp<A, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_mass> M, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_mass> M, DimensionOf<dim_length> L>
 struct dim_density : derived_dimension<Child, U, exp<M, 1>, exp<L, -3>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_energy> E, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_time> T>
 struct dim_power : derived_dimension<Child, U, exp<E, 1>, exp<T, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_power> P, DimensionOf<dim_electric_current> C>
+template<typename Child, in_unit U, DimensionOf<dim_power> P, DimensionOf<dim_electric_current> C>
 struct dim_voltage : derived_dimension<Child, U, exp<P, 1>, exp<C, -1>> {};
 
-template <typename Child, Unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_electric_current> C>
+template <typename Child, in_unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_electric_current> C>
 struct dim_resistance : derived_dimension<Child,U, exp<V, 1>, exp<C, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_time> T, DimensionOf<dim_electric_current> C>
+template<typename Child, in_unit U, DimensionOf<dim_time> T, DimensionOf<dim_electric_current> C>
 struct dim_electric_charge : derived_dimension<Child, U, exp<T, 1>, exp<C, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_electric_charge> C, DimensionOf<dim_voltage> V>
+template<typename Child, in_unit U, DimensionOf<dim_electric_charge> C, DimensionOf<dim_voltage> V>
 struct dim_capacitance : derived_dimension<Child, U, exp<C, 1>, exp<V, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_force> F, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_force> F, DimensionOf<dim_length> L>
 struct dim_surface_tension : derived_dimension<Child, U, exp<F, 1>, exp<L, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_force> F, DimensionOf<dim_area> A>
+template<typename Child, in_unit U, DimensionOf<dim_force> F, DimensionOf<dim_area> A>
 struct dim_pressure : derived_dimension<Child, U, exp<F, 1>, exp<A, -1>> {};
 
-template <typename Child, Unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_time> T, DimensionOf<dim_length> L>
+template <typename Child, in_unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_time> T, DimensionOf<dim_length> L>
 struct dim_magnetic_induction : derived_dimension<Child, U, exp<V, 1>, exp<T, 1>, exp<L, -2>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_magnetic_induction> B, DimensionOf<dim_area> A>
+template<typename Child, in_unit U, DimensionOf<dim_magnetic_induction> B, DimensionOf<dim_area> A>
 struct dim_magnetic_flux : derived_dimension<Child, U, exp<B, 1>, exp<A, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_magnetic_flux> F, DimensionOf<dim_electric_current> I>
+template<typename Child, in_unit U, DimensionOf<dim_magnetic_flux> F, DimensionOf<dim_electric_current> I>
 struct dim_inductance : derived_dimension<Child, U, exp<F, 1>, exp<I, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_resistance> R>
+template<typename Child, in_unit U, DimensionOf<dim_resistance> R>
 struct dim_conductance : derived_dimension<Child, U, exp<R, -1>> {};
 
 // TODO Add when downcasting issue is solved
-// template<typename Child, Unit U, DimensionOf<dim_time> T>
+// template<typename Child, in_unit U, DimensionOf<dim_time> T>
 // struct dim_radioactivity : derived_dimension<Child, U, exp<T, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_time> T, DimensionOf<dim_substance> M>
+template<typename Child, in_unit U, DimensionOf<dim_time> T, DimensionOf<dim_substance> M>
 struct dim_catalytic_activity : derived_dimension<Child, U, exp<T, -1>, exp<M, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_energy> E, DimensionOf<dim_mass> M>
+template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_mass> M>
 struct dim_absorbed_dose : derived_dimension<Child, U, exp<E, 1>, exp<M, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_electric_current> I, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_electric_current> I, DimensionOf<dim_length> L>
 struct dim_current_density : derived_dimension<Child, U, exp<I, 1>, exp<L, -2>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_substance> M, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_substance> M, DimensionOf<dim_length> L>
 struct dim_concentration : derived_dimension<Child, U, exp<M, 1>, exp<L, -3>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_luminous_intensity> I, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_luminous_intensity> I, DimensionOf<dim_length> L>
 struct dim_luminance : derived_dimension<Child, U, exp<I, 1>, exp<L, -2>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_pressure> P, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, DimensionOf<dim_pressure> P, DimensionOf<dim_time> T>
 struct dim_dynamic_viscosity : derived_dimension<Child, U, exp<P, 1>, exp<T, 1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_energy> E, DimensionOf<dim_thermodynamic_temperature> T>
+template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_thermodynamic_temperature> T>
 struct dim_heat_capacity : derived_dimension<Child, U, exp<E, 1>, exp<T, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_heat_capacity> C, DimensionOf<dim_mass> M>
+template<typename Child, in_unit U, DimensionOf<dim_heat_capacity> C, DimensionOf<dim_mass> M>
 struct dim_specific_heat_capacity : derived_dimension<Child, U, exp<C, 1>, exp<M, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_heat_capacity> C, DimensionOf<dim_substance> M>
+template<typename Child, in_unit U, DimensionOf<dim_heat_capacity> C, DimensionOf<dim_substance> M>
 struct dim_molar_heat_capacity : derived_dimension<Child, U, exp<C, 1>, exp<M, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_power> P, DimensionOf<dim_length> L, DimensionOf<dim_thermodynamic_temperature> T>
+template<typename Child, in_unit U, DimensionOf<dim_power> P, DimensionOf<dim_length> L, DimensionOf<dim_thermodynamic_temperature> T>
 struct dim_thermal_conductivity : derived_dimension<Child, U, exp<P, 1>, exp<L, -1>, exp<T, -1>> {};
 
 // TODO Add when downcasting issue is solved
-// template<typename Child, Unit U, DimensionOf<dim_energy> E, DimensionOf<dim_length> L>
+// template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_length> L>
 // struct dim_energy_density : derived_dimension<Child, U, exp<E, 1>, exp<L, -3>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_length> L>
 struct dim_electric_field_strength : derived_dimension<Child, U, exp<V, 1>, exp<L, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_electric_charge> Q, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_electric_charge> Q, DimensionOf<dim_length> L>
 struct dim_charge_density : derived_dimension<Child, U, exp<Q, 1>, exp<L, -3>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_electric_charge> Q, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_electric_charge> Q, DimensionOf<dim_length> L>
 struct dim_surface_charge_density : derived_dimension<Child, U, exp<Q, 1>, exp<L, -2>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_capacitance> C, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_capacitance> C, DimensionOf<dim_length> L>
 struct dim_permittivity : derived_dimension<Child, U, exp<C, 1>, exp<L, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_inductance> H, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, DimensionOf<dim_inductance> H, DimensionOf<dim_length> L>
 struct dim_permeability : derived_dimension<Child, U, exp<H, 1>, exp<L, -1>> {};
 
-template<typename Child, Unit U, DimensionOf<dim_energy> E, DimensionOf<dim_substance> M>
+template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_substance> M>
 struct dim_molar_energy : derived_dimension<Child, U, exp<E, 1>, exp<M, -1>> {};
 
 template<typename T>

--- a/src/include/units/physical/dimensions.h
+++ b/src/include/units/physical/dimensions.h
@@ -30,10 +30,10 @@
 namespace units::physical {
 
 template<typename Dim, template<typename...> typename DimTemplate>
-concept DimensionOf = Dimension<Dim> && is_derived_from_instantiation<Dim, DimTemplate>;
+concept in_dimension_of = in_dimension<Dim> && is_derived_from_instantiation<Dim, DimTemplate>;
 
 template<typename Q, template<typename...> typename DimTemplate>
-concept QuantityOf = Quantity<Q> && is_derived_from_instantiation<typename Q::dimension, DimTemplate>;
+concept QuantityOf = in_quantity<Q> && is_derived_from_instantiation<typename Q::dimension, DimTemplate>;
 
 // ------------------------ base dimensions -----------------------------
 
@@ -63,123 +63,123 @@ struct dim_angle : base_dimension<"A", U> {};
 
 // ------------------------ derived dimensions -----------------------------
 
-template<typename Child, in_unit U, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, in_dimension_of<dim_time> T>
 struct dim_frequency : derived_dimension<Child, U, exp<T, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_length> L>
 struct dim_area : derived_dimension<Child, U, exp<L, 2>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_length> L>
 struct dim_volume : derived_dimension<Child, U, exp<L, 3>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_length> L, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, in_dimension_of<dim_length> L, in_dimension_of<dim_time> T>
 struct dim_speed : derived_dimension<Child, U, exp<L, 1>, exp<T, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_length> L, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, in_dimension_of<dim_length> L, in_dimension_of<dim_time> T>
 struct dim_acceleration : derived_dimension<Child, U, exp<L, 1>, exp<T, -2>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_mass> M, DimensionOf<dim_acceleration> A>
+template<typename Child, in_unit U, in_dimension_of<dim_mass> M, in_dimension_of<dim_acceleration> A>
 struct dim_force : derived_dimension<Child, U, exp<M, 1>, exp<A, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_mass> M, DimensionOf<dim_speed> V>
+template<typename Child, in_unit U, in_dimension_of<dim_mass> M, in_dimension_of<dim_speed> V>
 struct dim_momentum : derived_dimension<Child, U, exp<M, 1>, exp<V, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_force> F, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_force> F, in_dimension_of<dim_length> L>
 struct dim_energy : derived_dimension<Child, U, exp<F, 1>, exp<L, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_angle> A>
+template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_of<dim_angle> A>
 struct dim_torque : derived_dimension<Child, U, exp<E, 1>, exp<A, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_mass> M, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_mass> M, in_dimension_of<dim_length> L>
 struct dim_density : derived_dimension<Child, U, exp<M, 1>, exp<L, -3>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_of<dim_time> T>
 struct dim_power : derived_dimension<Child, U, exp<E, 1>, exp<T, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_power> P, DimensionOf<dim_electric_current> C>
+template<typename Child, in_unit U, in_dimension_of<dim_power> P, in_dimension_of<dim_electric_current> C>
 struct dim_voltage : derived_dimension<Child, U, exp<P, 1>, exp<C, -1>> {};
 
-template <typename Child, in_unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_electric_current> C>
+template <typename Child, in_unit U, in_dimension_of<dim_voltage> V, in_dimension_of<dim_electric_current> C>
 struct dim_resistance : derived_dimension<Child,U, exp<V, 1>, exp<C, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_time> T, DimensionOf<dim_electric_current> C>
+template<typename Child, in_unit U, in_dimension_of<dim_time> T, in_dimension_of<dim_electric_current> C>
 struct dim_electric_charge : derived_dimension<Child, U, exp<T, 1>, exp<C, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_electric_charge> C, DimensionOf<dim_voltage> V>
+template<typename Child, in_unit U, in_dimension_of<dim_electric_charge> C, in_dimension_of<dim_voltage> V>
 struct dim_capacitance : derived_dimension<Child, U, exp<C, 1>, exp<V, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_force> F, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_force> F, in_dimension_of<dim_length> L>
 struct dim_surface_tension : derived_dimension<Child, U, exp<F, 1>, exp<L, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_force> F, DimensionOf<dim_area> A>
+template<typename Child, in_unit U, in_dimension_of<dim_force> F, in_dimension_of<dim_area> A>
 struct dim_pressure : derived_dimension<Child, U, exp<F, 1>, exp<A, -1>> {};
 
-template <typename Child, in_unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_time> T, DimensionOf<dim_length> L>
+template <typename Child, in_unit U, in_dimension_of<dim_voltage> V, in_dimension_of<dim_time> T, in_dimension_of<dim_length> L>
 struct dim_magnetic_induction : derived_dimension<Child, U, exp<V, 1>, exp<T, 1>, exp<L, -2>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_magnetic_induction> B, DimensionOf<dim_area> A>
+template<typename Child, in_unit U, in_dimension_of<dim_magnetic_induction> B, in_dimension_of<dim_area> A>
 struct dim_magnetic_flux : derived_dimension<Child, U, exp<B, 1>, exp<A, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_magnetic_flux> F, DimensionOf<dim_electric_current> I>
+template<typename Child, in_unit U, in_dimension_of<dim_magnetic_flux> F, in_dimension_of<dim_electric_current> I>
 struct dim_inductance : derived_dimension<Child, U, exp<F, 1>, exp<I, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_resistance> R>
+template<typename Child, in_unit U, in_dimension_of<dim_resistance> R>
 struct dim_conductance : derived_dimension<Child, U, exp<R, -1>> {};
 
 // TODO Add when downcasting issue is solved
-// template<typename Child, in_unit U, DimensionOf<dim_time> T>
+// template<typename Child, in_unit U, in_dimension_of<dim_time> T>
 // struct dim_radioactivity : derived_dimension<Child, U, exp<T, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_time> T, DimensionOf<dim_substance> M>
+template<typename Child, in_unit U, in_dimension_of<dim_time> T, in_dimension_of<dim_substance> M>
 struct dim_catalytic_activity : derived_dimension<Child, U, exp<T, -1>, exp<M, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_mass> M>
+template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_of<dim_mass> M>
 struct dim_absorbed_dose : derived_dimension<Child, U, exp<E, 1>, exp<M, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_electric_current> I, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_electric_current> I, in_dimension_of<dim_length> L>
 struct dim_current_density : derived_dimension<Child, U, exp<I, 1>, exp<L, -2>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_substance> M, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_substance> M, in_dimension_of<dim_length> L>
 struct dim_concentration : derived_dimension<Child, U, exp<M, 1>, exp<L, -3>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_luminous_intensity> I, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_luminous_intensity> I, in_dimension_of<dim_length> L>
 struct dim_luminance : derived_dimension<Child, U, exp<I, 1>, exp<L, -2>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_pressure> P, DimensionOf<dim_time> T>
+template<typename Child, in_unit U, in_dimension_of<dim_pressure> P, in_dimension_of<dim_time> T>
 struct dim_dynamic_viscosity : derived_dimension<Child, U, exp<P, 1>, exp<T, 1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_thermodynamic_temperature> T>
+template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_of<dim_thermodynamic_temperature> T>
 struct dim_heat_capacity : derived_dimension<Child, U, exp<E, 1>, exp<T, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_heat_capacity> C, DimensionOf<dim_mass> M>
+template<typename Child, in_unit U, in_dimension_of<dim_heat_capacity> C, in_dimension_of<dim_mass> M>
 struct dim_specific_heat_capacity : derived_dimension<Child, U, exp<C, 1>, exp<M, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_heat_capacity> C, DimensionOf<dim_substance> M>
+template<typename Child, in_unit U, in_dimension_of<dim_heat_capacity> C, in_dimension_of<dim_substance> M>
 struct dim_molar_heat_capacity : derived_dimension<Child, U, exp<C, 1>, exp<M, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_power> P, DimensionOf<dim_length> L, DimensionOf<dim_thermodynamic_temperature> T>
+template<typename Child, in_unit U, in_dimension_of<dim_power> P, in_dimension_of<dim_length> L, in_dimension_of<dim_thermodynamic_temperature> T>
 struct dim_thermal_conductivity : derived_dimension<Child, U, exp<P, 1>, exp<L, -1>, exp<T, -1>> {};
 
 // TODO Add when downcasting issue is solved
-// template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_length> L>
+// template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_of<dim_length> L>
 // struct dim_energy_density : derived_dimension<Child, U, exp<E, 1>, exp<L, -3>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_voltage> V, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_voltage> V, in_dimension_of<dim_length> L>
 struct dim_electric_field_strength : derived_dimension<Child, U, exp<V, 1>, exp<L, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_electric_charge> Q, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_electric_charge> Q, in_dimension_of<dim_length> L>
 struct dim_charge_density : derived_dimension<Child, U, exp<Q, 1>, exp<L, -3>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_electric_charge> Q, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_electric_charge> Q, in_dimension_of<dim_length> L>
 struct dim_surface_charge_density : derived_dimension<Child, U, exp<Q, 1>, exp<L, -2>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_capacitance> C, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_capacitance> C, in_dimension_of<dim_length> L>
 struct dim_permittivity : derived_dimension<Child, U, exp<C, 1>, exp<L, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_inductance> H, DimensionOf<dim_length> L>
+template<typename Child, in_unit U, in_dimension_of<dim_inductance> H, in_dimension_of<dim_length> L>
 struct dim_permeability : derived_dimension<Child, U, exp<H, 1>, exp<L, -1>> {};
 
-template<typename Child, in_unit U, DimensionOf<dim_energy> E, DimensionOf<dim_substance> M>
+template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_of<dim_substance> M>
 struct dim_molar_energy : derived_dimension<Child, U, exp<E, 1>, exp<M, -1>> {};
 
 template<typename T>

--- a/src/include/units/physical/dimensions.h
+++ b/src/include/units/physical/dimensions.h
@@ -33,7 +33,7 @@ template<typename Dim, template<typename...> typename DimTemplate>
 concept in_dimension_of = in_dimension<Dim> && is_derived_from_instantiation<Dim, DimTemplate>;
 
 template<typename Q, template<typename...> typename DimTemplate>
-concept QuantityOf = in_quantity<Q> && is_derived_from_instantiation<typename Q::dimension, DimTemplate>;
+concept in_quantity_of = in_quantity<Q> && is_derived_from_instantiation<typename Q::dimension, DimTemplate>;
 
 // ------------------------ base dimensions -----------------------------
 
@@ -183,143 +183,143 @@ template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_
 struct dim_molar_energy : derived_dimension<Child, U, exp<E, 1>, exp<M, -1>> {};
 
 template<typename T>
-concept Length = QuantityOf<T, dim_length>;
+concept Length = in_quantity_of<T, dim_length>;
 
 template<typename T>
-concept Mass = QuantityOf<T, dim_mass>;
+concept Mass = in_quantity_of<T, dim_mass>;
 
 template<typename T>
-concept Time = QuantityOf<T, dim_time>;
+concept Time = in_quantity_of<T, dim_time>;
 
 template<typename T>
-concept Current = QuantityOf<T, dim_electric_current>;
+concept Current = in_quantity_of<T, dim_electric_current>;
 
 template<typename T>
-concept Temperature = QuantityOf<T, dim_thermodynamic_temperature>;
+concept Temperature = in_quantity_of<T, dim_thermodynamic_temperature>;
 
 template<typename T>
-concept Substance = QuantityOf<T, dim_substance>;
+concept Substance = in_quantity_of<T, dim_substance>;
 
 template<typename T>
-concept LuminousIntensity = QuantityOf<T, dim_luminous_intensity>;
+concept LuminousIntensity = in_quantity_of<T, dim_luminous_intensity>;
 
 template <typename T>
-concept Angle = QuantityOf<T, dim_angle>;
+concept Angle = in_quantity_of<T, dim_angle>;
 
 template<typename T>
-concept Frequency = QuantityOf<T, dim_frequency>;
+concept Frequency = in_quantity_of<T, dim_frequency>;
 
 template<typename T>
-concept Area = QuantityOf<T, dim_area>;
+concept Area = in_quantity_of<T, dim_area>;
 
 template<typename T>
-concept Volume = QuantityOf<T, dim_volume>;
+concept Volume = in_quantity_of<T, dim_volume>;
 
 template<typename T>
-concept Speed = QuantityOf<T, dim_speed>;
+concept Speed = in_quantity_of<T, dim_speed>;
 
 template<typename T>
-concept Acceleration = QuantityOf<T, dim_acceleration>;
+concept Acceleration = in_quantity_of<T, dim_acceleration>;
 
 template<typename T>
-concept Force = QuantityOf<T, dim_force>;
+concept Force = in_quantity_of<T, dim_force>;
 
 template<typename T>
-concept Momentum = QuantityOf<T, dim_momentum>;
+concept Momentum = in_quantity_of<T, dim_momentum>;
 
 template<typename T>
-concept Energy = QuantityOf<T, dim_energy>;
+concept Energy = in_quantity_of<T, dim_energy>;
 
 template<typename T>
-concept Torque = QuantityOf<T, dim_torque>;
+concept Torque = in_quantity_of<T, dim_torque>;
 
 template<typename T>
-concept Density = QuantityOf<T, dim_density>;
+concept Density = in_quantity_of<T, dim_density>;
 
 template<typename T>
-concept Power = QuantityOf<T, dim_power>;
+concept Power = in_quantity_of<T, dim_power>;
 
 template<typename T>
-concept Voltage = QuantityOf<T, dim_voltage>;
+concept Voltage = in_quantity_of<T, dim_voltage>;
 
 template<typename T>
-concept ElectricCharge = QuantityOf<T, dim_electric_charge>;
+concept ElectricCharge = in_quantity_of<T, dim_electric_charge>;
 
 template<typename T>
-concept Capacitance = QuantityOf<T, dim_capacitance>;
+concept Capacitance = in_quantity_of<T, dim_capacitance>;
 
 template<typename T>
-concept SurfaceTension = QuantityOf<T, dim_surface_tension>;
+concept SurfaceTension = in_quantity_of<T, dim_surface_tension>;
 
 template<typename T>
-concept Pressure = QuantityOf<T, dim_pressure>;
+concept Pressure = in_quantity_of<T, dim_pressure>;
 
 template<typename T>
-concept MagneticInduction = QuantityOf<T, dim_magnetic_induction>;
+concept MagneticInduction = in_quantity_of<T, dim_magnetic_induction>;
 
 template<typename T>
-concept MagneticFlux = QuantityOf<T, dim_magnetic_flux>;
+concept MagneticFlux = in_quantity_of<T, dim_magnetic_flux>;
 
 template<typename T>
-concept Inductance = QuantityOf<T, dim_inductance>;
+concept Inductance = in_quantity_of<T, dim_inductance>;
 
 template<typename T>
-concept Conductance = QuantityOf<T, dim_conductance>;
+concept Conductance = in_quantity_of<T, dim_conductance>;
 
 // TODO Add when downcasting issue is solved
 // template<typename T>
-// concept Radioactivity = QuantityOf<T, dim_radioactivity>;
+// concept Radioactivity = in_quantity_of<T, dim_radioactivity>;
 
 template<typename T>
-concept CatalyticActivity = QuantityOf<T, dim_catalytic_activity>;
+concept CatalyticActivity = in_quantity_of<T, dim_catalytic_activity>;
 
 template<typename T>
-concept AbsorbedDose = QuantityOf<T, dim_absorbed_dose>;
+concept AbsorbedDose = in_quantity_of<T, dim_absorbed_dose>;
 
 template<typename T>
-concept CurrentDensity = QuantityOf<T, dim_current_density>;
+concept CurrentDensity = in_quantity_of<T, dim_current_density>;
 
 template<typename T>
-concept Concentration = QuantityOf<T, dim_concentration>;
+concept Concentration = in_quantity_of<T, dim_concentration>;
 
 template<typename T>
-concept Luminance = QuantityOf<T, dim_luminance>;
+concept Luminance = in_quantity_of<T, dim_luminance>;
 
 template<typename T>
-concept DynamicViscosity = QuantityOf<T, dim_dynamic_viscosity>;
+concept DynamicViscosity = in_quantity_of<T, dim_dynamic_viscosity>;
 
 template<typename T>
-concept HeatCapacity = QuantityOf<T, dim_heat_capacity>;
+concept HeatCapacity = in_quantity_of<T, dim_heat_capacity>;
 
 template<typename T>
-concept SpecificHeatCapacity = QuantityOf<T, dim_specific_heat_capacity>;
+concept SpecificHeatCapacity = in_quantity_of<T, dim_specific_heat_capacity>;
 
 template<typename T>
-concept MolarHeatCapacity = QuantityOf<T, dim_molar_heat_capacity>;
+concept MolarHeatCapacity = in_quantity_of<T, dim_molar_heat_capacity>;
 
 template<typename T>
-concept ThermalConductivity = QuantityOf<T, dim_thermal_conductivity>;
+concept ThermalConductivity = in_quantity_of<T, dim_thermal_conductivity>;
 
 // TODO Add when downcasting issue is solved
 // template<typename T>
-// concept EnergyDensity = QuantityOf<T, dim_energy_density>;
+// concept EnergyDensity = in_quantity_of<T, dim_energy_density>;
 
 template<typename T>
-concept ElectricFieldStrength = QuantityOf<T, dim_electric_field_strength>;
+concept ElectricFieldStrength = in_quantity_of<T, dim_electric_field_strength>;
 
 template<typename T>
-concept ChargeDensity = QuantityOf<T, dim_charge_density>;
+concept ChargeDensity = in_quantity_of<T, dim_charge_density>;
 
 template<typename T>
-concept SurfaceChargeDensity = QuantityOf<T, dim_surface_charge_density>;
+concept SurfaceChargeDensity = in_quantity_of<T, dim_surface_charge_density>;
 
 template<typename T>
-concept Permittivity = QuantityOf<T, dim_permittivity>;
+concept Permittivity = in_quantity_of<T, dim_permittivity>;
 
 template<typename T>
-concept Permeability = QuantityOf<T, dim_permeability>;
+concept Permeability = in_quantity_of<T, dim_permeability>;
 
 template<typename T>
-concept MolarEnergy = QuantityOf<T, dim_molar_energy>;
+concept MolarEnergy = in_quantity_of<T, dim_molar_energy>;
 
 }  // namespace units::physical

--- a/src/include/units/physical/dimensions.h
+++ b/src/include/units/physical/dimensions.h
@@ -183,143 +183,143 @@ template<typename Child, in_unit U, in_dimension_of<dim_energy> E, in_dimension_
 struct dim_molar_energy : derived_dimension<Child, U, exp<E, 1>, exp<M, -1>> {};
 
 template<typename T>
-concept Length = in_quantity_of<T, dim_length>;
+concept in_length = in_quantity_of<T, dim_length>;
 
 template<typename T>
-concept Mass = in_quantity_of<T, dim_mass>;
+concept in_mass = in_quantity_of<T, dim_mass>;
 
 template<typename T>
-concept Time = in_quantity_of<T, dim_time>;
+concept in_time = in_quantity_of<T, dim_time>;
 
 template<typename T>
-concept Current = in_quantity_of<T, dim_electric_current>;
+concept in_current = in_quantity_of<T, dim_electric_current>;
 
 template<typename T>
-concept Temperature = in_quantity_of<T, dim_thermodynamic_temperature>;
+concept in_temperature = in_quantity_of<T, dim_thermodynamic_temperature>;
 
 template<typename T>
-concept Substance = in_quantity_of<T, dim_substance>;
+concept in_substance = in_quantity_of<T, dim_substance>;
 
 template<typename T>
-concept LuminousIntensity = in_quantity_of<T, dim_luminous_intensity>;
+concept in_luminous_intensity = in_quantity_of<T, dim_luminous_intensity>;
 
 template <typename T>
-concept Angle = in_quantity_of<T, dim_angle>;
+concept in_angle = in_quantity_of<T, dim_angle>;
 
 template<typename T>
-concept Frequency = in_quantity_of<T, dim_frequency>;
+concept in_frequency = in_quantity_of<T, dim_frequency>;
 
 template<typename T>
-concept Area = in_quantity_of<T, dim_area>;
+concept in_area = in_quantity_of<T, dim_area>;
 
 template<typename T>
-concept Volume = in_quantity_of<T, dim_volume>;
+concept in_volume = in_quantity_of<T, dim_volume>;
 
 template<typename T>
-concept Speed = in_quantity_of<T, dim_speed>;
+concept in_speed = in_quantity_of<T, dim_speed>;
 
 template<typename T>
-concept Acceleration = in_quantity_of<T, dim_acceleration>;
+concept in_acceleration = in_quantity_of<T, dim_acceleration>;
 
 template<typename T>
-concept Force = in_quantity_of<T, dim_force>;
+concept in_force = in_quantity_of<T, dim_force>;
 
 template<typename T>
-concept Momentum = in_quantity_of<T, dim_momentum>;
+concept in_momentum = in_quantity_of<T, dim_momentum>;
 
 template<typename T>
-concept Energy = in_quantity_of<T, dim_energy>;
+concept in_energy = in_quantity_of<T, dim_energy>;
 
 template<typename T>
-concept Torque = in_quantity_of<T, dim_torque>;
+concept in_torque = in_quantity_of<T, dim_torque>;
 
 template<typename T>
-concept Density = in_quantity_of<T, dim_density>;
+concept in_density = in_quantity_of<T, dim_density>;
 
 template<typename T>
-concept Power = in_quantity_of<T, dim_power>;
+concept in_power = in_quantity_of<T, dim_power>;
 
 template<typename T>
-concept Voltage = in_quantity_of<T, dim_voltage>;
+concept in_voltage = in_quantity_of<T, dim_voltage>;
 
 template<typename T>
-concept ElectricCharge = in_quantity_of<T, dim_electric_charge>;
+concept in_electric_charge = in_quantity_of<T, dim_electric_charge>;
 
 template<typename T>
-concept Capacitance = in_quantity_of<T, dim_capacitance>;
+concept in_capacitance = in_quantity_of<T, dim_capacitance>;
 
 template<typename T>
-concept SurfaceTension = in_quantity_of<T, dim_surface_tension>;
+concept in_surface_tension = in_quantity_of<T, dim_surface_tension>;
 
 template<typename T>
-concept Pressure = in_quantity_of<T, dim_pressure>;
+concept in_pressure = in_quantity_of<T, dim_pressure>;
 
 template<typename T>
-concept MagneticInduction = in_quantity_of<T, dim_magnetic_induction>;
+concept in_magnetic_induction = in_quantity_of<T, dim_magnetic_induction>;
 
 template<typename T>
-concept MagneticFlux = in_quantity_of<T, dim_magnetic_flux>;
+concept in_magnetic_flux = in_quantity_of<T, dim_magnetic_flux>;
 
 template<typename T>
-concept Inductance = in_quantity_of<T, dim_inductance>;
+concept in_inductance = in_quantity_of<T, dim_inductance>;
 
 template<typename T>
-concept Conductance = in_quantity_of<T, dim_conductance>;
+concept in_conductance = in_quantity_of<T, dim_conductance>;
 
 // TODO Add when downcasting issue is solved
 // template<typename T>
 // concept Radioactivity = in_quantity_of<T, dim_radioactivity>;
 
 template<typename T>
-concept CatalyticActivity = in_quantity_of<T, dim_catalytic_activity>;
+concept in_catalytic_activity = in_quantity_of<T, dim_catalytic_activity>;
 
 template<typename T>
-concept AbsorbedDose = in_quantity_of<T, dim_absorbed_dose>;
+concept in_absorbed_dose = in_quantity_of<T, dim_absorbed_dose>;
 
 template<typename T>
-concept CurrentDensity = in_quantity_of<T, dim_current_density>;
+concept in_current_density = in_quantity_of<T, dim_current_density>;
 
 template<typename T>
-concept Concentration = in_quantity_of<T, dim_concentration>;
+concept in_concentration = in_quantity_of<T, dim_concentration>;
 
 template<typename T>
-concept Luminance = in_quantity_of<T, dim_luminance>;
+concept in_luminance = in_quantity_of<T, dim_luminance>;
 
 template<typename T>
-concept DynamicViscosity = in_quantity_of<T, dim_dynamic_viscosity>;
+concept in_dynamic_viscosity = in_quantity_of<T, dim_dynamic_viscosity>;
 
 template<typename T>
-concept HeatCapacity = in_quantity_of<T, dim_heat_capacity>;
+concept in_heat_capacity = in_quantity_of<T, dim_heat_capacity>;
 
 template<typename T>
-concept SpecificHeatCapacity = in_quantity_of<T, dim_specific_heat_capacity>;
+concept in_specific_heat_capacity = in_quantity_of<T, dim_specific_heat_capacity>;
 
 template<typename T>
-concept MolarHeatCapacity = in_quantity_of<T, dim_molar_heat_capacity>;
+concept in_molar_heat_capacity = in_quantity_of<T, dim_molar_heat_capacity>;
 
 template<typename T>
-concept ThermalConductivity = in_quantity_of<T, dim_thermal_conductivity>;
+concept in_thermal_conductivity = in_quantity_of<T, dim_thermal_conductivity>;
 
 // TODO Add when downcasting issue is solved
 // template<typename T>
 // concept EnergyDensity = in_quantity_of<T, dim_energy_density>;
 
 template<typename T>
-concept ElectricFieldStrength = in_quantity_of<T, dim_electric_field_strength>;
+concept in_electric_field_strength = in_quantity_of<T, dim_electric_field_strength>;
 
 template<typename T>
-concept ChargeDensity = in_quantity_of<T, dim_charge_density>;
+concept in_charge_density = in_quantity_of<T, dim_charge_density>;
 
 template<typename T>
-concept SurfaceChargeDensity = in_quantity_of<T, dim_surface_charge_density>;
+concept in_surface_charge_density = in_quantity_of<T, dim_surface_charge_density>;
 
 template<typename T>
-concept Permittivity = in_quantity_of<T, dim_permittivity>;
+concept in_permittivity = in_quantity_of<T, dim_permittivity>;
 
 template<typename T>
-concept Permeability = in_quantity_of<T, dim_permeability>;
+concept in_permeability = in_quantity_of<T, dim_permeability>;
 
 template<typename T>
-concept MolarEnergy = in_quantity_of<T, dim_molar_energy>;
+concept in_molar_energy = in_quantity_of<T, dim_molar_energy>;
 
 }  // namespace units::physical

--- a/src/include/units/physical/natural/constants.h
+++ b/src/include/units/physical/natural/constants.h
@@ -26,7 +26,7 @@
 
 namespace units::physical::natural {
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto speed_of_light = speed<unitless, Rep>(1);
 
 }  // namespace units::physical::natural

--- a/src/include/units/physical/natural/constants.h
+++ b/src/include/units/physical/natural/constants.h
@@ -26,7 +26,7 @@
 
 namespace units::physical::natural {
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto speed_of_light = speed<unitless, Rep>(1);
 
 }  // namespace units::physical::natural

--- a/src/include/units/physical/natural/constants.h
+++ b/src/include/units/physical/natural/constants.h
@@ -26,7 +26,7 @@
 
 namespace units::physical::natural {
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto speed_of_light = speed<unitless, Rep>(1);
 
 }  // namespace units::physical::natural

--- a/src/include/units/physical/natural/dimensions.h
+++ b/src/include/units/physical/natural/dimensions.h
@@ -29,35 +29,35 @@
 namespace units::physical::natural {
 
 struct dim_length : physical::dim_length<inverted_gigaelectronvolt> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 struct dim_time : physical::dim_time<inverted_gigaelectronvolt> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 struct dim_mass : physical::dim_mass<gigaelectronvolt> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 struct dim_speed : physical::dim_speed<dim_speed, unitless, dim_length, dim_time> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gigaelectronvolt, dim_length, dim_time> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 struct dim_force : physical::dim_force<dim_force, square_gigaelectronvolt, dim_mass, dim_acceleration> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 struct dim_momentum : physical::dim_momentum<dim_momentum, gigaelectronvolt, dim_mass, dim_speed> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 struct dim_energy : physical::dim_energy<dim_energy, gigaelectronvolt, dim_force, dim_length> {};
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using energy = quantity<dim_force, U, Rep>;
 
 // Typical UDLs will not work here as the same units are reused by many quantities.

--- a/src/include/units/physical/natural/dimensions.h
+++ b/src/include/units/physical/natural/dimensions.h
@@ -29,35 +29,35 @@
 namespace units::physical::natural {
 
 struct dim_length : physical::dim_length<inverted_gigaelectronvolt> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 struct dim_time : physical::dim_time<inverted_gigaelectronvolt> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 struct dim_mass : physical::dim_mass<gigaelectronvolt> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 struct dim_speed : physical::dim_speed<dim_speed, unitless, dim_length, dim_time> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gigaelectronvolt, dim_length, dim_time> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 struct dim_force : physical::dim_force<dim_force, square_gigaelectronvolt, dim_mass, dim_acceleration> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 struct dim_momentum : physical::dim_momentum<dim_momentum, gigaelectronvolt, dim_mass, dim_speed> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 struct dim_energy : physical::dim_energy<dim_energy, gigaelectronvolt, dim_force, dim_length> {};
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using energy = quantity<dim_force, U, Rep>;
 
 // Typical UDLs will not work here as the same units are reused by many quantities.

--- a/src/include/units/physical/natural/dimensions.h
+++ b/src/include/units/physical/natural/dimensions.h
@@ -29,35 +29,35 @@
 namespace units::physical::natural {
 
 struct dim_length : physical::dim_length<inverted_gigaelectronvolt> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 struct dim_time : physical::dim_time<inverted_gigaelectronvolt> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 struct dim_mass : physical::dim_mass<gigaelectronvolt> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 struct dim_speed : physical::dim_speed<dim_speed, unitless, dim_length, dim_time> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gigaelectronvolt, dim_length, dim_time> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 struct dim_force : physical::dim_force<dim_force, square_gigaelectronvolt, dim_mass, dim_acceleration> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 struct dim_momentum : physical::dim_momentum<dim_momentum, gigaelectronvolt, dim_mass, dim_speed> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 struct dim_energy : physical::dim_energy<dim_energy, gigaelectronvolt, dim_force, dim_length> {};
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using energy = quantity<dim_force, U, Rep>;
 
 // Typical UDLs will not work here as the same units are reused by many quantities.

--- a/src/include/units/physical/natural/dimensions.h
+++ b/src/include/units/physical/natural/dimensions.h
@@ -29,35 +29,35 @@
 namespace units::physical::natural {
 
 struct dim_length : physical::dim_length<inverted_gigaelectronvolt> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 struct dim_time : physical::dim_time<inverted_gigaelectronvolt> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 struct dim_mass : physical::dim_mass<gigaelectronvolt> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 struct dim_speed : physical::dim_speed<dim_speed, unitless, dim_length, dim_time> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, gigaelectronvolt, dim_length, dim_time> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 struct dim_force : physical::dim_force<dim_force, square_gigaelectronvolt, dim_mass, dim_acceleration> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 struct dim_momentum : physical::dim_momentum<dim_momentum, gigaelectronvolt, dim_mass, dim_speed> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 struct dim_energy : physical::dim_energy<dim_energy, gigaelectronvolt, dim_force, dim_length> {};
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using energy = quantity<dim_force, U, Rep>;
 
 // Typical UDLs will not work here as the same units are reused by many quantities.

--- a/src/include/units/physical/si/absorbed_dose.h
+++ b/src/include/units/physical/si/absorbed_dose.h
@@ -54,7 +54,7 @@ struct yottagray : prefixed_unit<yottagray, yotta, gray> {};
 
 struct dim_absorbed_dose : physical::dim_absorbed_dose<dim_absorbed_dose, gray, dim_energy, dim_mass> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using absorbed_dose = quantity<dim_absorbed_dose, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/absorbed_dose.h
+++ b/src/include/units/physical/si/absorbed_dose.h
@@ -54,7 +54,7 @@ struct yottagray : prefixed_unit<yottagray, yotta, gray> {};
 
 struct dim_absorbed_dose : physical::dim_absorbed_dose<dim_absorbed_dose, gray, dim_energy, dim_mass> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using absorbed_dose = quantity<dim_absorbed_dose, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/absorbed_dose.h
+++ b/src/include/units/physical/si/absorbed_dose.h
@@ -54,7 +54,7 @@ struct yottagray : prefixed_unit<yottagray, yotta, gray> {};
 
 struct dim_absorbed_dose : physical::dim_absorbed_dose<dim_absorbed_dose, gray, dim_energy, dim_mass> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using absorbed_dose = quantity<dim_absorbed_dose, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/absorbed_dose.h
+++ b/src/include/units/physical/si/absorbed_dose.h
@@ -54,7 +54,7 @@ struct yottagray : prefixed_unit<yottagray, yotta, gray> {};
 
 struct dim_absorbed_dose : physical::dim_absorbed_dose<dim_absorbed_dose, gray, dim_energy, dim_mass> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using absorbed_dose = quantity<dim_absorbed_dose, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/acceleration.h
+++ b/src/include/units/physical/si/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct metre_per_second_sq : unit<metre_per_second_sq> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, metre_per_second_sq, dim_length, dim_time> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/acceleration.h
+++ b/src/include/units/physical/si/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct metre_per_second_sq : unit<metre_per_second_sq> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, metre_per_second_sq, dim_length, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/acceleration.h
+++ b/src/include/units/physical/si/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct metre_per_second_sq : unit<metre_per_second_sq> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, metre_per_second_sq, dim_length, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/acceleration.h
+++ b/src/include/units/physical/si/acceleration.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct metre_per_second_sq : unit<metre_per_second_sq> {};
 struct dim_acceleration : physical::dim_acceleration<dim_acceleration, metre_per_second_sq, dim_length, dim_time> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using acceleration = quantity<dim_acceleration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/angle.h
+++ b/src/include/units/physical/si/angle.h
@@ -32,7 +32,7 @@ struct radian : named_unit<radian, "rad", prefix> {};
 
 struct dim_angle : physical::dim_angle<radian> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using angle = quantity<dim_angle, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/angle.h
+++ b/src/include/units/physical/si/angle.h
@@ -32,7 +32,7 @@ struct radian : named_unit<radian, "rad", prefix> {};
 
 struct dim_angle : physical::dim_angle<radian> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using angle = quantity<dim_angle, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/angle.h
+++ b/src/include/units/physical/si/angle.h
@@ -32,7 +32,7 @@ struct radian : named_unit<radian, "rad", prefix> {};
 
 struct dim_angle : physical::dim_angle<radian> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using angle = quantity<dim_angle, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/angle.h
+++ b/src/include/units/physical/si/angle.h
@@ -32,7 +32,7 @@ struct radian : named_unit<radian, "rad", prefix> {};
 
 struct dim_angle : physical::dim_angle<radian> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using angle = quantity<dim_angle, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -54,7 +54,7 @@ struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre>
 
 struct hectare : alias_unit<square_hectometre, "ha", no_prefix> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -54,7 +54,7 @@ struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre>
 
 struct hectare : alias_unit<square_hectometre, "ha", no_prefix> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -54,7 +54,7 @@ struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre>
 
 struct hectare : alias_unit<square_hectometre, "ha", no_prefix> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/area.h
+++ b/src/include/units/physical/si/area.h
@@ -54,7 +54,7 @@ struct square_yottametre : deduced_unit<square_yottametre, dim_area, yottametre>
 
 struct hectare : alias_unit<square_hectometre, "ha", no_prefix> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using area = quantity<dim_area, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -54,7 +54,7 @@ struct yottafarad : prefixed_unit<yottafarad, yotta, farad> {};
 
 struct dim_capacitance : physical::dim_capacitance<dim_capacitance, farad, dim_electric_charge, dim_voltage> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using capacitance = quantity<dim_capacitance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -54,7 +54,7 @@ struct yottafarad : prefixed_unit<yottafarad, yotta, farad> {};
 
 struct dim_capacitance : physical::dim_capacitance<dim_capacitance, farad, dim_electric_charge, dim_voltage> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using capacitance = quantity<dim_capacitance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -54,7 +54,7 @@ struct yottafarad : prefixed_unit<yottafarad, yotta, farad> {};
 
 struct dim_capacitance : physical::dim_capacitance<dim_capacitance, farad, dim_electric_charge, dim_voltage> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using capacitance = quantity<dim_capacitance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/capacitance.h
+++ b/src/include/units/physical/si/capacitance.h
@@ -54,7 +54,7 @@ struct yottafarad : prefixed_unit<yottafarad, yotta, farad> {};
 
 struct dim_capacitance : physical::dim_capacitance<dim_capacitance, farad, dim_electric_charge, dim_voltage> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using capacitance = quantity<dim_capacitance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/catalytic_activity.h
+++ b/src/include/units/physical/si/catalytic_activity.h
@@ -56,7 +56,7 @@ struct enzyme_unit : named_scaled_unit<enzyme_unit, "U", prefix, ratio<1, 60, -6
 
 struct dim_catalytic_activity : physical::dim_catalytic_activity<dim_catalytic_activity, katal, dim_time, dim_substance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using catalytic_activity = quantity<dim_catalytic_activity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/catalytic_activity.h
+++ b/src/include/units/physical/si/catalytic_activity.h
@@ -56,7 +56,7 @@ struct enzyme_unit : named_scaled_unit<enzyme_unit, "U", prefix, ratio<1, 60, -6
 
 struct dim_catalytic_activity : physical::dim_catalytic_activity<dim_catalytic_activity, katal, dim_time, dim_substance> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using catalytic_activity = quantity<dim_catalytic_activity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/catalytic_activity.h
+++ b/src/include/units/physical/si/catalytic_activity.h
@@ -56,7 +56,7 @@ struct enzyme_unit : named_scaled_unit<enzyme_unit, "U", prefix, ratio<1, 60, -6
 
 struct dim_catalytic_activity : physical::dim_catalytic_activity<dim_catalytic_activity, katal, dim_time, dim_substance> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using catalytic_activity = quantity<dim_catalytic_activity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/catalytic_activity.h
+++ b/src/include/units/physical/si/catalytic_activity.h
@@ -56,7 +56,7 @@ struct enzyme_unit : named_scaled_unit<enzyme_unit, "U", prefix, ratio<1, 60, -6
 
 struct dim_catalytic_activity : physical::dim_catalytic_activity<dim_catalytic_activity, katal, dim_time, dim_substance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using catalytic_activity = quantity<dim_catalytic_activity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/charge_density.h
+++ b/src/include/units/physical/si/charge_density.h
@@ -36,10 +36,10 @@ struct coulomb_per_metre_sq : unit<coulomb_per_metre_sq> {};
 struct dim_charge_density : physical::dim_charge_density<dim_charge_density, coulomb_per_metre_cub, dim_electric_charge, dim_length> {};
 struct dim_surface_charge_density : physical::dim_surface_charge_density<dim_surface_charge_density, coulomb_per_metre_sq, dim_electric_charge, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using charge_density = quantity<dim_charge_density, U, Rep>;
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using surface_charge_density = quantity<dim_surface_charge_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/charge_density.h
+++ b/src/include/units/physical/si/charge_density.h
@@ -36,10 +36,10 @@ struct coulomb_per_metre_sq : unit<coulomb_per_metre_sq> {};
 struct dim_charge_density : physical::dim_charge_density<dim_charge_density, coulomb_per_metre_cub, dim_electric_charge, dim_length> {};
 struct dim_surface_charge_density : physical::dim_surface_charge_density<dim_surface_charge_density, coulomb_per_metre_sq, dim_electric_charge, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using charge_density = quantity<dim_charge_density, U, Rep>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using surface_charge_density = quantity<dim_surface_charge_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/charge_density.h
+++ b/src/include/units/physical/si/charge_density.h
@@ -36,10 +36,10 @@ struct coulomb_per_metre_sq : unit<coulomb_per_metre_sq> {};
 struct dim_charge_density : physical::dim_charge_density<dim_charge_density, coulomb_per_metre_cub, dim_electric_charge, dim_length> {};
 struct dim_surface_charge_density : physical::dim_surface_charge_density<dim_surface_charge_density, coulomb_per_metre_sq, dim_electric_charge, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using charge_density = quantity<dim_charge_density, U, Rep>;
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using surface_charge_density = quantity<dim_surface_charge_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/charge_density.h
+++ b/src/include/units/physical/si/charge_density.h
@@ -36,10 +36,10 @@ struct coulomb_per_metre_sq : unit<coulomb_per_metre_sq> {};
 struct dim_charge_density : physical::dim_charge_density<dim_charge_density, coulomb_per_metre_cub, dim_electric_charge, dim_length> {};
 struct dim_surface_charge_density : physical::dim_surface_charge_density<dim_surface_charge_density, coulomb_per_metre_sq, dim_electric_charge, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using charge_density = quantity<dim_charge_density, U, Rep>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using surface_charge_density = quantity<dim_surface_charge_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/concentration.h
+++ b/src/include/units/physical/si/concentration.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct mol_per_metre_cub : unit<mol_per_metre_cub> {};
 struct dim_concentration : physical::dim_concentration<dim_concentration, mol_per_metre_cub, dim_substance, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using concentration = quantity<dim_concentration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/concentration.h
+++ b/src/include/units/physical/si/concentration.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct mol_per_metre_cub : unit<mol_per_metre_cub> {};
 struct dim_concentration : physical::dim_concentration<dim_concentration, mol_per_metre_cub, dim_substance, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using concentration = quantity<dim_concentration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/concentration.h
+++ b/src/include/units/physical/si/concentration.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct mol_per_metre_cub : unit<mol_per_metre_cub> {};
 struct dim_concentration : physical::dim_concentration<dim_concentration, mol_per_metre_cub, dim_substance, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using concentration = quantity<dim_concentration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/concentration.h
+++ b/src/include/units/physical/si/concentration.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct mol_per_metre_cub : unit<mol_per_metre_cub> {};
 struct dim_concentration : physical::dim_concentration<dim_concentration, mol_per_metre_cub, dim_substance, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using concentration = quantity<dim_concentration, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/conductance.h
+++ b/src/include/units/physical/si/conductance.h
@@ -49,7 +49,7 @@ struct yottasiemens : prefixed_unit<yottasiemens, yotta, siemens> {};
 
 struct dim_conductance : physical::dim_conductance<dim_conductance, siemens, dim_resistance> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using conductance = quantity<dim_conductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/conductance.h
+++ b/src/include/units/physical/si/conductance.h
@@ -49,7 +49,7 @@ struct yottasiemens : prefixed_unit<yottasiemens, yotta, siemens> {};
 
 struct dim_conductance : physical::dim_conductance<dim_conductance, siemens, dim_resistance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using conductance = quantity<dim_conductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/conductance.h
+++ b/src/include/units/physical/si/conductance.h
@@ -49,7 +49,7 @@ struct yottasiemens : prefixed_unit<yottasiemens, yotta, siemens> {};
 
 struct dim_conductance : physical::dim_conductance<dim_conductance, siemens, dim_resistance> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using conductance = quantity<dim_conductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/conductance.h
+++ b/src/include/units/physical/si/conductance.h
@@ -49,7 +49,7 @@ struct yottasiemens : prefixed_unit<yottasiemens, yotta, siemens> {};
 
 struct dim_conductance : physical::dim_conductance<dim_conductance, siemens, dim_resistance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using conductance = quantity<dim_conductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/constants.h
+++ b/src/include/units/physical/si/constants.h
@@ -32,31 +32,31 @@
 
 namespace units::physical::si::si2019 {
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto planck_constant = energy<joule, Rep>(6.62607015e-34) * time<second, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto reduced_planck_constant = energy<gigaelectronvolt, Rep>(6.582119569e-10) * time<second, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto elementary_charge = electric_charge<coulomb, Rep>(1.602176634e-19);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto boltzmann_constant = energy<joule, Rep>(1.380649e-23) / temperature<kelvin, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto avogadro_constant = Rep(6.02214076e23) / substance<mole, Rep>(1);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto speed_of_light = speed<metre_per_second, Rep>(299'792'458);
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto hyperfine_structure_transition_frequency = frequency<hertz, Rep>(9'192'631'770);
 
-// template<Value Rep = double>
+// template<NumericValue Rep = double>
 // inline constexpr auto luminous_efficacy = 683q_lm / 1q_W;
 
-template<Value Rep = double>
+template<NumericValue Rep = double>
 inline constexpr auto standard_gravity = acceleration<metre_per_second_sq, Rep>(9.80665);
 
 }  // namespace units::physical::si::si2019

--- a/src/include/units/physical/si/constants.h
+++ b/src/include/units/physical/si/constants.h
@@ -32,31 +32,31 @@
 
 namespace units::physical::si::si2019 {
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto planck_constant = energy<joule, Rep>(6.62607015e-34) * time<second, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto reduced_planck_constant = energy<gigaelectronvolt, Rep>(6.582119569e-10) * time<second, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto elementary_charge = electric_charge<coulomb, Rep>(1.602176634e-19);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto boltzmann_constant = energy<joule, Rep>(1.380649e-23) / temperature<kelvin, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto avogadro_constant = Rep(6.02214076e23) / substance<mole, Rep>(1);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto speed_of_light = speed<metre_per_second, Rep>(299'792'458);
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto hyperfine_structure_transition_frequency = frequency<hertz, Rep>(9'192'631'770);
 
-// template<Scalar Rep = double>
+// template<Value Rep = double>
 // inline constexpr auto luminous_efficacy = 683q_lm / 1q_W;
 
-template<Scalar Rep = double>
+template<Value Rep = double>
 inline constexpr auto standard_gravity = acceleration<metre_per_second_sq, Rep>(9.80665);
 
 }  // namespace units::physical::si::si2019

--- a/src/include/units/physical/si/constants.h
+++ b/src/include/units/physical/si/constants.h
@@ -32,31 +32,31 @@
 
 namespace units::physical::si::si2019 {
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto planck_constant = energy<joule, Rep>(6.62607015e-34) * time<second, Rep>(1);
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto reduced_planck_constant = energy<gigaelectronvolt, Rep>(6.582119569e-10) * time<second, Rep>(1);
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto elementary_charge = electric_charge<coulomb, Rep>(1.602176634e-19);
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto boltzmann_constant = energy<joule, Rep>(1.380649e-23) / temperature<kelvin, Rep>(1);
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto avogadro_constant = Rep(6.02214076e23) / substance<mole, Rep>(1);
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto speed_of_light = speed<metre_per_second, Rep>(299'792'458);
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto hyperfine_structure_transition_frequency = frequency<hertz, Rep>(9'192'631'770);
 
-// template<NumericValue Rep = double>
+// template<in_numeric_value Rep = double>
 // inline constexpr auto luminous_efficacy = 683q_lm / 1q_W;
 
-template<NumericValue Rep = double>
+template<in_numeric_value Rep = double>
 inline constexpr auto standard_gravity = acceleration<metre_per_second_sq, Rep>(9.80665);
 
 }  // namespace units::physical::si::si2019

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -52,7 +52,7 @@ struct yottaampere : prefixed_unit<yottaampere, yotta, ampere> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using current = quantity<dim_electric_current, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -52,7 +52,7 @@ struct yottaampere : prefixed_unit<yottaampere, yotta, ampere> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using current = quantity<dim_electric_current, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -52,7 +52,7 @@ struct yottaampere : prefixed_unit<yottaampere, yotta, ampere> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using current = quantity<dim_electric_current, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current.h
+++ b/src/include/units/physical/si/current.h
@@ -52,7 +52,7 @@ struct yottaampere : prefixed_unit<yottaampere, yotta, ampere> {};
 
 struct dim_electric_current : physical::dim_electric_current<ampere> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using current = quantity<dim_electric_current, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current_density.h
+++ b/src/include/units/physical/si/current_density.h
@@ -34,7 +34,7 @@ struct ampere_per_metre_sq : unit<ampere_per_metre_sq> {};
 
 struct dim_current_density : physical::dim_current_density<dim_current_density, ampere_per_metre_sq, dim_electric_current, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using current_density = quantity<dim_current_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current_density.h
+++ b/src/include/units/physical/si/current_density.h
@@ -34,7 +34,7 @@ struct ampere_per_metre_sq : unit<ampere_per_metre_sq> {};
 
 struct dim_current_density : physical::dim_current_density<dim_current_density, ampere_per_metre_sq, dim_electric_current, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using current_density = quantity<dim_current_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current_density.h
+++ b/src/include/units/physical/si/current_density.h
@@ -34,7 +34,7 @@ struct ampere_per_metre_sq : unit<ampere_per_metre_sq> {};
 
 struct dim_current_density : physical::dim_current_density<dim_current_density, ampere_per_metre_sq, dim_electric_current, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using current_density = quantity<dim_current_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/current_density.h
+++ b/src/include/units/physical/si/current_density.h
@@ -34,7 +34,7 @@ struct ampere_per_metre_sq : unit<ampere_per_metre_sq> {};
 
 struct dim_current_density : physical::dim_current_density<dim_current_density, ampere_per_metre_sq, dim_electric_current, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using current_density = quantity<dim_current_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/density.h
+++ b/src/include/units/physical/si/density.h
@@ -34,7 +34,7 @@ struct kilogram_per_metre_cub : unit<kilogram_per_metre_cub> {};
 
 struct dim_density : physical::dim_density<dim_density, kilogram_per_metre_cub, dim_mass, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using density = quantity<dim_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/density.h
+++ b/src/include/units/physical/si/density.h
@@ -34,7 +34,7 @@ struct kilogram_per_metre_cub : unit<kilogram_per_metre_cub> {};
 
 struct dim_density : physical::dim_density<dim_density, kilogram_per_metre_cub, dim_mass, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using density = quantity<dim_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/density.h
+++ b/src/include/units/physical/si/density.h
@@ -34,7 +34,7 @@ struct kilogram_per_metre_cub : unit<kilogram_per_metre_cub> {};
 
 struct dim_density : physical::dim_density<dim_density, kilogram_per_metre_cub, dim_mass, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using density = quantity<dim_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/density.h
+++ b/src/include/units/physical/si/density.h
@@ -34,7 +34,7 @@ struct kilogram_per_metre_cub : unit<kilogram_per_metre_cub> {};
 
 struct dim_density : physical::dim_density<dim_density, kilogram_per_metre_cub, dim_mass, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using density = quantity<dim_density, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/dynamic_viscosity.h
+++ b/src/include/units/physical/si/dynamic_viscosity.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct pascal_second : unit<pascal_second> {};
 struct dim_dynamic_viscosity : physical::dim_dynamic_viscosity<dim_dynamic_viscosity, pascal_second, dim_pressure, dim_time> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using dynamic_viscosity = quantity<dim_dynamic_viscosity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/dynamic_viscosity.h
+++ b/src/include/units/physical/si/dynamic_viscosity.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct pascal_second : unit<pascal_second> {};
 struct dim_dynamic_viscosity : physical::dim_dynamic_viscosity<dim_dynamic_viscosity, pascal_second, dim_pressure, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using dynamic_viscosity = quantity<dim_dynamic_viscosity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/dynamic_viscosity.h
+++ b/src/include/units/physical/si/dynamic_viscosity.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct pascal_second : unit<pascal_second> {};
 struct dim_dynamic_viscosity : physical::dim_dynamic_viscosity<dim_dynamic_viscosity, pascal_second, dim_pressure, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using dynamic_viscosity = quantity<dim_dynamic_viscosity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/dynamic_viscosity.h
+++ b/src/include/units/physical/si/dynamic_viscosity.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct pascal_second : unit<pascal_second> {};
 struct dim_dynamic_viscosity : physical::dim_dynamic_viscosity<dim_dynamic_viscosity, pascal_second, dim_pressure, dim_time> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using dynamic_viscosity = quantity<dim_dynamic_viscosity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_charge.h
+++ b/src/include/units/physical/si/electric_charge.h
@@ -33,7 +33,7 @@ struct coulomb : named_unit<coulomb, "C", prefix> {};
 
 struct dim_electric_charge : physical::dim_electric_charge<dim_electric_charge, coulomb, dim_time, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using electric_charge = quantity<dim_electric_charge, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_charge.h
+++ b/src/include/units/physical/si/electric_charge.h
@@ -33,7 +33,7 @@ struct coulomb : named_unit<coulomb, "C", prefix> {};
 
 struct dim_electric_charge : physical::dim_electric_charge<dim_electric_charge, coulomb, dim_time, dim_electric_current> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using electric_charge = quantity<dim_electric_charge, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_charge.h
+++ b/src/include/units/physical/si/electric_charge.h
@@ -33,7 +33,7 @@ struct coulomb : named_unit<coulomb, "C", prefix> {};
 
 struct dim_electric_charge : physical::dim_electric_charge<dim_electric_charge, coulomb, dim_time, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using electric_charge = quantity<dim_electric_charge, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_charge.h
+++ b/src/include/units/physical/si/electric_charge.h
@@ -33,7 +33,7 @@ struct coulomb : named_unit<coulomb, "C", prefix> {};
 
 struct dim_electric_charge : physical::dim_electric_charge<dim_electric_charge, coulomb, dim_time, dim_electric_current> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using electric_charge = quantity<dim_electric_charge, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_field_strength.h
+++ b/src/include/units/physical/si/electric_field_strength.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct volt_per_metre : unit<volt_per_metre> {};
 struct dim_electric_field_strength : physical::dim_electric_field_strength<dim_electric_field_strength, volt_per_metre, dim_voltage, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using electric_field_strength = quantity<dim_electric_field_strength, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_field_strength.h
+++ b/src/include/units/physical/si/electric_field_strength.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct volt_per_metre : unit<volt_per_metre> {};
 struct dim_electric_field_strength : physical::dim_electric_field_strength<dim_electric_field_strength, volt_per_metre, dim_voltage, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using electric_field_strength = quantity<dim_electric_field_strength, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_field_strength.h
+++ b/src/include/units/physical/si/electric_field_strength.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct volt_per_metre : unit<volt_per_metre> {};
 struct dim_electric_field_strength : physical::dim_electric_field_strength<dim_electric_field_strength, volt_per_metre, dim_voltage, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using electric_field_strength = quantity<dim_electric_field_strength, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/electric_field_strength.h
+++ b/src/include/units/physical/si/electric_field_strength.h
@@ -31,7 +31,7 @@ namespace units::physical::si {
 struct volt_per_metre : unit<volt_per_metre> {};
 struct dim_electric_field_strength : physical::dim_electric_field_strength<dim_electric_field_strength, volt_per_metre, dim_voltage, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using electric_field_strength = quantity<dim_electric_field_strength, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -52,7 +52,7 @@ struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {}
 
 struct dim_energy : physical::dim_energy<dim_energy, joule, dim_force, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -52,7 +52,7 @@ struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {}
 
 struct dim_energy : physical::dim_energy<dim_energy, joule, dim_force, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -52,7 +52,7 @@ struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {}
 
 struct dim_energy : physical::dim_energy<dim_energy, joule, dim_force, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/energy.h
+++ b/src/include/units/physical/si/energy.h
@@ -52,7 +52,7 @@ struct gigaelectronvolt : prefixed_unit<gigaelectronvolt, giga, electronvolt> {}
 
 struct dim_energy : physical::dim_energy<dim_energy, joule, dim_force, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using energy = quantity<dim_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -54,7 +54,7 @@ struct yottanewton : prefixed_unit<yottanewton, yotta, newton> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -54,7 +54,7 @@ struct yottanewton : prefixed_unit<yottanewton, yotta, newton> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -54,7 +54,7 @@ struct yottanewton : prefixed_unit<yottanewton, yotta, newton> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/force.h
+++ b/src/include/units/physical/si/force.h
@@ -54,7 +54,7 @@ struct yottanewton : prefixed_unit<yottanewton, yotta, newton> {};
 
 struct dim_force : physical::dim_force<dim_force, newton, dim_mass, dim_acceleration> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using force = quantity<dim_force, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -48,7 +48,7 @@ struct yottahertz : prefixed_unit<yottahertz, yotta, hertz> {};
 
 struct dim_frequency : physical::dim_frequency<dim_frequency, hertz, dim_time> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using frequency = quantity<dim_frequency, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -48,7 +48,7 @@ struct yottahertz : prefixed_unit<yottahertz, yotta, hertz> {};
 
 struct dim_frequency : physical::dim_frequency<dim_frequency, hertz, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using frequency = quantity<dim_frequency, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -48,7 +48,7 @@ struct yottahertz : prefixed_unit<yottahertz, yotta, hertz> {};
 
 struct dim_frequency : physical::dim_frequency<dim_frequency, hertz, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using frequency = quantity<dim_frequency, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/frequency.h
+++ b/src/include/units/physical/si/frequency.h
@@ -48,7 +48,7 @@ struct yottahertz : prefixed_unit<yottahertz, yotta, hertz> {};
 
 struct dim_frequency : physical::dim_frequency<dim_frequency, hertz, dim_time> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using frequency = quantity<dim_frequency, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/heat_capacity.h
+++ b/src/include/units/physical/si/heat_capacity.h
@@ -39,13 +39,13 @@ struct dim_heat_capacity : physical::dim_heat_capacity<dim_heat_capacity, joule_
 struct dim_specific_heat_capacity : physical::dim_specific_heat_capacity<dim_specific_heat_capacity, joule_per_kilogram_kelvin, dim_heat_capacity, dim_mass> {};
 struct dim_molar_heat_capacity : physical::dim_molar_heat_capacity<dim_molar_heat_capacity, joule_per_mole_kelvin, dim_heat_capacity, dim_substance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using heat_capacity = quantity<dim_heat_capacity, U, Rep>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using specific_heat_capacity = quantity<dim_specific_heat_capacity, U, Rep>;
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using molar_heat_capacity = quantity<dim_molar_heat_capacity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/heat_capacity.h
+++ b/src/include/units/physical/si/heat_capacity.h
@@ -39,13 +39,13 @@ struct dim_heat_capacity : physical::dim_heat_capacity<dim_heat_capacity, joule_
 struct dim_specific_heat_capacity : physical::dim_specific_heat_capacity<dim_specific_heat_capacity, joule_per_kilogram_kelvin, dim_heat_capacity, dim_mass> {};
 struct dim_molar_heat_capacity : physical::dim_molar_heat_capacity<dim_molar_heat_capacity, joule_per_mole_kelvin, dim_heat_capacity, dim_substance> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using heat_capacity = quantity<dim_heat_capacity, U, Rep>;
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using specific_heat_capacity = quantity<dim_specific_heat_capacity, U, Rep>;
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using molar_heat_capacity = quantity<dim_molar_heat_capacity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/heat_capacity.h
+++ b/src/include/units/physical/si/heat_capacity.h
@@ -39,13 +39,13 @@ struct dim_heat_capacity : physical::dim_heat_capacity<dim_heat_capacity, joule_
 struct dim_specific_heat_capacity : physical::dim_specific_heat_capacity<dim_specific_heat_capacity, joule_per_kilogram_kelvin, dim_heat_capacity, dim_mass> {};
 struct dim_molar_heat_capacity : physical::dim_molar_heat_capacity<dim_molar_heat_capacity, joule_per_mole_kelvin, dim_heat_capacity, dim_substance> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using heat_capacity = quantity<dim_heat_capacity, U, Rep>;
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using specific_heat_capacity = quantity<dim_specific_heat_capacity, U, Rep>;
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using molar_heat_capacity = quantity<dim_molar_heat_capacity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/heat_capacity.h
+++ b/src/include/units/physical/si/heat_capacity.h
@@ -39,13 +39,13 @@ struct dim_heat_capacity : physical::dim_heat_capacity<dim_heat_capacity, joule_
 struct dim_specific_heat_capacity : physical::dim_specific_heat_capacity<dim_specific_heat_capacity, joule_per_kilogram_kelvin, dim_heat_capacity, dim_mass> {};
 struct dim_molar_heat_capacity : physical::dim_molar_heat_capacity<dim_molar_heat_capacity, joule_per_mole_kelvin, dim_heat_capacity, dim_substance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using heat_capacity = quantity<dim_heat_capacity, U, Rep>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using specific_heat_capacity = quantity<dim_specific_heat_capacity, U, Rep>;
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using molar_heat_capacity = quantity<dim_molar_heat_capacity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/inductance.h
+++ b/src/include/units/physical/si/inductance.h
@@ -50,7 +50,7 @@ struct yottahenry : prefixed_unit<yottahenry, yotta, henry> {};
 
 struct dim_inductance : physical::dim_inductance<dim_inductance, henry, dim_magnetic_flux, dim_electric_current> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using inductance = quantity<dim_inductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/inductance.h
+++ b/src/include/units/physical/si/inductance.h
@@ -50,7 +50,7 @@ struct yottahenry : prefixed_unit<yottahenry, yotta, henry> {};
 
 struct dim_inductance : physical::dim_inductance<dim_inductance, henry, dim_magnetic_flux, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using inductance = quantity<dim_inductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/inductance.h
+++ b/src/include/units/physical/si/inductance.h
@@ -50,7 +50,7 @@ struct yottahenry : prefixed_unit<yottahenry, yotta, henry> {};
 
 struct dim_inductance : physical::dim_inductance<dim_inductance, henry, dim_magnetic_flux, dim_electric_current> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using inductance = quantity<dim_inductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/inductance.h
+++ b/src/include/units/physical/si/inductance.h
@@ -50,7 +50,7 @@ struct yottahenry : prefixed_unit<yottahenry, yotta, henry> {};
 
 struct dim_inductance : physical::dim_inductance<dim_inductance, henry, dim_magnetic_flux, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using inductance = quantity<dim_inductance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -54,7 +54,7 @@ struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix,
 
 struct dim_length : physical::dim_length<metre> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -54,7 +54,7 @@ struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix,
 
 struct dim_length : physical::dim_length<metre> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -54,7 +54,7 @@ struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix,
 
 struct dim_length : physical::dim_length<metre> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/length.h
+++ b/src/include/units/physical/si/length.h
@@ -54,7 +54,7 @@ struct astronomical_unit : named_scaled_unit<astronomical_unit, "au", no_prefix,
 
 struct dim_length : physical::dim_length<metre> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using length = quantity<dim_length, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminance.h
+++ b/src/include/units/physical/si/luminance.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct candela_per_metre_sq : unit<candela_per_metre_sq> {};
 struct dim_luminance : physical::dim_luminance<dim_luminance, candela_per_metre_sq, dim_luminous_intensity, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using luminance = quantity<dim_luminance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminance.h
+++ b/src/include/units/physical/si/luminance.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct candela_per_metre_sq : unit<candela_per_metre_sq> {};
 struct dim_luminance : physical::dim_luminance<dim_luminance, candela_per_metre_sq, dim_luminous_intensity, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using luminance = quantity<dim_luminance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminance.h
+++ b/src/include/units/physical/si/luminance.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct candela_per_metre_sq : unit<candela_per_metre_sq> {};
 struct dim_luminance : physical::dim_luminance<dim_luminance, candela_per_metre_sq, dim_luminous_intensity, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using luminance = quantity<dim_luminance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminance.h
+++ b/src/include/units/physical/si/luminance.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct candela_per_metre_sq : unit<candela_per_metre_sq> {};
 struct dim_luminance : physical::dim_luminance<dim_luminance, candela_per_metre_sq, dim_luminous_intensity, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using luminance = quantity<dim_luminance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -52,7 +52,7 @@ struct yottacandela : prefixed_unit<yottacandela, yotta, candela> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using luminous_intensity = quantity<dim_luminous_intensity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -52,7 +52,7 @@ struct yottacandela : prefixed_unit<yottacandela, yotta, candela> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using luminous_intensity = quantity<dim_luminous_intensity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -52,7 +52,7 @@ struct yottacandela : prefixed_unit<yottacandela, yotta, candela> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using luminous_intensity = quantity<dim_luminous_intensity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/luminous_intensity.h
+++ b/src/include/units/physical/si/luminous_intensity.h
@@ -52,7 +52,7 @@ struct yottacandela : prefixed_unit<yottacandela, yotta, candela> {};
 
 struct dim_luminous_intensity : physical::dim_luminous_intensity<candela> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using luminous_intensity = quantity<dim_luminous_intensity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_flux.h
+++ b/src/include/units/physical/si/magnetic_flux.h
@@ -50,7 +50,7 @@ struct yottaweber : prefixed_unit<yottaweber, yotta, weber> {};
 
 struct dim_magnetic_flux : physical::dim_magnetic_flux<dim_magnetic_flux, weber, dim_magnetic_induction, dim_area> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using magnetic_flux = quantity<dim_magnetic_flux, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_flux.h
+++ b/src/include/units/physical/si/magnetic_flux.h
@@ -50,7 +50,7 @@ struct yottaweber : prefixed_unit<yottaweber, yotta, weber> {};
 
 struct dim_magnetic_flux : physical::dim_magnetic_flux<dim_magnetic_flux, weber, dim_magnetic_induction, dim_area> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using magnetic_flux = quantity<dim_magnetic_flux, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_flux.h
+++ b/src/include/units/physical/si/magnetic_flux.h
@@ -50,7 +50,7 @@ struct yottaweber : prefixed_unit<yottaweber, yotta, weber> {};
 
 struct dim_magnetic_flux : physical::dim_magnetic_flux<dim_magnetic_flux, weber, dim_magnetic_induction, dim_area> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using magnetic_flux = quantity<dim_magnetic_flux, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_flux.h
+++ b/src/include/units/physical/si/magnetic_flux.h
@@ -50,7 +50,7 @@ struct yottaweber : prefixed_unit<yottaweber, yotta, weber> {};
 
 struct dim_magnetic_flux : physical::dim_magnetic_flux<dim_magnetic_flux, weber, dim_magnetic_induction, dim_area> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using magnetic_flux = quantity<dim_magnetic_flux, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_induction.h
+++ b/src/include/units/physical/si/magnetic_induction.h
@@ -54,7 +54,7 @@ struct gauss : named_scaled_unit<gauss, "G", prefix, ratio<1, 10'000>, tesla> {}
 
 struct dim_magnetic_induction : physical::dim_magnetic_induction<dim_magnetic_induction, tesla, dim_voltage, dim_time, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using magnetic_induction = quantity<dim_magnetic_induction, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_induction.h
+++ b/src/include/units/physical/si/magnetic_induction.h
@@ -54,7 +54,7 @@ struct gauss : named_scaled_unit<gauss, "G", prefix, ratio<1, 10'000>, tesla> {}
 
 struct dim_magnetic_induction : physical::dim_magnetic_induction<dim_magnetic_induction, tesla, dim_voltage, dim_time, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using magnetic_induction = quantity<dim_magnetic_induction, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_induction.h
+++ b/src/include/units/physical/si/magnetic_induction.h
@@ -54,7 +54,7 @@ struct gauss : named_scaled_unit<gauss, "G", prefix, ratio<1, 10'000>, tesla> {}
 
 struct dim_magnetic_induction : physical::dim_magnetic_induction<dim_magnetic_induction, tesla, dim_voltage, dim_time, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using magnetic_induction = quantity<dim_magnetic_induction, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/magnetic_induction.h
+++ b/src/include/units/physical/si/magnetic_induction.h
@@ -54,7 +54,7 @@ struct gauss : named_scaled_unit<gauss, "G", prefix, ratio<1, 10'000>, tesla> {}
 
 struct dim_magnetic_induction : physical::dim_magnetic_induction<dim_magnetic_induction, tesla, dim_voltage, dim_time, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using magnetic_induction = quantity<dim_magnetic_induction, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -76,7 +76,7 @@ struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'
 
 struct dim_mass : physical::dim_mass<kilogram> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -76,7 +76,7 @@ struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'
 
 struct dim_mass : physical::dim_mass<kilogram> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -76,7 +76,7 @@ struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'
 
 struct dim_mass : physical::dim_mass<kilogram> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/mass.h
+++ b/src/include/units/physical/si/mass.h
@@ -76,7 +76,7 @@ struct dalton : named_scaled_unit<dalton, "Da", no_prefix, ratio<16'605'390'666'
 
 struct dim_mass : physical::dim_mass<kilogram> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using mass = quantity<dim_mass, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/molar_energy.h
+++ b/src/include/units/physical/si/molar_energy.h
@@ -34,7 +34,7 @@ struct joule_per_mole : unit<joule_per_mole> {};
 
 struct dim_molar_energy : physical::dim_molar_energy<dim_molar_energy, joule_per_mole, dim_energy, dim_substance> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using molar_energy = quantity<dim_molar_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/molar_energy.h
+++ b/src/include/units/physical/si/molar_energy.h
@@ -34,7 +34,7 @@ struct joule_per_mole : unit<joule_per_mole> {};
 
 struct dim_molar_energy : physical::dim_molar_energy<dim_molar_energy, joule_per_mole, dim_energy, dim_substance> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using molar_energy = quantity<dim_molar_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/molar_energy.h
+++ b/src/include/units/physical/si/molar_energy.h
@@ -34,7 +34,7 @@ struct joule_per_mole : unit<joule_per_mole> {};
 
 struct dim_molar_energy : physical::dim_molar_energy<dim_molar_energy, joule_per_mole, dim_energy, dim_substance> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using molar_energy = quantity<dim_molar_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/molar_energy.h
+++ b/src/include/units/physical/si/molar_energy.h
@@ -34,7 +34,7 @@ struct joule_per_mole : unit<joule_per_mole> {};
 
 struct dim_molar_energy : physical::dim_molar_energy<dim_molar_energy, joule_per_mole, dim_energy, dim_substance> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using molar_energy = quantity<dim_molar_energy, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/momentum.h
+++ b/src/include/units/physical/si/momentum.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct kilogram_metre_per_second : unit<kilogram_metre_per_second> {};
 struct dim_momentum : physical::dim_momentum<dim_momentum, kilogram_metre_per_second, dim_mass, dim_speed> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/momentum.h
+++ b/src/include/units/physical/si/momentum.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct kilogram_metre_per_second : unit<kilogram_metre_per_second> {};
 struct dim_momentum : physical::dim_momentum<dim_momentum, kilogram_metre_per_second, dim_mass, dim_speed> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/momentum.h
+++ b/src/include/units/physical/si/momentum.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct kilogram_metre_per_second : unit<kilogram_metre_per_second> {};
 struct dim_momentum : physical::dim_momentum<dim_momentum, kilogram_metre_per_second, dim_mass, dim_speed> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/momentum.h
+++ b/src/include/units/physical/si/momentum.h
@@ -32,7 +32,7 @@ namespace units::physical::si {
 struct kilogram_metre_per_second : unit<kilogram_metre_per_second> {};
 struct dim_momentum : physical::dim_momentum<dim_momentum, kilogram_metre_per_second, dim_mass, dim_speed> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using momentum = quantity<dim_momentum, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permeability.h
+++ b/src/include/units/physical/si/permeability.h
@@ -33,7 +33,7 @@ struct henry_per_metre : unit<henry_per_metre> {};
 
 struct dim_permeability : physical::dim_permeability<dim_permeability, henry_per_metre, dim_inductance, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using permeability = quantity<dim_permeability, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permeability.h
+++ b/src/include/units/physical/si/permeability.h
@@ -33,7 +33,7 @@ struct henry_per_metre : unit<henry_per_metre> {};
 
 struct dim_permeability : physical::dim_permeability<dim_permeability, henry_per_metre, dim_inductance, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using permeability = quantity<dim_permeability, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permeability.h
+++ b/src/include/units/physical/si/permeability.h
@@ -33,7 +33,7 @@ struct henry_per_metre : unit<henry_per_metre> {};
 
 struct dim_permeability : physical::dim_permeability<dim_permeability, henry_per_metre, dim_inductance, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using permeability = quantity<dim_permeability, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permeability.h
+++ b/src/include/units/physical/si/permeability.h
@@ -33,7 +33,7 @@ struct henry_per_metre : unit<henry_per_metre> {};
 
 struct dim_permeability : physical::dim_permeability<dim_permeability, henry_per_metre, dim_inductance, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using permeability = quantity<dim_permeability, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permittivity.h
+++ b/src/include/units/physical/si/permittivity.h
@@ -33,7 +33,7 @@ struct farad_per_metre : unit<farad_per_metre> {};
 
 struct dim_permittivity : physical::dim_permittivity<dim_permittivity, farad_per_metre, dim_capacitance, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using permittivity = quantity<dim_permittivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permittivity.h
+++ b/src/include/units/physical/si/permittivity.h
@@ -33,7 +33,7 @@ struct farad_per_metre : unit<farad_per_metre> {};
 
 struct dim_permittivity : physical::dim_permittivity<dim_permittivity, farad_per_metre, dim_capacitance, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using permittivity = quantity<dim_permittivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permittivity.h
+++ b/src/include/units/physical/si/permittivity.h
@@ -33,7 +33,7 @@ struct farad_per_metre : unit<farad_per_metre> {};
 
 struct dim_permittivity : physical::dim_permittivity<dim_permittivity, farad_per_metre, dim_capacitance, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using permittivity = quantity<dim_permittivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/permittivity.h
+++ b/src/include/units/physical/si/permittivity.h
@@ -33,7 +33,7 @@ struct farad_per_metre : unit<farad_per_metre> {};
 
 struct dim_permittivity : physical::dim_permittivity<dim_permittivity, farad_per_metre, dim_capacitance, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using permittivity = quantity<dim_permittivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -49,7 +49,7 @@ struct yottawatt : prefixed_unit<yottawatt, yotta, watt> {};
 
 struct dim_power : physical::dim_power<dim_power, watt, dim_energy, dim_time> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -49,7 +49,7 @@ struct yottawatt : prefixed_unit<yottawatt, yotta, watt> {};
 
 struct dim_power : physical::dim_power<dim_power, watt, dim_energy, dim_time> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -49,7 +49,7 @@ struct yottawatt : prefixed_unit<yottawatt, yotta, watt> {};
 
 struct dim_power : physical::dim_power<dim_power, watt, dim_energy, dim_time> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/power.h
+++ b/src/include/units/physical/si/power.h
@@ -49,7 +49,7 @@ struct yottawatt : prefixed_unit<yottawatt, yotta, watt> {};
 
 struct dim_power : physical::dim_power<dim_power, watt, dim_energy, dim_time> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using power = quantity<dim_power, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -54,7 +54,7 @@ struct yottapascal : prefixed_unit<yottapascal, yotta, pascal> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -54,7 +54,7 @@ struct yottapascal : prefixed_unit<yottapascal, yotta, pascal> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -54,7 +54,7 @@ struct yottapascal : prefixed_unit<yottapascal, yotta, pascal> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/pressure.h
+++ b/src/include/units/physical/si/pressure.h
@@ -54,7 +54,7 @@ struct yottapascal : prefixed_unit<yottapascal, yotta, pascal> {};
 
 struct dim_pressure : physical::dim_pressure<dim_pressure, pascal, dim_force, dim_area> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using pressure = quantity<dim_pressure, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -50,7 +50,7 @@ struct yottaohm : prefixed_unit<yottaohm, yotta, ohm> {};
 
 struct dim_resistance : physical::dim_resistance<dim_resistance, ohm, dim_voltage, dim_electric_current> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using resistance = quantity<dim_resistance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -50,7 +50,7 @@ struct yottaohm : prefixed_unit<yottaohm, yotta, ohm> {};
 
 struct dim_resistance : physical::dim_resistance<dim_resistance, ohm, dim_voltage, dim_electric_current> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using resistance = quantity<dim_resistance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -50,7 +50,7 @@ struct yottaohm : prefixed_unit<yottaohm, yotta, ohm> {};
 
 struct dim_resistance : physical::dim_resistance<dim_resistance, ohm, dim_voltage, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using resistance = quantity<dim_resistance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/resistance.h
+++ b/src/include/units/physical/si/resistance.h
@@ -50,7 +50,7 @@ struct yottaohm : prefixed_unit<yottaohm, yotta, ohm> {};
 
 struct dim_resistance : physical::dim_resistance<dim_resistance, ohm, dim_voltage, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using resistance = quantity<dim_resistance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/speed.h
+++ b/src/include/units/physical/si/speed.h
@@ -34,7 +34,7 @@ struct dim_speed : physical::dim_speed<dim_speed, metre_per_second, dim_length, 
 
 struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_speed, kilometre, hour> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/speed.h
+++ b/src/include/units/physical/si/speed.h
@@ -34,7 +34,7 @@ struct dim_speed : physical::dim_speed<dim_speed, metre_per_second, dim_length, 
 
 struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_speed, kilometre, hour> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/speed.h
+++ b/src/include/units/physical/si/speed.h
@@ -34,7 +34,7 @@ struct dim_speed : physical::dim_speed<dim_speed, metre_per_second, dim_length, 
 
 struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_speed, kilometre, hour> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/speed.h
+++ b/src/include/units/physical/si/speed.h
@@ -34,7 +34,7 @@ struct dim_speed : physical::dim_speed<dim_speed, metre_per_second, dim_length, 
 
 struct kilometre_per_hour : deduced_unit<kilometre_per_hour, dim_speed, kilometre, hour> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using speed = quantity<dim_speed, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -32,7 +32,7 @@ struct mole : named_unit<metre, "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using substance = quantity<dim_substance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -32,7 +32,7 @@ struct mole : named_unit<metre, "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using substance = quantity<dim_substance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -32,7 +32,7 @@ struct mole : named_unit<metre, "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using substance = quantity<dim_substance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -32,7 +32,7 @@ struct mole : named_unit<metre, "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using substance = quantity<dim_substance, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/surface_tension.h
+++ b/src/include/units/physical/si/surface_tension.h
@@ -32,7 +32,7 @@ struct newton_per_metre : unit<newton_per_metre> {};
 
 struct dim_surface_tension : physical::dim_surface_tension<dim_surface_tension, newton_per_metre, dim_force, dim_length> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using surface_tension = quantity<dim_surface_tension, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/surface_tension.h
+++ b/src/include/units/physical/si/surface_tension.h
@@ -32,7 +32,7 @@ struct newton_per_metre : unit<newton_per_metre> {};
 
 struct dim_surface_tension : physical::dim_surface_tension<dim_surface_tension, newton_per_metre, dim_force, dim_length> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using surface_tension = quantity<dim_surface_tension, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/surface_tension.h
+++ b/src/include/units/physical/si/surface_tension.h
@@ -32,7 +32,7 @@ struct newton_per_metre : unit<newton_per_metre> {};
 
 struct dim_surface_tension : physical::dim_surface_tension<dim_surface_tension, newton_per_metre, dim_force, dim_length> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using surface_tension = quantity<dim_surface_tension, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/surface_tension.h
+++ b/src/include/units/physical/si/surface_tension.h
@@ -32,7 +32,7 @@ struct newton_per_metre : unit<newton_per_metre> {};
 
 struct dim_surface_tension : physical::dim_surface_tension<dim_surface_tension, newton_per_metre, dim_force, dim_length> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using surface_tension = quantity<dim_surface_tension, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/temperature.h
+++ b/src/include/units/physical/si/temperature.h
@@ -31,7 +31,7 @@ struct kelvin : named_unit<kelvin, "K", no_prefix> {};
 
 struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<kelvin> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using temperature = quantity<dim_thermodynamic_temperature, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/temperature.h
+++ b/src/include/units/physical/si/temperature.h
@@ -31,7 +31,7 @@ struct kelvin : named_unit<kelvin, "K", no_prefix> {};
 
 struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<kelvin> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using temperature = quantity<dim_thermodynamic_temperature, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/temperature.h
+++ b/src/include/units/physical/si/temperature.h
@@ -31,7 +31,7 @@ struct kelvin : named_unit<kelvin, "K", no_prefix> {};
 
 struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<kelvin> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using temperature = quantity<dim_thermodynamic_temperature, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/temperature.h
+++ b/src/include/units/physical/si/temperature.h
@@ -31,7 +31,7 @@ struct kelvin : named_unit<kelvin, "K", no_prefix> {};
 
 struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<kelvin> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using temperature = quantity<dim_thermodynamic_temperature, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/thermal_conductivity.h
+++ b/src/include/units/physical/si/thermal_conductivity.h
@@ -33,7 +33,7 @@ struct watt_per_metre_kelvin : unit<watt_per_metre_kelvin> {};
 
 struct dim_thermal_conductivity : physical::dim_thermal_conductivity<dim_thermal_conductivity, watt_per_metre_kelvin, dim_power, dim_length, dim_thermodynamic_temperature> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using thermal_conductivity = quantity<dim_thermal_conductivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/thermal_conductivity.h
+++ b/src/include/units/physical/si/thermal_conductivity.h
@@ -33,7 +33,7 @@ struct watt_per_metre_kelvin : unit<watt_per_metre_kelvin> {};
 
 struct dim_thermal_conductivity : physical::dim_thermal_conductivity<dim_thermal_conductivity, watt_per_metre_kelvin, dim_power, dim_length, dim_thermodynamic_temperature> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using thermal_conductivity = quantity<dim_thermal_conductivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/thermal_conductivity.h
+++ b/src/include/units/physical/si/thermal_conductivity.h
@@ -33,7 +33,7 @@ struct watt_per_metre_kelvin : unit<watt_per_metre_kelvin> {};
 
 struct dim_thermal_conductivity : physical::dim_thermal_conductivity<dim_thermal_conductivity, watt_per_metre_kelvin, dim_power, dim_length, dim_thermodynamic_temperature> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using thermal_conductivity = quantity<dim_thermal_conductivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/thermal_conductivity.h
+++ b/src/include/units/physical/si/thermal_conductivity.h
@@ -33,7 +33,7 @@ struct watt_per_metre_kelvin : unit<watt_per_metre_kelvin> {};
 
 struct dim_thermal_conductivity : physical::dim_thermal_conductivity<dim_thermal_conductivity, watt_per_metre_kelvin, dim_power, dim_length, dim_thermodynamic_temperature> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using thermal_conductivity = quantity<dim_thermal_conductivity, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -43,7 +43,7 @@ struct day : named_scaled_unit<hour, "d", no_prefix, ratio<24>, hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -43,7 +43,7 @@ struct day : named_scaled_unit<hour, "d", no_prefix, ratio<24>, hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -43,7 +43,7 @@ struct day : named_scaled_unit<hour, "d", no_prefix, ratio<24>, hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -43,7 +43,7 @@ struct day : named_scaled_unit<hour, "d", no_prefix, ratio<24>, hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using time = quantity<dim_time, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/torque.h
+++ b/src/include/units/physical/si/torque.h
@@ -34,7 +34,7 @@ struct newton_metre : named_unit<newton_metre, "Nm", prefix> {};
 
 struct dim_torque : physical::dim_torque<dim_torque, newton_metre, dim_energy, dim_angle> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using torque = quantity<dim_torque, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/torque.h
+++ b/src/include/units/physical/si/torque.h
@@ -34,7 +34,7 @@ struct newton_metre : named_unit<newton_metre, "Nm", prefix> {};
 
 struct dim_torque : physical::dim_torque<dim_torque, newton_metre, dim_energy, dim_angle> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using torque = quantity<dim_torque, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/torque.h
+++ b/src/include/units/physical/si/torque.h
@@ -34,7 +34,7 @@ struct newton_metre : named_unit<newton_metre, "Nm", prefix> {};
 
 struct dim_torque : physical::dim_torque<dim_torque, newton_metre, dim_energy, dim_angle> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using torque = quantity<dim_torque, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/torque.h
+++ b/src/include/units/physical/si/torque.h
@@ -34,7 +34,7 @@ struct newton_metre : named_unit<newton_metre, "Nm", prefix> {};
 
 struct dim_torque : physical::dim_torque<dim_torque, newton_metre, dim_energy, dim_angle> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using torque = quantity<dim_torque, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -54,7 +54,7 @@ struct yottavolt : prefixed_unit<yottavolt, yotta, volt> {};
 
 struct dim_voltage : physical::dim_voltage<dim_voltage, volt, dim_power, dim_electric_current> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using voltage = quantity<dim_voltage, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -54,7 +54,7 @@ struct yottavolt : prefixed_unit<yottavolt, yotta, volt> {};
 
 struct dim_voltage : physical::dim_voltage<dim_voltage, volt, dim_power, dim_electric_current> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using voltage = quantity<dim_voltage, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -54,7 +54,7 @@ struct yottavolt : prefixed_unit<yottavolt, yotta, volt> {};
 
 struct dim_voltage : physical::dim_voltage<dim_voltage, volt, dim_power, dim_electric_current> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using voltage = quantity<dim_voltage, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/voltage.h
+++ b/src/include/units/physical/si/voltage.h
@@ -54,7 +54,7 @@ struct yottavolt : prefixed_unit<yottavolt, yotta, volt> {};
 
 struct dim_voltage : physical::dim_voltage<dim_voltage, volt, dim_power, dim_electric_current> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using voltage = quantity<dim_voltage, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -74,7 +74,7 @@ struct exalitre : prefixed_unit<petalitre, exa, litre> {};
 struct zettalitre : prefixed_alias_unit<cubic_megametre, zetta, litre> {};
 struct yottalitre : prefixed_unit<yottalitre, yotta, litre> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -74,7 +74,7 @@ struct exalitre : prefixed_unit<petalitre, exa, litre> {};
 struct zettalitre : prefixed_alias_unit<cubic_megametre, zetta, litre> {};
 struct yottalitre : prefixed_unit<yottalitre, yotta, litre> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -74,7 +74,7 @@ struct exalitre : prefixed_unit<petalitre, exa, litre> {};
 struct zettalitre : prefixed_alias_unit<cubic_megametre, zetta, litre> {};
 struct yottalitre : prefixed_unit<yottalitre, yotta, litre> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/physical/si/volume.h
+++ b/src/include/units/physical/si/volume.h
@@ -74,7 +74,7 @@ struct exalitre : prefixed_unit<petalitre, exa, litre> {};
 struct zettalitre : prefixed_alias_unit<cubic_megametre, zetta, litre> {};
 struct yottalitre : prefixed_unit<yottalitre, yotta, litre> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using volume = quantity<dim_volume, U, Rep>;
 
 inline namespace literals {

--- a/src/include/units/prefix.h
+++ b/src/include/units/prefix.h
@@ -31,7 +31,7 @@ namespace units {
 /**
  * @brief The base for all prefix families
  *
- * Every prefix family should inherit from this type to satisfy PrefixFamily concept.
+ * Every prefix family should inherit from this type to satisfy in_prefix_family concept.
  */
 struct prefix_family {};
 
@@ -45,7 +45,7 @@ struct no_prefix : prefix_family {};
 
 namespace detail {
 
-template<PrefixFamily PF, Ratio R>
+template<in_prefix_family PF, in_ratio R>
 struct prefix_base : downcast_base<prefix_base<PF, R>> {
   using prefix_family = PF;
   using ratio = R;
@@ -68,7 +68,7 @@ struct prefix_base : downcast_base<prefix_base<PF, R>> {
  * @tparam Symbol a text representation of the prefix
  * @tparam R factor to be used to scale a unit
  */
-template<typename Child, PrefixFamily PF, basic_symbol_text Symbol, Ratio R>
+template<typename Child, in_prefix_family PF, basic_symbol_text Symbol, in_ratio R>
   requires (!std::same_as<PF, no_prefix>)
 struct prefix : downcast_child<Child, detail::prefix_base<PF, R>> {
   static constexpr auto symbol = Symbol;

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -60,7 +60,7 @@ concept safe_divisible = // exposition only
  * @tparam U a measurement unit of the quantity
  * @tparam Rep a type to be used to represent values of a quantity
  */
-template<Dimension D, UnitOf<D> U, Scalar Rep = double>
+template<Dimension D, UnitOf<D> U, Value Rep = double>
 class quantity {
   Rep value_{};
 
@@ -73,9 +73,9 @@ public:
   quantity(const quantity&) = default;
   quantity(quantity&&) = default;
 
-  template<Scalar Value>
-    requires detail::safe_convertible<Value, rep>
-  constexpr explicit quantity(const Value& v) : value_{static_cast<rep>(v)} {}
+  template<Value Val>
+    requires detail::safe_convertible<Val, rep>
+  constexpr explicit quantity(const Val& v) : value_{static_cast<rep>(v)} {}
 
   template<Quantity Q2>
     requires equivalent_dim<D, typename Q2::dimension> &&
@@ -200,11 +200,11 @@ public:
     return *this;
   }
 
-  template<Scalar Value, typename T = Rep>
-  constexpr quantity& operator%=(const Value& rhs)
+  template<Value Val, typename T = Rep>
+  constexpr quantity& operator%=(const Val& rhs)
     requires (!treat_as_floating_point<rep>) &&
-             (!treat_as_floating_point<Value>) &&
-             requires(T v1, Value v2) { { v1 %= v2 } -> SAME_AS(T&); }
+             (!treat_as_floating_point<Val>) &&
+             requires(T v1, Val v2) { { v1 %= v2 } -> SAME_AS(T&); }
   //  requires(rep v1, Value v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
   {
     value_ %= rhs;
@@ -322,24 +322,24 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::multiplies<>, Rep, Value>
+template<typename D, typename U, typename Rep, Value Val>
+[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Val& v)
+  requires std::regular_invocable<std::multiplies<>, Rep, Val>
 {
   using common_rep = decltype(q.count() * v);
   using ret = quantity<D, U, common_rep>;
   return ret(q.count() * v);
 }
 
-template<Scalar Value, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::multiplies<>, Value, Rep>
+template<Value Val, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr Quantity AUTO operator*(const Val& v, const quantity<D, U, Rep>& q)
+  requires std::regular_invocable<std::multiplies<>, Val, Rep>
 {
   return q * v;
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Scalar AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr Value AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::multiplies<>, Rep1, Rep2> &&
            equivalent_dim<D1, dim_invert<D2>>
 {
@@ -366,9 +366,9 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() * rhs.count());
 }
 
-template<Scalar Value, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::divides<>, Value, Rep>
+template<Value Val, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr Quantity AUTO operator/(const Val& v, const quantity<D, U, Rep>& q)
+  requires std::regular_invocable<std::divides<>, Val, Rep>
 {
   Expects(q.count() != 0);
 
@@ -380,11 +380,11 @@ template<Scalar Value, typename D, typename U, typename Rep>
   return ret(v / q.count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::divides<>, Rep, Value>
+template<typename D, typename U, typename Rep, Value Val>
+[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Val& v)
+  requires std::regular_invocable<std::divides<>, Rep, Val>
 {
-  Expects(v != Value{0});
+  Expects(v != Val{0});
 
   using common_rep = decltype(q.count() / v);
   using ret = quantity<D, U, common_rep>;
@@ -392,7 +392,7 @@ template<typename D, typename U, typename Rep, Scalar Value>
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Scalar AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr Value AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::divides<>, Rep1, Rep2> &&
            equivalent_dim<D1, D2>
 {
@@ -419,11 +419,11 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() / rhs.count());
 }
 
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Value& v)
+template<typename D, typename U, typename Rep, Value Val>
+[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Val& v)
   requires (!treat_as_floating_point<Rep>) &&
-           (!treat_as_floating_point<Value>) &&
-           std::regular_invocable<std::modulus<>, Rep, Value>
+           (!treat_as_floating_point<Val>) &&
+           std::regular_invocable<std::modulus<>, Rep, Val>
 {
   using common_rep = decltype(q.count() % v);
   using ret = quantity<D, U, common_rep>;

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -56,7 +56,7 @@ concept safe_divisible = // exposition only
  * Property of a phenomenon, body, or substance, where the property has a magnitude that can be
  * expressed by means of a number and a measurement unit.
  *
- * @tparam D a dimension of the quantity (can be either a BaseDimension or a DerivedDimension)
+ * @tparam D a dimension of the quantity (can be either a in_base_dimension or a in_derived_dimension)
  * @tparam U a measurement unit of the quantity
  * @tparam Rep a type to be used to represent values of a quantity
  */

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -60,7 +60,7 @@ concept safe_divisible = // exposition only
  * @tparam U a measurement unit of the quantity
  * @tparam Rep a type to be used to represent values of a quantity
  */
-template<Dimension D, UnitOf<D> U, Value Rep = double>
+template<Dimension D, UnitOf<D> U, NumericValue Rep = double>
 class quantity {
   Rep value_{};
 
@@ -73,7 +73,7 @@ public:
   quantity(const quantity&) = default;
   quantity(quantity&&) = default;
 
-  template<Value Val>
+  template<NumericValue Val>
     requires detail::safe_convertible<Val, rep>
   constexpr explicit quantity(const Val& v) : value_{static_cast<rep>(v)} {}
 
@@ -200,12 +200,12 @@ public:
     return *this;
   }
 
-  template<Value Val, typename T = Rep>
+  template<NumericValue Val, typename T = Rep>
   constexpr quantity& operator%=(const Val& rhs)
     requires (!treat_as_floating_point<rep>) &&
              (!treat_as_floating_point<Val>) &&
              requires(T v1, Val v2) { { v1 %= v2 } -> SAME_AS(T&); }
-  //  requires(rep v1, Value v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
+  //  requires(rep v1, NumericValue v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
   {
     value_ %= rhs;
     return *this;
@@ -322,7 +322,7 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, Value Val>
+template<typename D, typename U, typename Rep, NumericValue Val>
 [[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Val& v)
   requires std::regular_invocable<std::multiplies<>, Rep, Val>
 {
@@ -331,7 +331,7 @@ template<typename D, typename U, typename Rep, Value Val>
   return ret(q.count() * v);
 }
 
-template<Value Val, typename D, typename U, typename Rep>
+template<NumericValue Val, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator*(const Val& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::multiplies<>, Val, Rep>
 {
@@ -339,7 +339,7 @@ template<Value Val, typename D, typename U, typename Rep>
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Value AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr NumericValue AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::multiplies<>, Rep1, Rep2> &&
            equivalent_dim<D1, dim_invert<D2>>
 {
@@ -366,7 +366,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() * rhs.count());
 }
 
-template<Value Val, typename D, typename U, typename Rep>
+template<NumericValue Val, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr Quantity AUTO operator/(const Val& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::divides<>, Val, Rep>
 {
@@ -380,7 +380,7 @@ template<Value Val, typename D, typename U, typename Rep>
   return ret(v / q.count());
 }
 
-template<typename D, typename U, typename Rep, Value Val>
+template<typename D, typename U, typename Rep, NumericValue Val>
 [[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Val& v)
   requires std::regular_invocable<std::divides<>, Rep, Val>
 {
@@ -392,7 +392,7 @@ template<typename D, typename U, typename Rep, Value Val>
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Value AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr NumericValue AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::divides<>, Rep1, Rep2> &&
            equivalent_dim<D1, D2>
 {
@@ -419,7 +419,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() / rhs.count());
 }
 
-template<typename D, typename U, typename Rep, Value Val>
+template<typename D, typename U, typename Rep, NumericValue Val>
 [[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Val& v)
   requires (!treat_as_floating_point<Rep>) &&
            (!treat_as_floating_point<Val>) &&

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -60,7 +60,7 @@ concept safe_divisible = // exposition only
  * @tparam U a measurement unit of the quantity
  * @tparam Rep a type to be used to represent values of a quantity
  */
-template<Dimension D, UnitOf<D> U, NumericValue Rep = double>
+template<in_dimension D, UnitOf<D> U, in_numeric_value Rep = double>
 class quantity {
   Rep value_{};
 
@@ -73,11 +73,11 @@ public:
   quantity(const quantity&) = default;
   quantity(quantity&&) = default;
 
-  template<NumericValue Val>
+  template<in_numeric_value Val>
     requires detail::safe_convertible<Val, rep>
   constexpr explicit quantity(const Val& v) : value_{static_cast<rep>(v)} {}
 
-  template<Quantity Q2>
+  template<in_quantity Q2>
     requires equivalent_dim<D, typename Q2::dimension> &&
              detail::safe_convertible<typename Q2::rep, rep> &&
              detail::safe_divisible<rep, typename Q2::unit, unit>
@@ -200,12 +200,12 @@ public:
     return *this;
   }
 
-  template<NumericValue Val, typename T = Rep>
+  template<in_numeric_value Val, typename T = Rep>
   constexpr quantity& operator%=(const Val& rhs)
     requires (!treat_as_floating_point<rep>) &&
              (!treat_as_floating_point<Val>) &&
              requires(T v1, Val v2) { { v1 %= v2 } -> SAME_AS(T&); }
-  //  requires(rep v1, NumericValue v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
+  //  requires(rep v1, in_numeric_value v2) { { v1 %= v2 } -> SAME_AS(rep&); }  // TODO gated by gcc-9 (fixed in gcc-10)
   {
     value_ %= rhs;
     return *this;
@@ -305,7 +305,7 @@ public:
 };
 
 template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator+(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
+[[nodiscard]] constexpr in_quantity AUTO operator+(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
   requires std::regular_invocable<std::plus<>, Rep1, Rep2>
 {
   using common_rep = decltype(lhs.count() + rhs.count());
@@ -314,7 +314,7 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
 }
 
 template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator-(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
+[[nodiscard]] constexpr in_quantity AUTO operator-(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
   requires std::regular_invocable<std::minus<>, Rep1, Rep2>
 {
   using common_rep = decltype(lhs.count() - rhs.count());
@@ -322,8 +322,8 @@ template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
   return ret(ret(lhs).count() - ret(rhs).count());
 }
 
-template<typename D, typename U, typename Rep, NumericValue Val>
-[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Val& v)
+template<typename D, typename U, typename Rep, in_numeric_value Val>
+[[nodiscard]] constexpr in_quantity AUTO operator*(const quantity<D, U, Rep>& q, const Val& v)
   requires std::regular_invocable<std::multiplies<>, Rep, Val>
 {
   using common_rep = decltype(q.count() * v);
@@ -331,15 +331,15 @@ template<typename D, typename U, typename Rep, NumericValue Val>
   return ret(q.count() * v);
 }
 
-template<NumericValue Val, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Val& v, const quantity<D, U, Rep>& q)
+template<in_numeric_value Val, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr in_quantity AUTO operator*(const Val& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::multiplies<>, Val, Rep>
 {
   return q * v;
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr NumericValue AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr in_numeric_value AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::multiplies<>, Rep1, Rep2> &&
            equivalent_dim<D1, dim_invert<D2>>
 {
@@ -353,7 +353,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr in_quantity AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::multiplies<>, Rep1, Rep2>
 {
   using dim = dimension_multiply<D1, D2>;
@@ -366,8 +366,8 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() * rhs.count());
 }
 
-template<NumericValue Val, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Val& v, const quantity<D, U, Rep>& q)
+template<in_numeric_value Val, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr in_quantity AUTO operator/(const Val& v, const quantity<D, U, Rep>& q)
   requires std::regular_invocable<std::divides<>, Val, Rep>
 {
   Expects(q.count() != 0);
@@ -380,8 +380,8 @@ template<NumericValue Val, typename D, typename U, typename Rep>
   return ret(v / q.count());
 }
 
-template<typename D, typename U, typename Rep, NumericValue Val>
-[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Val& v)
+template<typename D, typename U, typename Rep, in_numeric_value Val>
+[[nodiscard]] constexpr in_quantity AUTO operator/(const quantity<D, U, Rep>& q, const Val& v)
   requires std::regular_invocable<std::divides<>, Rep, Val>
 {
   Expects(v != Val{0});
@@ -392,7 +392,7 @@ template<typename D, typename U, typename Rep, NumericValue Val>
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr NumericValue AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr in_numeric_value AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::divides<>, Rep1, Rep2> &&
            equivalent_dim<D1, D2>
 {
@@ -404,7 +404,7 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
 }
 
 template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
+[[nodiscard]] constexpr in_quantity AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
   requires std::regular_invocable<std::divides<>, Rep1, Rep2>
 {
   Expects(rhs.count() != 0);
@@ -419,8 +419,8 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   return ret(lhs.count() / rhs.count());
 }
 
-template<typename D, typename U, typename Rep, NumericValue Val>
-[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Val& v)
+template<typename D, typename U, typename Rep, in_numeric_value Val>
+[[nodiscard]] constexpr in_quantity AUTO operator%(const quantity<D, U, Rep>& q, const Val& v)
   requires (!treat_as_floating_point<Rep>) &&
            (!treat_as_floating_point<Val>) &&
            std::regular_invocable<std::modulus<>, Rep, Val>
@@ -431,7 +431,7 @@ template<typename D, typename U, typename Rep, NumericValue Val>
 }
 
 template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
+[[nodiscard]] constexpr in_quantity AUTO operator%(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
   requires (!treat_as_floating_point<Rep1>) &&
            (!treat_as_floating_point<Rep2>) &&
            std::regular_invocable<std::modulus<>, Rep1, Rep2>

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -386,7 +386,7 @@ template<Unit ToU, typename D, typename U, typename Rep>
  *
  * @tparam ToRep a representation type to use for a target quantity
  */
-template<Value ToRep, typename D, typename U, typename Rep>
+template<NumericValue ToRep, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
 {
   return quantity_cast<quantity<D, U, ToRep>>(q);

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -63,7 +63,7 @@ constexpr long double fpow10(std::intmax_t exp)
 
 // QuantityOf
 template<typename T, typename Dim>
-concept QuantityOf = Quantity<T> && Dimension<Dim> && equivalent_dim<typename T::dimension, Dim>;
+concept QuantityOf = in_quantity<T> && in_dimension<Dim> && equivalent_dim<typename T::dimension, Dim>;
 
 // quantity_cast
 namespace detail {
@@ -73,7 +73,7 @@ struct quantity_cast_impl;
 
 template<typename To, typename CRatio, typename CRep>
 struct quantity_cast_impl<To, CRatio, CRep, true, true, true> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     return To(static_cast<To::rep>(q.count()));
@@ -82,7 +82,7 @@ struct quantity_cast_impl<To, CRatio, CRep, true, true, true> {
 
 template<typename To, typename CRatio, constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, true, true, false> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
@@ -138,7 +138,7 @@ struct quantity_cast_impl<To, CRatio, CRep, false, false, false> {
 
 template<typename To, typename CRatio, constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, true, false, true> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     return To(static_cast<To::rep>(static_cast<CRep>(q.count()) / static_cast<CRep>(CRatio::den)));
@@ -147,7 +147,7 @@ struct quantity_cast_impl<To, CRatio, CRep, true, false, true> {
 
 template<typename To, typename CRatio, constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, true, false, false> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
@@ -165,7 +165,7 @@ struct quantity_cast_impl<To, CRatio, CRep, true, false, false> {
 
 template<typename To, typename CRatio, constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, false, true, true> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     return To(static_cast<To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(CRatio::num)));
@@ -174,7 +174,7 @@ struct quantity_cast_impl<To, CRatio, CRep, false, true, true> {
 
 template<typename To, typename CRatio, constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, false, true, false> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
@@ -192,7 +192,7 @@ struct quantity_cast_impl<To, CRatio, CRep, false, true, false> {
 
 template<typename To, typename CRatio, not_constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, true, true, false> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
@@ -237,7 +237,7 @@ struct quantity_cast_impl<To, CRatio, CRep, false, false, false> {
 
 template<typename To, typename CRatio, not_constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, true, false, true> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     return To(static_cast<To::rep>(q.count() / CRatio::den));
@@ -246,7 +246,7 @@ struct quantity_cast_impl<To, CRatio, CRep, true, false, true> {
 
 template<typename To, typename CRatio, not_constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, true, false, false> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
@@ -264,7 +264,7 @@ struct quantity_cast_impl<To, CRatio, CRep, true, false, false> {
 
 template<typename To, typename CRatio, not_constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, false, true, true> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     return To(static_cast<To::rep>(q.count() * CRatio::num));
@@ -273,7 +273,7 @@ struct quantity_cast_impl<To, CRatio, CRep, false, true, true> {
 
 template<typename To, typename CRatio, not_constructible_from_integral CRep>
 struct quantity_cast_impl<To, CRatio, CRep, false, true, false> {
-  template<Quantity Q>
+  template<in_quantity Q>
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
@@ -289,7 +289,7 @@ struct quantity_cast_impl<To, CRatio, CRep, false, true, false> {
   }
 };
 
-template<Dimension FromD, in_unit FromU, Dimension ToD, in_unit ToU>
+template<in_dimension FromD, in_unit FromU, in_dimension ToD, in_unit ToU>
 struct cast_ratio;
 
 template<in_base_dimension FromD, in_unit FromU, in_base_dimension ToD, in_unit ToU>
@@ -324,7 +324,7 @@ struct cast_ratio<FromD, FromU, ToD, ToU> {
  *
  * @tparam To a target quantity type to cast to
  */
-template<Quantity To, typename D, typename U, typename Rep>
+template<in_quantity To, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
   requires QuantityOf<To, D>
 {
@@ -348,7 +348,7 @@ template<Quantity To, typename D, typename U, typename Rep>
  *
  * @tparam ToD a dimension type to use for a target quantity
  */
-template<Dimension ToD, typename D, typename U, typename Rep>
+template<in_dimension ToD, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
   requires equivalent_dim<ToD, D>
 {
@@ -386,7 +386,7 @@ template<in_unit ToU, typename D, typename U, typename Rep>
  *
  * @tparam ToRep a representation type to use for a target quantity
  */
-template<NumericValue ToRep, typename D, typename U, typename Rep>
+template<in_numeric_value ToRep, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
 {
   return quantity_cast<quantity<D, U, ToRep>>(q);

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -386,7 +386,7 @@ template<Unit ToU, typename D, typename U, typename Rep>
  *
  * @tparam ToRep a representation type to use for a target quantity
  */
-template<Scalar ToRep, typename D, typename U, typename Rep>
+template<Value ToRep, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
 {
   return quantity_cast<quantity<D, U, ToRep>>(q);

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -61,9 +61,9 @@ constexpr long double fpow10(std::intmax_t exp)
 }
 
 
-// QuantityOf
+// in_quantity_of
 template<typename T, typename Dim>
-concept QuantityOf = in_quantity<T> && in_dimension<Dim> && equivalent_dim<typename T::dimension, Dim>;
+concept in_quantity_of = in_quantity<T> && in_dimension<Dim> && equivalent_dim<typename T::dimension, Dim>;
 
 // quantity_cast
 namespace detail {
@@ -326,7 +326,7 @@ struct cast_ratio<FromD, FromU, ToD, ToU> {
  */
 template<in_quantity To, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
-  requires QuantityOf<To, D>
+  requires in_quantity_of<To, D>
 {
   using c_ratio = detail::cast_ratio<D, U, typename To::dimension, typename To::unit>::type;
   using c_rep = std::common_type_t<typename To::rep, Rep>;

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -289,21 +289,21 @@ struct quantity_cast_impl<To, CRatio, CRep, false, true, false> {
   }
 };
 
-template<Dimension FromD, Unit FromU, Dimension ToD, Unit ToU>
+template<Dimension FromD, in_unit FromU, Dimension ToD, in_unit ToU>
 struct cast_ratio;
 
-template<BaseDimension FromD, Unit FromU, BaseDimension ToD, Unit ToU>
+template<in_base_dimension FromD, in_unit FromU, in_base_dimension ToD, in_unit ToU>
 struct cast_ratio<FromD, FromU, ToD, ToU> {
   using type = ratio_divide<typename FromU::ratio, typename ToU::ratio>;
 };
 
-template<DerivedDimension FromD, Unit FromU, DerivedDimension ToD, Unit ToU>
+template<in_derived_dimension FromD, in_unit FromU, in_derived_dimension ToD, in_unit ToU>
   requires same_unit_reference<FromU, ToU>::value
 struct cast_ratio<FromD, FromU, ToD, ToU> {
   using type = ratio_divide<typename FromU::ratio, typename ToU::ratio>;
 };
 
-template<DerivedDimension FromD, Unit FromU, DerivedDimension ToD, Unit ToU>
+template<in_derived_dimension FromD, in_unit FromU, in_derived_dimension ToD, in_unit ToU>
 struct cast_ratio<FromD, FromU, ToD, ToU> {
   using from_ratio = ratio_multiply<typename FromD::base_units_ratio, typename FromU::ratio>;
   using to_ratio = ratio_multiply<typename ToD::base_units_ratio, typename ToU::ratio>;
@@ -367,7 +367,7 @@ template<Dimension ToD, typename D, typename U, typename Rep>
  *
  * @tparam ToU a unit type to use for a target quantity
  */
-template<Unit ToU, typename D, typename U, typename Rep>
+template<in_unit ToU, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr auto quantity_cast(const quantity<D, U, Rep>& q)
   requires UnitOf<ToU, D>
 {

--- a/src/include/units/random.h
+++ b/src/include/units/random.h
@@ -29,7 +29,7 @@
 namespace units {
 
 namespace detail {
-    template <Quantity Q, typename InputIt>
+    template <in_quantity Q, typename InputIt>
     static std::vector<typename Q::rep> i_qty_to_rep(InputIt first, InputIt last)
     {
         std::vector<typename Q::rep> intervals_rep;
@@ -38,7 +38,7 @@ namespace detail {
         return intervals_rep;
     }
     
-    template <Quantity Q>
+    template <in_quantity Q>
     static std::vector<typename Q::rep> bl_qty_to_rep(std::initializer_list<Q>& bl)
     {
         std::vector<typename Q::rep> bl_rep;
@@ -47,7 +47,7 @@ namespace detail {
         return bl_rep;
     }
 
-    template <Quantity Q, typename UnaryOperation>
+    template <in_quantity Q, typename UnaryOperation>
     inline static std::vector<typename Q::rep> fw_bl_pwc(std::initializer_list<Q>& bl, UnaryOperation fw)
     {
         using rep = Q::rep;
@@ -61,7 +61,7 @@ namespace detail {
         return weights;
     }
 
-    template <Quantity Q, typename UnaryOperation>
+    template <in_quantity Q, typename UnaryOperation>
     static std::vector<typename Q::rep> fw_bl_pwl(std::initializer_list<Q>& bl, UnaryOperation fw)
     {
         std::vector<typename Q::rep> weights;
@@ -71,7 +71,7 @@ namespace detail {
     }
 } // namespace detail
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::integral<typename Q::rep>
 struct uniform_int_distribution : public std::uniform_int_distribution<typename Q::rep>
 {
@@ -91,7 +91,7 @@ struct uniform_int_distribution : public std::uniform_int_distribution<typename 
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct uniform_real_distribution : public std::uniform_real_distribution<typename Q::rep>
 {
@@ -111,7 +111,7 @@ struct uniform_real_distribution : public std::uniform_real_distribution<typenam
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::integral<typename Q::rep>
 struct binomial_distribution : public std::binomial_distribution<typename Q::rep>
 {
@@ -130,7 +130,7 @@ struct binomial_distribution : public std::binomial_distribution<typename Q::rep
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::integral<typename Q::rep>
 struct negative_binomial_distribution : public std::negative_binomial_distribution<typename Q::rep>
 {
@@ -149,7 +149,7 @@ struct negative_binomial_distribution : public std::negative_binomial_distributi
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::integral<typename Q::rep>
 struct geometric_distribution : public std::geometric_distribution<typename Q::rep>
 {
@@ -166,7 +166,7 @@ struct geometric_distribution : public std::geometric_distribution<typename Q::r
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::integral<typename Q::rep>
 struct poisson_distribution : public std::poisson_distribution<typename Q::rep>
 {
@@ -183,7 +183,7 @@ struct poisson_distribution : public std::poisson_distribution<typename Q::rep>
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct exponential_distribution : public std::exponential_distribution<typename Q::rep>
 {
@@ -200,7 +200,7 @@ struct exponential_distribution : public std::exponential_distribution<typename 
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct gamma_distribution : public std::gamma_distribution<typename Q::rep>
 {
@@ -217,7 +217,7 @@ struct gamma_distribution : public std::gamma_distribution<typename Q::rep>
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct weibull_distribution : public std::weibull_distribution<typename Q::rep>
 {
@@ -234,7 +234,7 @@ struct weibull_distribution : public std::weibull_distribution<typename Q::rep>
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct extreme_value_distribution : public std::extreme_value_distribution<typename Q::rep>
 {
@@ -253,7 +253,7 @@ struct extreme_value_distribution : public std::extreme_value_distribution<typen
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct normal_distribution : public std::normal_distribution<typename Q::rep>
 {
@@ -273,7 +273,7 @@ struct normal_distribution : public std::normal_distribution<typename Q::rep>
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct lognormal_distribution : public std::lognormal_distribution<typename Q::rep>
 {
@@ -293,7 +293,7 @@ struct lognormal_distribution : public std::lognormal_distribution<typename Q::r
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct chi_squared_distribution : public std::chi_squared_distribution<typename Q::rep>
 {
@@ -310,7 +310,7 @@ struct chi_squared_distribution : public std::chi_squared_distribution<typename 
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct cauchy_distribution : public std::cauchy_distribution<typename Q::rep>
 {
@@ -330,7 +330,7 @@ struct cauchy_distribution : public std::cauchy_distribution<typename Q::rep>
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct fisher_f_distribution : public std::fisher_f_distribution<typename Q::rep>
 {
@@ -347,7 +347,7 @@ struct fisher_f_distribution : public std::fisher_f_distribution<typename Q::rep
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 struct student_t_distribution : public std::student_t_distribution<typename Q::rep>
 {
@@ -364,7 +364,7 @@ struct student_t_distribution : public std::student_t_distribution<typename Q::r
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::integral<typename Q::rep>
 struct discrete_distribution : public std::discrete_distribution<typename Q::rep>
 {
@@ -389,7 +389,7 @@ struct discrete_distribution : public std::discrete_distribution<typename Q::rep
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 class piecewise_constant_distribution : public std::piecewise_constant_distribution<typename Q::rep>
 {
@@ -434,7 +434,7 @@ public:
     Q max() const { return Q(base::max()); }
 };
 
-template<Quantity Q>
+template<in_quantity Q>
     requires std::floating_point<typename Q::rep>
 class piecewise_linear_distribution : public std::piecewise_linear_distribution<typename Q::rep>
 {

--- a/src/include/units/ratio.h
+++ b/src/include/units/ratio.h
@@ -41,7 +41,7 @@ namespace units {
  * 
  * @tparam Num Numerator
  * @tparam Den Denominator (default @c 1)
- * @tparam Exp Exponent (default @c 0)
+ * @tparam Exp in_exponent (default @c 0)
  */
 template<std::intmax_t Num, std::intmax_t Den = 1, std::intmax_t Exp = 0>
   requires(Den != 0)
@@ -75,7 +75,7 @@ inline constexpr bool is_ratio<ratio<Num, Den, Exp>> = true;
 
 // unused, and align exponents process could be subject to overflow in extreme cases
 
-// template<Ratio R1, Ratio R2>
+// template<in_ratio R1, in_ratio R2>
 // constexpr auto ratio_add_detail() {
 //   std::intmax_t num1 = R1::num;
 //   std::intmax_t num2 = R2::num;
@@ -105,7 +105,7 @@ inline constexpr bool is_ratio<ratio<Num, Den, Exp>> = true;
 // }
 
 
-// template<Ratio R1, Ratio R2>
+// template<in_ratio R1, in_ratio R2>
 // struct ratio_add_impl {
 //   static constexpr auto detail = ratio_add_detail<R1, R2>();
 //   using type = ratio<detail[0], detail[1], detail[2]>;
@@ -114,12 +114,12 @@ inline constexpr bool is_ratio<ratio<Num, Den, Exp>> = true;
 
 
 // ratio_add : not used
-// template<Ratio R1, Ratio R2>
+// template<in_ratio R1, in_ratio R2>
 // using ratio_add = detail::ratio_add_impl<R1, R2>::type;
 
 // ratio_subtract : not used
 // TODO implement ratio_subtract
-// template<Ratio R1, Ratio R2>
+// template<in_ratio R1, in_ratio R2>
 // using ratio_subtract = detail::ratio_subtract_impl<R1, R2>::type;
 
 // ratio_multiply
@@ -166,7 +166,7 @@ public:
 
 }  // namespace detail
 
-template<Ratio R1, Ratio R2>
+template<in_ratio R1, in_ratio R2>
 using ratio_multiply = detail::ratio_multiply_impl<R1, R2>::type;
 
 // ratio_divide
@@ -184,7 +184,7 @@ struct ratio_divide_impl {
 
 }  // namespace detail
 
-template<Ratio R1, Ratio R2>
+template<in_ratio R1, in_ratio R2>
 using ratio_divide = detail::ratio_divide_impl<R1, R2>::type;
 
 // ratio_pow
@@ -208,7 +208,7 @@ struct ratio_pow_impl<R, 0> {
 
 }  // namespace detail
 
-template<Ratio R, std::intmax_t N>
+template<in_ratio R, std::intmax_t N>
 using ratio_pow = detail::ratio_pow_impl<R, N>::type;
 
 // ratio_sqrt
@@ -237,7 +237,7 @@ static constexpr std::intmax_t sqrt_impl(std::intmax_t v)
   return root;
 }
 
-template<Ratio R>
+template<in_ratio R>
 constexpr auto make_exp_even()
 {
   if constexpr (R::exp % 2 == 0)
@@ -263,7 +263,7 @@ struct ratio_sqrt_impl<ratio<0, Den>> {
 
 }  // namespace detail
 
-template<Ratio R>
+template<in_ratio R>
 using ratio_sqrt = detail::ratio_sqrt_impl<R>::type;
 
 // common_ratio
@@ -282,7 +282,7 @@ struct common_ratio_impl {
 
 }  // namespace detail
 
-template<Ratio R1, Ratio R2>
+template<in_ratio R1, in_ratio R2>
 using common_ratio = detail::common_ratio_impl<R1, R2>::type;
 
 }  // namespace units

--- a/src/include/units/unit.h
+++ b/src/include/units/unit.h
@@ -50,16 +50,16 @@ namespace units {
  * @tparam U a unit to use as a reference for this dimension
  * @tparam R a ratio of a reference unit
  */
-template<UnitRatio R, typename U>
+template<in_unit_ratio R, typename U>
 struct scaled_unit : downcast_base<scaled_unit<R, U>> {
   using ratio = R;
   using reference = U;
 };
 
-template<Dimension D, UnitRatio R>
+template<Dimension D, in_unit_ratio R>
 using downcast_unit = downcast<scaled_unit<R, typename dimension_unit<D>::reference>>;
 
-template<Unit U1, Unit U2>
+template<in_unit U1, in_unit U2>
 struct same_unit_reference : std::is_same<typename U1::reference, typename U2::reference> {};
 
 /**
@@ -95,7 +95,7 @@ struct unknown_coherent_unit : unit<unknown_coherent_unit> {};
  * @tparam Symbol a short text representation of the unit
  * @tparam PF no_prefix or a type of prefix family
  */
-template<typename Child, basic_symbol_text Symbol, PrefixFamily PF>
+template<typename Child, basic_symbol_text Symbol, in_prefix_family PF>
 struct named_unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
@@ -116,7 +116,7 @@ struct named_unit : downcast_child<Child, scaled_unit<ratio<1>, Child>> {
  * @tparam R a scale to apply to U
  * @tparam U a reference unit to scale
  */
-template<typename Child, basic_symbol_text Symbol, PrefixFamily PF, UnitRatio R, Unit U>
+template<typename Child, basic_symbol_text Symbol, in_prefix_family PF, in_unit_ratio R, in_unit U>
 struct named_scaled_unit : downcast_child<Child, scaled_unit<ratio_multiply<R, typename U::ratio>, typename U::reference>> {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
@@ -134,7 +134,7 @@ struct named_scaled_unit : downcast_child<Child, scaled_unit<ratio_multiply<R, t
  * @tparam P prefix to be appied to the reference unit
  * @tparam U reference unit
  */
-template<typename Child, Prefix P, Unit U>
+template<typename Child, in_prefix P, in_unit U>
   requires U::is_named && std::same_as<typename P::prefix_family, typename U::prefix_family>
 struct prefixed_unit :
     downcast_child<Child, scaled_unit<ratio_multiply<typename P::ratio, typename U::ratio>, typename U::reference>> {
@@ -156,7 +156,7 @@ struct prefixed_unit :
  * @tparam U the unit of the first composite dimension from provided derived dimension's recipe
  * @tparam URest the units for the rest of dimensions from the recipe
  */
-template<typename Child, DerivedDimension Dim, Unit U, Unit... URest>
+template<typename Child, in_derived_dimension Dim, in_unit U, in_unit... URest>
   requires detail::same_scaled_units<typename Dim::recipe, U, URest...> &&
            (U::is_named && (URest::is_named && ... && true))
 struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest...>> {
@@ -165,7 +165,7 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
   using prefix_family = no_prefix;
 };
 
-// template<typename Child, Dimension Dim, basic_fixed_string Symbol, PrefixFamily PF, Unit U, Unit... Us>
+// template<typename Child, Dimension Dim, basic_fixed_string Symbol, in_prefix_family PF, in_unit U, in_unit... Us>
 // struct named_deduced_derived_unit : downcast_child<Child, detail::deduced_derived_unit<Dim, U, Us...>> {
 //   static constexpr bool is_named = true;
 //   static constexpr auto symbol = Symbol;
@@ -181,11 +181,11 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
  * no_prefix is provided for PF template parameter (in such a case it is impossible to define
  * a prefix unit based on this one).
  *
- * @tparam U Unit for which an alias is defined
+ * @tparam U in_unit for which an alias is defined
  * @tparam Symbol a short text representation of the unit
  * @tparam PF no_prefix or a type of prefix family
  */
-template<Unit U, basic_symbol_text Symbol, PrefixFamily PF>
+template<in_unit U, basic_symbol_text Symbol, in_prefix_family PF>
 struct alias_unit : U {
   static constexpr bool is_named = true;
   static constexpr auto symbol = Symbol;
@@ -199,15 +199,15 @@ struct alias_unit : U {
  * prefix. It is only possible to create such a unit if the given prefix type matches the one
  * defined in a reference unit.
  *
- * @tparam U Unit for which an alias is defined
+ * @tparam U in_unit for which an alias is defined
  * @tparam P prefix to be appied to the reference unit
  * @tparam AU reference alias unit
  */
 // TODO gcc bug: 95015
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95015
-// template<Unit U, Prefix P, AliasUnit AU>
+// template<in_unit U, in_prefix P, AliasUnit AU>
 //   requires (!AliasUnit<U>) && std::same_as<typename P::prefix_family, typename AU::prefix_family>
-template<Unit U, Prefix P, Unit AU>
+template<in_unit U, in_prefix P, in_unit AU>
   requires std::same_as<typename P::prefix_family, typename AU::prefix_family>
 struct prefixed_alias_unit : U {
   static constexpr bool is_named = true;

--- a/src/include/units/unit.h
+++ b/src/include/units/unit.h
@@ -56,7 +56,7 @@ struct scaled_unit : downcast_base<scaled_unit<R, U>> {
   using reference = U;
 };
 
-template<Dimension D, in_unit_ratio R>
+template<in_dimension D, in_unit_ratio R>
 using downcast_unit = downcast<scaled_unit<R, typename dimension_unit<D>::reference>>;
 
 template<in_unit U1, in_unit U2>
@@ -165,7 +165,7 @@ struct deduced_unit : downcast_child<Child, detail::deduced_unit<Dim, U, URest..
   using prefix_family = no_prefix;
 };
 
-// template<typename Child, Dimension Dim, basic_fixed_string Symbol, in_prefix_family PF, in_unit U, in_unit... Us>
+// template<typename Child, in_dimension Dim, basic_fixed_string Symbol, in_prefix_family PF, in_unit U, in_unit... Us>
 // struct named_deduced_derived_unit : downcast_child<Child, detail::deduced_derived_unit<Dim, U, Us...>> {
 //   static constexpr bool is_named = true;
 //   static constexpr auto symbol = Symbol;

--- a/test/unit_test/static/custom_rep_min_req_test.cpp
+++ b/test/unit_test/static/custom_rep_min_req_test.cpp
@@ -85,7 +85,7 @@ using impl_impl = impl_constructible_impl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_impl<float>>);
 static_assert(std::convertible_to<impl_impl<float>, float>);
-static_assert(units::NumericValue<impl_impl<float>>);
+static_assert(units::in_numeric_value<impl_impl<float>>);
 
 template<typename T>
 struct expl_constructible_impl_convertible : scalar_ops<expl_constructible_impl_convertible<T>> {
@@ -100,7 +100,7 @@ using expl_impl = expl_constructible_impl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_impl<float>>);
 static_assert(std::convertible_to<expl_impl<float>, float>);
-static_assert(units::NumericValue<expl_impl<float>>);
+static_assert(units::in_numeric_value<expl_impl<float>>);
 
 template<typename T>
 struct impl_constructible_expl_convertible : scalar_ops<impl_constructible_expl_convertible<T>> {
@@ -115,7 +115,7 @@ using impl_expl = impl_constructible_expl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_expl<float>>);
 static_assert(!std::convertible_to<impl_expl<float>, float>);
-static_assert(units::NumericValue<impl_expl<float>>);
+static_assert(units::in_numeric_value<impl_expl<float>>);
 
 template<typename T>
 struct expl_constructible_expl_convertible : scalar_ops<expl_constructible_expl_convertible<T>> {
@@ -130,7 +130,7 @@ using expl_expl = expl_constructible_expl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_expl<float>>);
 static_assert(!std::convertible_to<expl_expl<float>, float>);
-static_assert(units::NumericValue<expl_expl<float>>);
+static_assert(units::in_numeric_value<expl_expl<float>>);
 
 }  // namespace
 
@@ -169,7 +169,7 @@ using namespace units::physical::si;
 
 // constructors
 
-// Quantity from NumericValue
+// in_quantity from in_numeric_value
 // int <- int
 static_assert(length<metre, int>(expl_impl<int>(1)).count() == 1);
 // static_assert(length<metre, int>(impl_expl<int>(1)).count() == 1);  // should not compile (not convertible)
@@ -198,7 +198,7 @@ static_assert(length<metre, impl_expl<double>>(1).count() == impl_expl<double>{1
 // static_assert(length<metre, int>(expl_impl<double>(1.0)).count() == 1); // should not compile (truncating conversion)
 // static_assert(length<metre, impl_expl<int>>(1.0).count() == impl_expl<int>{1});   // should not compile (truncating conversion)
 
-// Quantity from other Quantity with different Rep
+// in_quantity from other in_quantity with different Rep
 // int <- int
 static_assert(length<metre, int>(length<metre, expl_impl<int>>(expl_impl<int>(1))).count() == 1);
 // static_assert(length<metre, int>(length<metre, impl_expl<int>>(1)).count() == 1);  // should not compile (not convertible)

--- a/test/unit_test/static/custom_rep_min_req_test.cpp
+++ b/test/unit_test/static/custom_rep_min_req_test.cpp
@@ -85,7 +85,7 @@ using impl_impl = impl_constructible_impl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_impl<float>>);
 static_assert(std::convertible_to<impl_impl<float>, float>);
-static_assert(units::Value<impl_impl<float>>);
+static_assert(units::NumericValue<impl_impl<float>>);
 
 template<typename T>
 struct expl_constructible_impl_convertible : scalar_ops<expl_constructible_impl_convertible<T>> {
@@ -100,7 +100,7 @@ using expl_impl = expl_constructible_impl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_impl<float>>);
 static_assert(std::convertible_to<expl_impl<float>, float>);
-static_assert(units::Value<expl_impl<float>>);
+static_assert(units::NumericValue<expl_impl<float>>);
 
 template<typename T>
 struct impl_constructible_expl_convertible : scalar_ops<impl_constructible_expl_convertible<T>> {
@@ -115,7 +115,7 @@ using impl_expl = impl_constructible_expl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_expl<float>>);
 static_assert(!std::convertible_to<impl_expl<float>, float>);
-static_assert(units::Value<impl_expl<float>>);
+static_assert(units::NumericValue<impl_expl<float>>);
 
 template<typename T>
 struct expl_constructible_expl_convertible : scalar_ops<expl_constructible_expl_convertible<T>> {
@@ -130,7 +130,7 @@ using expl_expl = expl_constructible_expl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_expl<float>>);
 static_assert(!std::convertible_to<expl_expl<float>, float>);
-static_assert(units::Value<expl_expl<float>>);
+static_assert(units::NumericValue<expl_expl<float>>);
 
 }  // namespace
 
@@ -169,7 +169,7 @@ using namespace units::physical::si;
 
 // constructors
 
-// Quantity from Value
+// Quantity from NumericValue
 // int <- int
 static_assert(length<metre, int>(expl_impl<int>(1)).count() == 1);
 // static_assert(length<metre, int>(impl_expl<int>(1)).count() == 1);  // should not compile (not convertible)

--- a/test/unit_test/static/custom_rep_min_req_test.cpp
+++ b/test/unit_test/static/custom_rep_min_req_test.cpp
@@ -85,7 +85,7 @@ using impl_impl = impl_constructible_impl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_impl<float>>);
 static_assert(std::convertible_to<impl_impl<float>, float>);
-static_assert(units::Scalar<impl_impl<float>>);
+static_assert(units::Value<impl_impl<float>>);
 
 template<typename T>
 struct expl_constructible_impl_convertible : scalar_ops<expl_constructible_impl_convertible<T>> {
@@ -100,7 +100,7 @@ using expl_impl = expl_constructible_impl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_impl<float>>);
 static_assert(std::convertible_to<expl_impl<float>, float>);
-static_assert(units::Scalar<expl_impl<float>>);
+static_assert(units::Value<expl_impl<float>>);
 
 template<typename T>
 struct impl_constructible_expl_convertible : scalar_ops<impl_constructible_expl_convertible<T>> {
@@ -115,7 +115,7 @@ using impl_expl = impl_constructible_expl_convertible<T>;
 
 static_assert(std::convertible_to<float, impl_expl<float>>);
 static_assert(!std::convertible_to<impl_expl<float>, float>);
-static_assert(units::Scalar<impl_expl<float>>);
+static_assert(units::Value<impl_expl<float>>);
 
 template<typename T>
 struct expl_constructible_expl_convertible : scalar_ops<expl_constructible_expl_convertible<T>> {
@@ -130,7 +130,7 @@ using expl_expl = expl_constructible_expl_convertible<T>;
 
 static_assert(!std::convertible_to<float, expl_expl<float>>);
 static_assert(!std::convertible_to<expl_expl<float>, float>);
-static_assert(units::Scalar<expl_expl<float>>);
+static_assert(units::Value<expl_expl<float>>);
 
 }  // namespace
 
@@ -169,7 +169,7 @@ using namespace units::physical::si;
 
 // constructors
 
-// Quantity from Scalar
+// Quantity from Value
 // int <- int
 static_assert(length<metre, int>(expl_impl<int>(1)).count() == 1);
 // static_assert(length<metre, int>(impl_expl<int>(1)).count() == 1);  // should not compile (not convertible)

--- a/test/unit_test/static/custom_unit_test.cpp
+++ b/test/unit_test/static/custom_unit_test.cpp
@@ -35,14 +35,14 @@ using namespace units::physical::si;
 struct sq_volt_per_hertz : unit<sq_volt_per_hertz> {};
 struct dim_power_spectral_density : derived_dimension<dim_power_spectral_density, sq_volt_per_hertz, units::exp<dim_voltage, 2>, units::exp<dim_frequency, -1>> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using power_spectral_density = quantity<dim_power_spectral_density, U, Rep>;
 
 // amplitude spectral density
 struct volt_per_sqrt_hertz : unit<volt_per_sqrt_hertz> {};
 struct dim_amplitude_spectral_density : derived_dimension<dim_amplitude_spectral_density, volt_per_sqrt_hertz, units::exp<dim_voltage, 1>, units::exp<dim_frequency, -1, 2>> {};
 
-template<in_unit U, NumericValue Rep = double>
+template<in_unit U, in_numeric_value Rep = double>
 using amplitude_spectral_density = quantity<dim_amplitude_spectral_density, U, Rep>;
 
 }

--- a/test/unit_test/static/custom_unit_test.cpp
+++ b/test/unit_test/static/custom_unit_test.cpp
@@ -35,14 +35,14 @@ using namespace units::physical::si;
 struct sq_volt_per_hertz : unit<sq_volt_per_hertz> {};
 struct dim_power_spectral_density : derived_dimension<dim_power_spectral_density, sq_volt_per_hertz, units::exp<dim_voltage, 2>, units::exp<dim_frequency, -1>> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using power_spectral_density = quantity<dim_power_spectral_density, U, Rep>;
 
 // amplitude spectral density
 struct volt_per_sqrt_hertz : unit<volt_per_sqrt_hertz> {};
 struct dim_amplitude_spectral_density : derived_dimension<dim_amplitude_spectral_density, volt_per_sqrt_hertz, units::exp<dim_voltage, 1>, units::exp<dim_frequency, -1, 2>> {};
 
-template<Unit U, Scalar Rep = double>
+template<Unit U, Value Rep = double>
 using amplitude_spectral_density = quantity<dim_amplitude_spectral_density, U, Rep>;
 
 }

--- a/test/unit_test/static/custom_unit_test.cpp
+++ b/test/unit_test/static/custom_unit_test.cpp
@@ -35,14 +35,14 @@ using namespace units::physical::si;
 struct sq_volt_per_hertz : unit<sq_volt_per_hertz> {};
 struct dim_power_spectral_density : derived_dimension<dim_power_spectral_density, sq_volt_per_hertz, units::exp<dim_voltage, 2>, units::exp<dim_frequency, -1>> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using power_spectral_density = quantity<dim_power_spectral_density, U, Rep>;
 
 // amplitude spectral density
 struct volt_per_sqrt_hertz : unit<volt_per_sqrt_hertz> {};
 struct dim_amplitude_spectral_density : derived_dimension<dim_amplitude_spectral_density, volt_per_sqrt_hertz, units::exp<dim_voltage, 1>, units::exp<dim_frequency, -1, 2>> {};
 
-template<Unit U, Value Rep = double>
+template<Unit U, NumericValue Rep = double>
 using amplitude_spectral_density = quantity<dim_amplitude_spectral_density, U, Rep>;
 
 }

--- a/test/unit_test/static/custom_unit_test.cpp
+++ b/test/unit_test/static/custom_unit_test.cpp
@@ -35,14 +35,14 @@ using namespace units::physical::si;
 struct sq_volt_per_hertz : unit<sq_volt_per_hertz> {};
 struct dim_power_spectral_density : derived_dimension<dim_power_spectral_density, sq_volt_per_hertz, units::exp<dim_voltage, 2>, units::exp<dim_frequency, -1>> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using power_spectral_density = quantity<dim_power_spectral_density, U, Rep>;
 
 // amplitude spectral density
 struct volt_per_sqrt_hertz : unit<volt_per_sqrt_hertz> {};
 struct dim_amplitude_spectral_density : derived_dimension<dim_amplitude_spectral_density, volt_per_sqrt_hertz, units::exp<dim_voltage, 1>, units::exp<dim_frequency, -1, 2>> {};
 
-template<Unit U, NumericValue Rep = double>
+template<in_unit U, NumericValue Rep = double>
 using amplitude_spectral_density = quantity<dim_amplitude_spectral_density, U, Rep>;
 
 }

--- a/test/unit_test/static/dimension_op_test.cpp
+++ b/test/unit_test/static/dimension_op_test.cpp
@@ -50,7 +50,7 @@ struct typeinfo;
 template<typename... Ts>
 using dim_unpack = detail::dim_unpack<Ts...>::type;
 
-template<Exponent... Es>
+template<in_exponent... Es>
 using derived_dim = detail::derived_dimension_base<Es...>;
 
 static_assert(std::is_same_v<dim_unpack<>, exp_list<>>);

--- a/test/unit_test/static/dimensions_concepts_test.cpp
+++ b/test/unit_test/static/dimensions_concepts_test.cpp
@@ -27,132 +27,132 @@ namespace {
 
 using namespace units::physical;
 
-static_assert(Length<si::length<si::metre>>);
-static_assert(!Length<si::time<si::second>>);
+static_assert(in_length<si::length<si::metre>>);
+static_assert(!in_length<si::time<si::second>>);
 
-static_assert(Mass<si::mass<si::kilogram>>);
-static_assert(!Mass<si::time<si::second>>);
+static_assert(in_mass<si::mass<si::kilogram>>);
+static_assert(!in_mass<si::time<si::second>>);
 
-static_assert(Time<si::time<si::second>>);
-static_assert(!Time<si::length<si::metre>>);
+static_assert(in_time<si::time<si::second>>);
+static_assert(!in_time<si::length<si::metre>>);
 
-static_assert(Current<si::current<si::ampere>>);
-static_assert(!Current<si::time<si::second>>);
+static_assert(in_current<si::current<si::ampere>>);
+static_assert(!in_current<si::time<si::second>>);
 
-static_assert(Temperature<si::temperature<si::kelvin>>);
-static_assert(!Temperature<si::time<si::second>>);
+static_assert(in_temperature<si::temperature<si::kelvin>>);
+static_assert(!in_temperature<si::time<si::second>>);
 
-static_assert(Substance<si::substance<si::mole>>);
-static_assert(!Substance<si::time<si::second>>);
+static_assert(in_substance<si::substance<si::mole>>);
+static_assert(!in_substance<si::time<si::second>>);
 
-static_assert(LuminousIntensity<si::luminous_intensity<si::candela>>);
-static_assert(!LuminousIntensity<si::time<si::second>>);
+static_assert(in_luminous_intensity<si::luminous_intensity<si::candela>>);
+static_assert(!in_luminous_intensity<si::time<si::second>>);
 
-static_assert(Frequency<si::frequency<si::hertz>>);
-static_assert(!Frequency<si::time<si::second>>);
+static_assert(in_frequency<si::frequency<si::hertz>>);
+static_assert(!in_frequency<si::time<si::second>>);
 
-static_assert(Area<si::area<si::square_metre>>);
-static_assert(!Area<si::time<si::second>>);
+static_assert(in_area<si::area<si::square_metre>>);
+static_assert(!in_area<si::time<si::second>>);
 
-static_assert(Volume<si::volume<si::cubic_metre>>);
-static_assert(!Volume<si::time<si::second>>);
+static_assert(in_volume<si::volume<si::cubic_metre>>);
+static_assert(!in_volume<si::time<si::second>>);
 
-static_assert(Speed<si::speed<si::metre_per_second>>);
-static_assert(!Speed<si::time<si::second>>);
+static_assert(in_speed<si::speed<si::metre_per_second>>);
+static_assert(!in_speed<si::time<si::second>>);
 
-static_assert(Acceleration<si::acceleration<si::metre_per_second_sq>>);
-static_assert(!Acceleration<si::time<si::second>>);
+static_assert(in_acceleration<si::acceleration<si::metre_per_second_sq>>);
+static_assert(!in_acceleration<si::time<si::second>>);
 
-static_assert(Force<si::force<si::newton>>);
-static_assert(!Force<si::time<si::second>>);
+static_assert(in_force<si::force<si::newton>>);
+static_assert(!in_force<si::time<si::second>>);
 
-static_assert(Energy<si::energy<si::joule>>);
-static_assert(!Energy<si::time<si::second>>);
+static_assert(in_energy<si::energy<si::joule>>);
+static_assert(!in_energy<si::time<si::second>>);
 
-static_assert(Power<si::power<si::watt>>);
-static_assert(!Power<si::time<si::second>>);
+static_assert(in_power<si::power<si::watt>>);
+static_assert(!in_power<si::time<si::second>>);
 
-static_assert(Voltage<si::voltage<si::volt>>);
-static_assert(!Voltage<si::time<si::second>>);
+static_assert(in_voltage<si::voltage<si::volt>>);
+static_assert(!in_voltage<si::time<si::second>>);
 
-static_assert(ElectricCharge<si::electric_charge<si::coulomb>>);
-static_assert(!ElectricCharge<si::time<si::second>>);
+static_assert(in_electric_charge<si::electric_charge<si::coulomb>>);
+static_assert(!in_electric_charge<si::time<si::second>>);
 
-static_assert(Capacitance<si::capacitance<si::farad>>);
-static_assert(!Capacitance<si::time<si::second>>);
+static_assert(in_capacitance<si::capacitance<si::farad>>);
+static_assert(!in_capacitance<si::time<si::second>>);
 
-static_assert(SurfaceTension<si::surface_tension<si::newton_per_metre>>);
-static_assert(!SurfaceTension<si::time<si::second>>);
+static_assert(in_surface_tension<si::surface_tension<si::newton_per_metre>>);
+static_assert(!in_surface_tension<si::time<si::second>>);
 
-static_assert(Pressure<si::pressure<si::pascal>>);
-static_assert(!Pressure<si::time<si::second>>);
+static_assert(in_pressure<si::pressure<si::pascal>>);
+static_assert(!in_pressure<si::time<si::second>>);
 
-static_assert(MagneticInduction<si::magnetic_induction<si::tesla>>);
-static_assert(!MagneticInduction<si::time<si::second>>);
+static_assert(in_magnetic_induction<si::magnetic_induction<si::tesla>>);
+static_assert(!in_magnetic_induction<si::time<si::second>>);
 
-static_assert(MagneticFlux<si::magnetic_flux<si::weber>>);
-static_assert(!MagneticFlux<si::time<si::second>>);
+static_assert(in_magnetic_flux<si::magnetic_flux<si::weber>>);
+static_assert(!in_magnetic_flux<si::time<si::second>>);
 
-static_assert(Inductance<si::inductance<si::henry>>);
-static_assert(!Inductance<si::time<si::second>>);
+static_assert(in_inductance<si::inductance<si::henry>>);
+static_assert(!in_inductance<si::time<si::second>>);
 
-static_assert(Conductance<si::conductance<si::siemens>>);
-static_assert(!Conductance<si::time<si::second>>);
+static_assert(in_conductance<si::conductance<si::siemens>>);
+static_assert(!in_conductance<si::time<si::second>>);
 
 // TODO Add when downcasting issue is solved
 // static_assert(Radioactivity<si::radioactivity<si::siemens>>);
 // static_assert(!Radioactivity<si::time<si::second>>);
 
-static_assert(CatalyticActivity<si::catalytic_activity<si::katal>>);
-static_assert(!CatalyticActivity<si::time<si::second>>);
+static_assert(in_catalytic_activity<si::catalytic_activity<si::katal>>);
+static_assert(!in_catalytic_activity<si::time<si::second>>);
 
-static_assert(AbsorbedDose<si::absorbed_dose<si::gray>>);
-static_assert(!AbsorbedDose<si::time<si::second>>);
+static_assert(in_absorbed_dose<si::absorbed_dose<si::gray>>);
+static_assert(!in_absorbed_dose<si::time<si::second>>);
 
-static_assert(CurrentDensity<si::current_density<si::ampere_per_metre_sq>>);
-static_assert(!CurrentDensity<si::time<si::second>>);
+static_assert(in_current_density<si::current_density<si::ampere_per_metre_sq>>);
+static_assert(!in_current_density<si::time<si::second>>);
 
-static_assert(Concentration<si::concentration<si::mol_per_metre_cub>>);
-static_assert(!Concentration<si::time<si::second>>);
+static_assert(in_concentration<si::concentration<si::mol_per_metre_cub>>);
+static_assert(!in_concentration<si::time<si::second>>);
 
-static_assert(Luminance<si::luminance<si::candela_per_metre_sq>>);
-static_assert(!Luminance<si::time<si::second>>);
+static_assert(in_luminance<si::luminance<si::candela_per_metre_sq>>);
+static_assert(!in_luminance<si::time<si::second>>);
 
-static_assert(DynamicViscosity<si::dynamic_viscosity<si::pascal_second>>);
-static_assert(!DynamicViscosity<si::time<si::second>>);
+static_assert(in_dynamic_viscosity<si::dynamic_viscosity<si::pascal_second>>);
+static_assert(!in_dynamic_viscosity<si::time<si::second>>);
 
-static_assert(HeatCapacity<si::heat_capacity<si::joule_per_kelvin>>);
-static_assert(!HeatCapacity<si::time<si::second>>);
+static_assert(in_heat_capacity<si::heat_capacity<si::joule_per_kelvin>>);
+static_assert(!in_heat_capacity<si::time<si::second>>);
 
-static_assert(SpecificHeatCapacity<si::specific_heat_capacity<si::joule_per_kilogram_kelvin>>);
-static_assert(!SpecificHeatCapacity<si::time<si::second>>);
+static_assert(in_specific_heat_capacity<si::specific_heat_capacity<si::joule_per_kilogram_kelvin>>);
+static_assert(!in_specific_heat_capacity<si::time<si::second>>);
 
-static_assert(MolarHeatCapacity<si::molar_heat_capacity<si::joule_per_mole_kelvin>>);
-static_assert(!MolarHeatCapacity<si::time<si::second>>);
+static_assert(in_molar_heat_capacity<si::molar_heat_capacity<si::joule_per_mole_kelvin>>);
+static_assert(!in_molar_heat_capacity<si::time<si::second>>);
 
-static_assert(ThermalConductivity<si::thermal_conductivity<si::watt_per_metre_kelvin>>);
-static_assert(!ThermalConductivity<si::time<si::second>>);
+static_assert(in_thermal_conductivity<si::thermal_conductivity<si::watt_per_metre_kelvin>>);
+static_assert(!in_thermal_conductivity<si::time<si::second>>);
 
 // TODO Add when downcasting issue is solved
 // static_assert(EnergyDensity<si::energy_density<si::joule_per_metre_cub>>);
 // static_assert(!EnergyDensity<si::time<si::second>>);
 
-static_assert(ElectricFieldStrength<si::electric_field_strength<si::volt_per_metre>>);
-static_assert(!ElectricFieldStrength<si::time<si::second>>);
+static_assert(in_electric_field_strength<si::electric_field_strength<si::volt_per_metre>>);
+static_assert(!in_electric_field_strength<si::time<si::second>>);
 
-static_assert(ChargeDensity<si::charge_density<si::coulomb_per_metre_cub>>);
-static_assert(!ChargeDensity<si::time<si::second>>);
+static_assert(in_charge_density<si::charge_density<si::coulomb_per_metre_cub>>);
+static_assert(!in_charge_density<si::time<si::second>>);
 
-static_assert(SurfaceChargeDensity<si::surface_charge_density<si::coulomb_per_metre_sq>>);
-static_assert(!SurfaceChargeDensity<si::time<si::second>>);
+static_assert(in_surface_charge_density<si::surface_charge_density<si::coulomb_per_metre_sq>>);
+static_assert(!in_surface_charge_density<si::time<si::second>>);
 
-static_assert(Permittivity<si::permittivity<si::farad_per_metre>>);
-static_assert(!Permittivity<si::time<si::second>>);
+static_assert(in_permittivity<si::permittivity<si::farad_per_metre>>);
+static_assert(!in_permittivity<si::time<si::second>>);
 
-static_assert(Permeability<si::permeability<si::henry_per_metre>>);
-static_assert(!Permeability<si::time<si::second>>);
+static_assert(in_permeability<si::permeability<si::henry_per_metre>>);
+static_assert(!in_permeability<si::time<si::second>>);
 
-static_assert(MolarEnergy<si::molar_energy<si::joule_per_mole>>);
-static_assert(!MolarEnergy<si::time<si::second>>);
+static_assert(in_molar_energy<si::molar_energy<si::joule_per_mole>>);
+static_assert(!in_molar_energy<si::time<si::second>>);
 
 }

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -213,7 +213,7 @@ static_assert(2q_dm3 + 2q_cm3 == 2002q_ml);
 
 // is_quantity
 
-static_assert(Quantity<length<millimetre, int>>);
+static_assert(in_quantity<length<millimetre, int>>);
 
 // common_quantity
 

--- a/test/unit_test/static/ratio_test.cpp
+++ b/test/unit_test/static/ratio_test.cpp
@@ -26,7 +26,7 @@
 
   using namespace units;
 
-  template<Ratio R1, Ratio R2>
+  template<in_ratio R1, in_ratio R2>
   inline constexpr bool same = R1::num == R2::num && R1::den == R2::den && R1::exp == R2::exp;
 
   static_assert(same<ratio<2, 4>, ratio<1, 2>>);


### PR DESCRIPTION
rename concepts to lower case using `in_` prefix.  Rather than discuss in the abstract and in the negative "what we don't want" ,  so here is a positive suggestion and you can view how it works in the source code where it actually matters.
Fixes https://github.com/mpusz/units/issues/93
Also fixes https://github.com/mpusz/units/issues/114  `Scalar` is renamed to `in_numeric_value`. I felt that in_value was a little short. `in_numeric_value` is amorphous enough to be more than just maths.