### PR TITLE
Add constants fps

### DIFF
--- a/src/include/units/physical/fps/constants.h
+++ b/src/include/units/physical/fps/constants.h
@@ -1,0 +1,37 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/physical/fps/acceleration.h>
+#include <units/physical/fps/speed.h>
+#include <units/physical/si/constants.h>
+
+namespace units::physical::fps::fps2019 {
+
+template<Scalar Rep = double>
+inline constexpr auto speed_of_light = speed<foot_per_second, Rep>(si::si2019::speed_of_light<Rep>);
+
+template<Scalar Rep = double>
+inline constexpr auto standard_gravity = acceleration<foot_per_second_sq, Rep>(si::si2019::standard_gravity<Rep>);
+
+}  // namespace units::physical::fps::fps2019 {

--- a/test/unit_test/static/si_fps_test.cpp
+++ b/test/unit_test/static/si_fps_test.cpp
@@ -20,6 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
+
 #include <units/physical/fps/acceleration.h>
 #include <units/physical/fps/area.h>
 #include <units/physical/fps/constants.h>
@@ -53,16 +54,14 @@ static_assert(fps::time<fps::second>(1) == si::time<si::second>(1));
 static_assert(fps::speed<fps::foot_per_second>(1) == si::speed<si::metre_per_second>(0.3048));
 static_assert(fps::area<fps::square_foot>(1) == si::area<si::square_metre>(0.09290304));
 static_assert(fps::acceleration<fps::foot_per_second_sq>(1) == si::acceleration<si::metre_per_second_sq>(0.3048));
-static_assert(fps::force<fps::poundal>(1) >= si::force<si::newton>(0.138254) &&
+static_assert(fps::force<fps::poundal>(1) >= si::force<si::newton>(0.138254) && 
               fps::force<fps::poundal>(1) <= si::force<si::newton>(0.138256));
-static_assert(fps::energy<fps::foot_poundal>(1) >= si::energy<si::joule>(0.042140110093804) &&
+static_assert(fps::energy<fps::foot_poundal>(1) >= si::energy<si::joule>(0.042140110093804) && 
               fps::energy<fps::foot_poundal>(1) <= si::energy<si::joule>(0.042140110093806));
-static_assert(fps::power<fps::foot_poundal_per_second>(1) >= si::power<si::watt>(0.042140110093804) &&
+static_assert(fps::power<fps::foot_poundal_per_second>(1) >= si::power<si::watt>(0.042140110093804) && 
               fps::power<fps::foot_poundal_per_second>(1) <= si::power<si::watt>(0.042140110093806));
 static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >= si::pressure<si::pascal>(1.4881639435) &&
               fps::pressure<fps::poundal_per_foot_sq>(1) <= si::pressure<si::pascal>(1.4881639437));
-
-
 
 namespace si_literals {
 
@@ -74,14 +73,15 @@ static_assert(fps::time<fps::second>(1) == 1q_s);
 static_assert(fps::speed<fps::foot_per_second>(1) == 0.3048q_m_per_s);
 static_assert(fps::area<fps::square_foot>(1) == 0.09290304q_m2);
 static_assert(fps::acceleration<fps::foot_per_second_sq>(1) == 0.3048q_m_per_s2);
-static_assert(fps::force<fps::poundal>(1) >= 0.138254q_N && fps::force<fps::poundal>(1) <= 0.138256q_N);
-static_assert(fps::energy<fps::foot_poundal>(1) >= 0.042140110093804q_J &&
+static_assert(fps::force<fps::poundal>(1) >= 0.138254q_N && 
+              fps::force<fps::poundal>(1) <= 0.138256q_N);
+static_assert(fps::energy<fps::foot_poundal>(1) >= 0.042140110093804q_J && 
               fps::energy<fps::foot_poundal>(1) <= 0.042140110093806q_J);
-static_assert(fps::power<fps::foot_poundal_per_second>(1) >= 0.042140110093804q_W &&
+static_assert(fps::power<fps::foot_poundal_per_second>(1) >= 0.042140110093804q_W && 
               fps::power<fps::foot_poundal_per_second>(1) <= 0.042140110093806q_W);
-static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >= 1.4881639435q_Pa &&
-              fps::pressure<fps::poundal_per_foot_sq>(1) <= 1.4881639437q_Pa);
-}  // namespace si_literals
+static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >=  1.4881639435q_Pa &&
+              fps::pressure<fps::poundal_per_foot_sq>(1) <=  1.4881639437q_Pa);
+}
 
 namespace fps_literals {
 
@@ -93,14 +93,15 @@ static_assert(1q_s == si::time<si::second>(1));
 static_assert(1q_ft_per_s == si::speed<si::metre_per_second>(0.3048));
 static_assert(1q_ft2 == si::area<si::square_metre>(0.09290304));
 static_assert(1q_ft_per_s2 == si::acceleration<si::metre_per_second_sq>(0.3048));
-static_assert(1q_pdl >= si::force<si::newton>(0.138254) && 1q_pdl <= si::force<si::newton>(0.138256));
-static_assert(1q_ft_pdl >= si::energy<si::joule>(0.042140110093804) &&
+static_assert(1q_pdl >= si::force<si::newton>(0.138254) && 
+              1q_pdl <= si::force<si::newton>(0.138256));
+static_assert(1q_ft_pdl >= si::energy<si::joule>(0.042140110093804) && 
               1q_ft_pdl <= si::energy<si::joule>(0.042140110093806));
-static_assert(1q_ft_pdl_per_s >= si::power<si::watt>(0.042140110093804) &&
+static_assert(1q_ft_pdl_per_s >= si::power<si::watt>(0.042140110093804) && 
               1q_ft_pdl_per_s <= si::power<si::watt>(0.042140110093806));
-static_assert(1q_pdl_per_ft2 >= si::pressure<si::pascal>(1.4881639435) &&
+static_assert(1q_pdl_per_ft2>= si::pressure<si::pascal>(1.4881639435) &&
               1q_pdl_per_ft2 <= si::pressure<si::pascal>(1.4881639437));
-}  // namespace fps_literals
+}
 
 namespace fps_plus_si_literals {
 
@@ -111,16 +112,20 @@ using namespace units::physical::fps::literals;
 // static_assert(1'000q_g == 1q_kg); // ambiguous
 static_assert(1q_ft == 0.3048q_m);
 static_assert(1q_lb == 0.45359237q_kg);
-static_assert(1q_s == 1q_s);
+static_assert(1q_s  == 1q_s);
 static_assert(1q_ft_per_s == 0.3048q_m_per_s);
 static_assert(1q_ft2 == 0.09290304q_m2);
 static_assert(1q_ft_per_s2 == 0.3048q_m_per_s2);
-static_assert(1q_pdl >= 0.138254q_N && 1q_pdl <= 0.138256q_N);
-static_assert(1q_ft_pdl >= 0.042140110093804q_J && 1q_ft_pdl <= 0.042140110093806q_J);
-static_assert(1q_ft_pdl_per_s >= 0.042140110093804q_W && 1q_ft_pdl_per_s <= 0.042140110093806q_W);
-static_assert(1q_pdl_per_ft2 >= 1.4881639435q_Pa && 1q_pdl_per_ft2 <= 1.4881639437q_Pa);
+static_assert(1q_pdl >= 0.138254q_N && 
+              1q_pdl <= 0.138256q_N);
+static_assert(1q_ft_pdl >= 0.042140110093804q_J && 
+              1q_ft_pdl <= 0.042140110093806q_J);
+static_assert(1q_ft_pdl_per_s >= 0.042140110093804q_W && 
+              1q_ft_pdl_per_s <= 0.042140110093806q_W);
+static_assert(1q_pdl_per_ft2>= 1.4881639435q_Pa &&
+              1q_pdl_per_ft2 <=1.4881639437q_Pa);
 
-}  // namespace fps_plus_si_literals
+}
 
 namespace fps_test {
 
@@ -128,52 +133,36 @@ using namespace units::physical::fps::literals;
 
 // addition
 
-// static_assert(si::length<si::metre>(1) + 1q_ft == si::length<si::metre>(1.3048)); // should not compile (different
-// dimensions) static_assert(1q_ft / 0.3048 + si::length<si::metre>(1) == si::length<si::metre>(1.3048)); // should not
-// compile (different dimensions)
-static_assert(quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) + si::length<si::metre>(1) ==
-              si::length<si::metre>(2));  // 1 m in ft + 1 m
-static_assert(si::length<si::metre>(1) + quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) ==
-              si::length<si::metre>(2));  // 1 m + 1 m in ft
-static_assert(1q_ft + quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) ==
-              2q_ft);  // 1 ft + 1 ft in m
-static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) + 1q_ft ==
-              2q_ft);  // 1 ft in m + 1 ft
+// static_assert(si::length<si::metre>(1) + 1q_ft == si::length<si::metre>(1.3048)); // should not compile (different dimensions)
+// static_assert(1q_ft / 0.3048 + si::length<si::metre>(1) == si::length<si::metre>(1.3048)); // should not compile (different dimensions)
+static_assert(quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) + si::length<si::metre>(1) == si::length<si::metre>(2));   // 1 m in ft + 1 m
+static_assert(si::length<si::metre>(1) + quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) == si::length<si::metre>(2));   // 1 m + 1 m in ft
+static_assert(1q_ft + quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) == 2q_ft);                         // 1 ft + 1 ft in m
+static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) + 1q_ft == 2q_ft);                         // 1 ft in m + 1 ft
 
 // substraction
 
-// static_assert(1q_ft - si::length<si::metre>(1) == -si::length<si::metre>(0.6952)); // should not compile (different
-// dimensions) static_assert(si::length<si::metre>(1) - 1q_ft == si::length<si::metre>(0.6952)); // should not compile
-// (different dimensions)
-static_assert(quantity_cast<si::length<si::metre>>(6.q_ft) - si::length<si::metre>(1) ==
-              si::length<si::metre>(0.8288));  // 6 ft in m - 1 m  = ... m
-static_assert(si::length<si::metre>(5) - quantity_cast<si::length<si::metre>>(6q_ft) ==
-              si::length<si::metre>(3.1712));  // 5 m - 6 ft in m  = ...
-static_assert(6.q_ft - quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) ==
-              5.q_ft);  // 6 ft - 1 ft in m = 5 ft
-static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(1.8288)) - 1.q_ft ==
-              5.q_ft);  // 6 ft in m - 1 ft = 5 ft
+// static_assert(1q_ft - si::length<si::metre>(1) == -si::length<si::metre>(0.6952)); // should not compile (different dimensions)
+// static_assert(si::length<si::metre>(1) - 1q_ft == si::length<si::metre>(0.6952)); // should not compile (different dimensions)
+static_assert(quantity_cast<si::length<si::metre>>(6.q_ft) - si::length<si::metre>(1) == si::length<si::metre>(0.8288));      // 6 ft in m - 1 m  = ... m
+static_assert(si::length<si::metre>(5) - quantity_cast<si::length<si::metre>>(6q_ft) == si::length<si::metre>(3.1712));       // 5 m - 6 ft in m  = ...
+static_assert(6.q_ft - quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) == 5.q_ft);                       // 6 ft - 1 ft in m = 5 ft
+static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(1.8288)) - 1.q_ft == 5.q_ft);                       // 6 ft in m - 1 ft = 5 ft
 
 // multiplication
 
-// static_assert(2q_ft * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); // should not compile (unknown
-// dimension) static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(2) ==
-// si::area<si::square_metre>(1.2192));
-static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(0.6096) ==
-              si::area<si::square_metre>(0.371612160));  // 2 ft * 2 ft == 4 sq ft
+// static_assert(2q_ft * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); // should not compile (unknown dimension)
+// static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); 
+static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(0.6096) == si::area<si::square_metre>(0.371612160));  // 2 ft * 2 ft == 4 sq ft
 static_assert(2.q_ft * quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.6096)) == 4.q_ft2);
 
 // division
 
-// static_assert(si::area<si::square_metre>(4) / 200q_cm == si::length<si::metre>(2)); // should not compile (unknown
-// dimension)
-static_assert(si::area<si::square_metre>(1.48644864) / quantity_cast<si::length<si::metre>>(4q_ft) ==
-              si::length<si::metre>(1.2192));  // 16 ft2 / 4 ft = 4 ft
-static_assert(quantity_cast<fps::area<fps::square_foot>>(si::area<si::square_metre>(1.48644864)) / 4.q_ft ==
-              4.q_ft);  // 16 ft2 / 4 ft = 4 ft
+// static_assert(si::area<si::square_metre>(4) / 200q_cm == si::length<si::metre>(2)); // should not compile (unknown dimension)
+static_assert(si::area<si::square_metre>(1.48644864) / quantity_cast<si::length<si::metre>>(4q_ft) == si::length<si::metre>(1.2192)); // 16 ft2 / 4 ft = 4 ft
+static_assert(quantity_cast<fps::area<fps::square_foot>>(si::area<si::square_metre>(1.48644864)) / 4.q_ft == 4.q_ft);                 // 16 ft2 / 4 ft = 4 ft
 
-}  // namespace fps_test
-
+}
 
 namespace fps_constants_test{
     
@@ -188,4 +177,4 @@ static_assert(fps::fps2019::standard_gravity<> >= si::si2019::standard_gravity<>
 
 }  // namespace fps_constants_test
 
-}  // namespace
+}

--- a/test/unit_test/static/si_fps_test.cpp
+++ b/test/unit_test/static/si_fps_test.cpp
@@ -20,27 +20,28 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-
 #include <units/physical/fps/acceleration.h>
 #include <units/physical/fps/area.h>
+#include <units/physical/fps/constants.h>
 #include <units/physical/fps/energy.h>
 #include <units/physical/fps/force.h>
 #include <units/physical/fps/length.h>
 #include <units/physical/fps/mass.h>
 #include <units/physical/fps/power.h>
 #include <units/physical/fps/pressure.h>
-#include <units/physical/fps/time.h>
 #include <units/physical/fps/speed.h>
+#include <units/physical/fps/time.h>
 #include <units/physical/si/acceleration.h>
 #include <units/physical/si/area.h>
+#include <units/physical/si/constants.h>
 #include <units/physical/si/energy.h>
 #include <units/physical/si/force.h>
 #include <units/physical/si/length.h>
 #include <units/physical/si/mass.h>
 #include <units/physical/si/power.h>
 #include <units/physical/si/pressure.h>
-#include <units/physical/si/time.h>
 #include <units/physical/si/speed.h>
+#include <units/physical/si/time.h>
 
 namespace {
 
@@ -52,14 +53,16 @@ static_assert(fps::time<fps::second>(1) == si::time<si::second>(1));
 static_assert(fps::speed<fps::foot_per_second>(1) == si::speed<si::metre_per_second>(0.3048));
 static_assert(fps::area<fps::square_foot>(1) == si::area<si::square_metre>(0.09290304));
 static_assert(fps::acceleration<fps::foot_per_second_sq>(1) == si::acceleration<si::metre_per_second_sq>(0.3048));
-static_assert(fps::force<fps::poundal>(1) >= si::force<si::newton>(0.138254) && 
+static_assert(fps::force<fps::poundal>(1) >= si::force<si::newton>(0.138254) &&
               fps::force<fps::poundal>(1) <= si::force<si::newton>(0.138256));
-static_assert(fps::energy<fps::foot_poundal>(1) >= si::energy<si::joule>(0.042140110093804) && 
+static_assert(fps::energy<fps::foot_poundal>(1) >= si::energy<si::joule>(0.042140110093804) &&
               fps::energy<fps::foot_poundal>(1) <= si::energy<si::joule>(0.042140110093806));
-static_assert(fps::power<fps::foot_poundal_per_second>(1) >= si::power<si::watt>(0.042140110093804) && 
+static_assert(fps::power<fps::foot_poundal_per_second>(1) >= si::power<si::watt>(0.042140110093804) &&
               fps::power<fps::foot_poundal_per_second>(1) <= si::power<si::watt>(0.042140110093806));
 static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >= si::pressure<si::pascal>(1.4881639435) &&
               fps::pressure<fps::poundal_per_foot_sq>(1) <= si::pressure<si::pascal>(1.4881639437));
+
+
 
 namespace si_literals {
 
@@ -71,15 +74,14 @@ static_assert(fps::time<fps::second>(1) == 1q_s);
 static_assert(fps::speed<fps::foot_per_second>(1) == 0.3048q_m_per_s);
 static_assert(fps::area<fps::square_foot>(1) == 0.09290304q_m2);
 static_assert(fps::acceleration<fps::foot_per_second_sq>(1) == 0.3048q_m_per_s2);
-static_assert(fps::force<fps::poundal>(1) >= 0.138254q_N && 
-              fps::force<fps::poundal>(1) <= 0.138256q_N);
-static_assert(fps::energy<fps::foot_poundal>(1) >= 0.042140110093804q_J && 
+static_assert(fps::force<fps::poundal>(1) >= 0.138254q_N && fps::force<fps::poundal>(1) <= 0.138256q_N);
+static_assert(fps::energy<fps::foot_poundal>(1) >= 0.042140110093804q_J &&
               fps::energy<fps::foot_poundal>(1) <= 0.042140110093806q_J);
-static_assert(fps::power<fps::foot_poundal_per_second>(1) >= 0.042140110093804q_W && 
+static_assert(fps::power<fps::foot_poundal_per_second>(1) >= 0.042140110093804q_W &&
               fps::power<fps::foot_poundal_per_second>(1) <= 0.042140110093806q_W);
-static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >=  1.4881639435q_Pa &&
-              fps::pressure<fps::poundal_per_foot_sq>(1) <=  1.4881639437q_Pa);
-}
+static_assert(fps::pressure<fps::poundal_per_foot_sq>(1) >= 1.4881639435q_Pa &&
+              fps::pressure<fps::poundal_per_foot_sq>(1) <= 1.4881639437q_Pa);
+}  // namespace si_literals
 
 namespace fps_literals {
 
@@ -91,15 +93,14 @@ static_assert(1q_s == si::time<si::second>(1));
 static_assert(1q_ft_per_s == si::speed<si::metre_per_second>(0.3048));
 static_assert(1q_ft2 == si::area<si::square_metre>(0.09290304));
 static_assert(1q_ft_per_s2 == si::acceleration<si::metre_per_second_sq>(0.3048));
-static_assert(1q_pdl >= si::force<si::newton>(0.138254) && 
-              1q_pdl <= si::force<si::newton>(0.138256));
-static_assert(1q_ft_pdl >= si::energy<si::joule>(0.042140110093804) && 
+static_assert(1q_pdl >= si::force<si::newton>(0.138254) && 1q_pdl <= si::force<si::newton>(0.138256));
+static_assert(1q_ft_pdl >= si::energy<si::joule>(0.042140110093804) &&
               1q_ft_pdl <= si::energy<si::joule>(0.042140110093806));
-static_assert(1q_ft_pdl_per_s >= si::power<si::watt>(0.042140110093804) && 
+static_assert(1q_ft_pdl_per_s >= si::power<si::watt>(0.042140110093804) &&
               1q_ft_pdl_per_s <= si::power<si::watt>(0.042140110093806));
-static_assert(1q_pdl_per_ft2>= si::pressure<si::pascal>(1.4881639435) &&
+static_assert(1q_pdl_per_ft2 >= si::pressure<si::pascal>(1.4881639435) &&
               1q_pdl_per_ft2 <= si::pressure<si::pascal>(1.4881639437));
-}
+}  // namespace fps_literals
 
 namespace fps_plus_si_literals {
 
@@ -110,56 +111,81 @@ using namespace units::physical::fps::literals;
 // static_assert(1'000q_g == 1q_kg); // ambiguous
 static_assert(1q_ft == 0.3048q_m);
 static_assert(1q_lb == 0.45359237q_kg);
-static_assert(1q_s  == 1q_s);
+static_assert(1q_s == 1q_s);
 static_assert(1q_ft_per_s == 0.3048q_m_per_s);
 static_assert(1q_ft2 == 0.09290304q_m2);
 static_assert(1q_ft_per_s2 == 0.3048q_m_per_s2);
-static_assert(1q_pdl >= 0.138254q_N && 
-              1q_pdl <= 0.138256q_N);
-static_assert(1q_ft_pdl >= 0.042140110093804q_J && 
-              1q_ft_pdl <= 0.042140110093806q_J);
-static_assert(1q_ft_pdl_per_s >= 0.042140110093804q_W && 
-              1q_ft_pdl_per_s <= 0.042140110093806q_W);
-static_assert(1q_pdl_per_ft2>= 1.4881639435q_Pa &&
-              1q_pdl_per_ft2 <=1.4881639437q_Pa);
+static_assert(1q_pdl >= 0.138254q_N && 1q_pdl <= 0.138256q_N);
+static_assert(1q_ft_pdl >= 0.042140110093804q_J && 1q_ft_pdl <= 0.042140110093806q_J);
+static_assert(1q_ft_pdl_per_s >= 0.042140110093804q_W && 1q_ft_pdl_per_s <= 0.042140110093806q_W);
+static_assert(1q_pdl_per_ft2 >= 1.4881639435q_Pa && 1q_pdl_per_ft2 <= 1.4881639437q_Pa);
 
-}
+}  // namespace fps_plus_si_literals
 
-namespace cgs_test {
+namespace fps_test {
 
 using namespace units::physical::fps::literals;
 
 // addition
 
-// static_assert(si::length<si::metre>(1) + 1q_ft == si::length<si::metre>(1.3048)); // should not compile (different dimensions)
-// static_assert(1q_ft / 0.3048 + si::length<si::metre>(1) == si::length<si::metre>(1.3048)); // should not compile (different dimensions)
-static_assert(quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) + si::length<si::metre>(1) == si::length<si::metre>(2));   // 1 m in ft + 1 m
-static_assert(si::length<si::metre>(1) + quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) == si::length<si::metre>(2));   // 1 m + 1 m in ft
-static_assert(1q_ft + quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) == 2q_ft);                         // 1 ft + 1 ft in m
-static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) + 1q_ft == 2q_ft);                         // 1 ft in m + 1 ft
+// static_assert(si::length<si::metre>(1) + 1q_ft == si::length<si::metre>(1.3048)); // should not compile (different
+// dimensions) static_assert(1q_ft / 0.3048 + si::length<si::metre>(1) == si::length<si::metre>(1.3048)); // should not
+// compile (different dimensions)
+static_assert(quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) + si::length<si::metre>(1) ==
+              si::length<si::metre>(2));  // 1 m in ft + 1 m
+static_assert(si::length<si::metre>(1) + quantity_cast<si::length<si::metre>>(1.q_ft / 0.3048) ==
+              si::length<si::metre>(2));  // 1 m + 1 m in ft
+static_assert(1q_ft + quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) ==
+              2q_ft);  // 1 ft + 1 ft in m
+static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) + 1q_ft ==
+              2q_ft);  // 1 ft in m + 1 ft
 
 // substraction
 
-// static_assert(1q_ft - si::length<si::metre>(1) == -si::length<si::metre>(0.6952)); // should not compile (different dimensions)
-// static_assert(si::length<si::metre>(1) - 1q_ft == si::length<si::metre>(0.6952)); // should not compile (different dimensions)
-static_assert(quantity_cast<si::length<si::metre>>(6.q_ft) - si::length<si::metre>(1) == si::length<si::metre>(0.8288));      // 6 ft in m - 1 m  = ... m
-static_assert(si::length<si::metre>(5) - quantity_cast<si::length<si::metre>>(6q_ft) == si::length<si::metre>(3.1712));       // 5 m - 6 ft in m  = ...
-static_assert(6.q_ft - quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) == 5.q_ft);                       // 6 ft - 1 ft in m = 5 ft
-static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(1.8288)) - 1.q_ft == 5.q_ft);                       // 6 ft in m - 1 ft = 5 ft
+// static_assert(1q_ft - si::length<si::metre>(1) == -si::length<si::metre>(0.6952)); // should not compile (different
+// dimensions) static_assert(si::length<si::metre>(1) - 1q_ft == si::length<si::metre>(0.6952)); // should not compile
+// (different dimensions)
+static_assert(quantity_cast<si::length<si::metre>>(6.q_ft) - si::length<si::metre>(1) ==
+              si::length<si::metre>(0.8288));  // 6 ft in m - 1 m  = ... m
+static_assert(si::length<si::metre>(5) - quantity_cast<si::length<si::metre>>(6q_ft) ==
+              si::length<si::metre>(3.1712));  // 5 m - 6 ft in m  = ...
+static_assert(6.q_ft - quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.3048)) ==
+              5.q_ft);  // 6 ft - 1 ft in m = 5 ft
+static_assert(quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(1.8288)) - 1.q_ft ==
+              5.q_ft);  // 6 ft in m - 1 ft = 5 ft
 
 // multiplication
 
-// static_assert(2q_ft * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); // should not compile (unknown dimension)
-// static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); 
-static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(0.6096) == si::area<si::square_metre>(0.371612160));  // 2 ft * 2 ft == 4 sq ft
+// static_assert(2q_ft * si::length<si::metre>(2) == si::area<si::square_metre>(1.2192)); // should not compile (unknown
+// dimension) static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(2) ==
+// si::area<si::square_metre>(1.2192));
+static_assert(quantity_cast<si::length<si::metre>>(2.q_ft) * si::length<si::metre>(0.6096) ==
+              si::area<si::square_metre>(0.371612160));  // 2 ft * 2 ft == 4 sq ft
 static_assert(2.q_ft * quantity_cast<fps::length<fps::foot>>(si::length<si::metre>(0.6096)) == 4.q_ft2);
 
 // division
 
-// static_assert(si::area<si::square_metre>(4) / 200q_cm == si::length<si::metre>(2)); // should not compile (unknown dimension)
-static_assert(si::area<si::square_metre>(1.48644864) / quantity_cast<si::length<si::metre>>(4q_ft) == si::length<si::metre>(1.2192)); // 16 ft2 / 4 ft = 4 ft
-static_assert(quantity_cast<fps::area<fps::square_foot>>(si::area<si::square_metre>(1.48644864)) / 4.q_ft == 4.q_ft);                 // 16 ft2 / 4 ft = 4 ft
+// static_assert(si::area<si::square_metre>(4) / 200q_cm == si::length<si::metre>(2)); // should not compile (unknown
+// dimension)
+static_assert(si::area<si::square_metre>(1.48644864) / quantity_cast<si::length<si::metre>>(4q_ft) ==
+              si::length<si::metre>(1.2192));  // 16 ft2 / 4 ft = 4 ft
+static_assert(quantity_cast<fps::area<fps::square_foot>>(si::area<si::square_metre>(1.48644864)) / 4.q_ft ==
+              4.q_ft);  // 16 ft2 / 4 ft = 4 ft
 
-}
+}  // namespace fps_test
 
-}
+
+namespace fps_constants_test{
+    
+using namespace si::literals;
+
+static_assert(fps::fps2019::speed_of_light<> >= si::si2019::speed_of_light<> - 1.q_m_per_s && 
+              fps::fps2019::speed_of_light<> <= si::si2019::speed_of_light<> + 1.q_m_per_s);
+
+static_assert(fps::fps2019::standard_gravity<> >= si::si2019::standard_gravity<> - 1e-7q_m_per_s2 && 
+              fps::fps2019::standard_gravity<> <= si::si2019::standard_gravity<> + 1e-7q_m_per_s2);
+   
+
+}  // namespace fps_constants_test
+
+}  // namespace


### PR DESCRIPTION
A small enhancement would to use constants to create deduced or scaled units. 

For the fps system pound-force is equal to the gravitational force of gravity acting on 1 pound of mass:
struct pound_force : named_scaled_unit<pound_force, "lbf", si::prefix, ratio<32'174'049, 1'000'000>, poundal> {};
it would be nice to remove the magic constants and write something like this:
struct pound_force : named_deduced_unit<pound_force, "lbf", si::prefix, pound, fps2019::standard_gravity> {};

I've only found a couple of other places in the codebase that it could be used; si::electronvolt could use si2019::elementary_charge, and iau::light_year could use si2019::speed_of_light, and I'm not sure how it should be implemented, but it would still be nice.





