### PR TITLE
Kwikius quantity concept operator signatures v3

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -36,6 +36,7 @@ add_example(clcpp_response)
 add_example(conversion_factor)
 add_example(kalman_filter-alpha_beta_filter_example2)
 add_example(experimental_angle)
+add_example(chrono_duration_compat)
 
 conan_check_testing(linear_algebra)
 add_example(linear_algebra)

--- a/example/chrono_duration_compat.cpp
+++ b/example/chrono_duration_compat.cpp
@@ -1,0 +1,65 @@
+
+
+/*
+   By using the in_quantity concept for quantity operator signatures rather tha type direct,
+   we can make stdL::chrono duration a model of quantity
+*/
+#include <units/physical/si/speed.h>
+#include <units/physical/si/time.h>
+
+#include <chrono>
+
+namespace units{ 
+
+ // Here we  make chrono::duration fit the requirements for units::in_quantity conscept
+
+   namespace detail{
+
+      // make std::chrono::duration a model of quantity
+      template< typename Rep, typename Period >
+      inline constexpr bool is_quantity<std::chrono::duration<Rep, Period> > = true;
+   }
+
+   // N.B. These metafunctions are used to access the traits in models of quantity rather than poking the class template direct
+   // In practise it would be best to add a get_count(q) function to requirements rather than use q.count();
+   template <typename Rep>
+   struct get_dimension<std::chrono::duration<Rep> >{
+      using type = typename get_dimension<units::physical::si::time<units::physical::si::second> >::type; 
+   };
+
+   template <typename Rep>
+   struct get_unit<std::chrono::duration<Rep> >{
+      using type = typename get_unit<units::physical::si::time<units::physical::si::second> >::type; 
+   };
+
+}
+
+#include <iostream>
+namespace {
+template <typename Rep>
+std::ostream & operator << (std::ostream & os, std::chrono::duration<Rep> const & v)
+{
+      return os << v.count() << " s";
+}
+}
+
+using namespace units::physical::si::literals;
+using namespace std::literals::chrono_literals;
+
+int main()
+{
+   std::cout << "Demonstration of superiority of concept operator function signatures.\n"
+                "Here we make std::chrono::duration a model of units::in_quantity concept\n\n";
+   auto v1 = 1000.0q_m_per_s;  // units_quantity
+   auto v2 = 25.s;           // std::chrono::duration
+
+   std::cout << "v1 = " << v1 <<'\n';
+
+   std::cout << "v2 = " << v2 <<'\n';
+
+   auto v3 = v1 * v2;       // <-- here we multiply a velocity by a chrono duration
+
+   std::cout << v1 << " * " << v2 << " = " << v3 <<'\n';
+   
+}
+

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -171,6 +171,9 @@ concept DerivedDimension = is_instantiation<downcast_base_t<T>, detail::derived_
 template<typename T>
 concept Dimension = BaseDimension<T> || DerivedDimension<T>;
 
+template <typename T> struct get_dimension;
+template <typename T> struct get_unit;
+
 // UnitOf
 namespace detail {
 

--- a/src/include/units/math.h
+++ b/src/include/units/math.h
@@ -38,15 +38,16 @@ namespace units {
  * @param q Quantity being the base of the operation
  * @return Quantity The result of computation 
  */
-template<std::intmax_t N, typename D, typename U, typename Rep>
+template<std::intmax_t N, Quantity Q>
   requires(N != 0)
-inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
+inline Quantity AUTO pow(const Q& q) noexcept
   requires requires { std::pow(q.count(), N); }
 {
-  using dim = dimension_pow<D, N>;
-  using ratio = ratio_pow<typename U::ratio, N>;
+  using dim = dimension_pow<typename Q::dimension, N>;
+  using ratio = ratio_pow<typename Q::unit::ratio, N>;
   using unit = downcast_unit<dim, ratio>;
-  return quantity<dim, unit, Rep>(static_cast<Rep>(std::pow(q.count(), N)));
+  using rep = Q::rep;
+  return quantity<dim, unit, rep>(static_cast<rep>(std::pow(q.count(), N)));
 }
 
 /**
@@ -54,9 +55,9 @@ inline Quantity AUTO pow(const quantity<D, U, Rep>& q) noexcept
  * 
  * @return Rep A scalar value of @c 1. 
  */
-template<std::intmax_t N, typename D, typename U, typename Rep>
+template<std::intmax_t N, Quantity Q>
   requires(N == 0)
-inline Rep pow(const quantity<D, U, Rep>&) noexcept
+inline typename Q::rep pow(const Q&) noexcept
 {
   return 1;
 }
@@ -69,14 +70,15 @@ inline Rep pow(const quantity<D, U, Rep>&) noexcept
  * @param q Quantity being the base of the operation
  * @return Quantity The result of computation 
  */
-template<typename D, typename U, typename Rep>
-inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
+template<Quantity Q>
+inline Quantity AUTO sqrt(const Q& q) noexcept
   requires requires { std::sqrt(q.count()); }
 {
-  using dim = dimension_sqrt<D>;
-  using ratio = ratio_sqrt<typename U::ratio>;
+  using dim = dimension_sqrt<typename Q::dimension>;
+  using ratio = ratio_sqrt<typename Q::unit::ratio>;
   using unit = downcast_unit<dim, ratio>;
-  return quantity<dim, unit, Rep>(static_cast<Rep>(std::sqrt(q.count())));
+  using rep = Q::rep;
+  return quantity<dim, unit,rep>(static_cast<rep>(std::sqrt(q.count())));
 }
 
 /**
@@ -85,11 +87,11 @@ inline Quantity AUTO sqrt(const quantity<D, U, Rep>& q) noexcept
  * @param q Quantity being the base of the operation
  * @return Quantity The absolute value of a provided quantity
  */
-template<typename D, typename U, typename Rep>
-constexpr Quantity AUTO abs(const quantity<D, U, Rep>& q) noexcept
+template<Quantity Q>
+constexpr Quantity AUTO abs(const Q& q) noexcept
   requires requires { std::abs(q.count()); }
 {
-  return quantity<D, U, Rep>(std::abs(q.count()));
+  return Q(std::abs(q.count()));
 }
 
 /**

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -108,13 +108,18 @@ struct quantity_friend_operations{
      }
    }
 
+
    template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
    [[nodiscard]] friend constexpr Quantity AUTO operator*(const Lhs& lhs, const Rhs& rhs)
      requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep>
    {
-     using dim = dimension_multiply<typename Lhs::dimension, typename Rhs::dimension>;
-     using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
-     using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
+     using lhs_dimension = typename get_dimension<Lhs>::type;
+     using rhs_dimension = typename get_dimension<Rhs>::type;
+     using dim = dimension_multiply<lhs_dimension, rhs_dimension>;
+     using lhs_unit = typename get_unit<Lhs>::type;
+     using rhs_unit = typename get_unit<Rhs>::type;
+     using ratio1 = ratio_divide<typename lhs_unit::ratio, typename dimension_unit<lhs_dimension>::ratio>;
+     using ratio2 = ratio_divide<typename rhs_unit::ratio, typename dimension_unit<rhs_dimension>::ratio>;
      using ratio = ratio_multiply<ratio_multiply<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
      using unit = downcast_unit<dim, ratio>;
      using common_rep = decltype(lhs.count() * rhs.count());
@@ -454,6 +459,14 @@ public:
   {
     return os << detail::to_string<CharT, Traits>(q); 
   }
+};
+
+template <typename D, typename U, typename V> struct get_dimension<quantity<U,D,V> >{ 
+    using type = quantity<U,D,V>::dimension;
+};
+
+template< typename D, typename U, typename V> struct get_unit<quantity<U,D,V> >{
+   using type = quantity<U,D,V>::unit;
 };
 
 namespace detail {

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -48,6 +48,158 @@ concept safe_divisible = // exposition only
     treat_as_floating_point<Rep> ||
     ratio_divide<typename UnitFrom::ratio, typename UnitTo::ratio>::is_integral();
 
+//  constrain operators to mpusz::units::quantity only
+template<typename T>
+concept ll_quantity_concept = detail::is_quantity<T>;
+
+// base class for quantity
+// no increase in size of derived object , see https://en.cppreference.com/w/cpp/language/ebo
+struct quantity_friend_operations{
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator+(const Lhs& lhs, const Rhs& rhs)
+     requires 
+            equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
+            std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() + rhs.count());
+     using ret = common_quantity<Lhs, Rhs, common_rep>;
+     return ret(ret(lhs).count() + ret(rhs).count());
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend  constexpr Quantity AUTO operator-(const Lhs& lhs, const Rhs& rhs)
+     requires 
+            equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
+            std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() + rhs.count());
+     using ret = common_quantity<Lhs, Rhs, common_rep>;
+     return ret(ret(lhs).count() - ret(rhs).count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Q& q, const Value& v)
+     requires std::regular_invocable<std::multiplies<>, typename Q::rep, Value>
+   {
+     using common_rep = decltype(q.count() * v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() * v);
+   }
+
+   template<Scalar Value, ll_quantity_concept Q>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Value& v, const Q& q)
+     requires std::regular_invocable<std::multiplies<>, Value, typename Q::rep>
+   {
+     return q * v;
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Scalar AUTO operator*(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep> &&
+              equivalent_dim<typename Lhs::dimension, dim_invert<typename Rhs::dimension>>
+   {
+     using common_rep = decltype(lhs.count() * rhs.count());
+     using ratio = ratio_multiply<typename Lhs::unit::ratio, typename Rhs::unit::ratio>;
+     if constexpr (treat_as_floating_point<common_rep>) {
+       return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * fpow10(ratio::exp) / common_rep(ratio::den);
+     } else {
+       return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * ipow10(ratio::exp) / common_rep(ratio::den);
+     }
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using dim = dimension_multiply<typename Lhs::dimension, typename Rhs::dimension>;
+     using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
+     using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
+     using ratio = ratio_multiply<ratio_multiply<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
+     using unit = downcast_unit<dim, ratio>;
+     using common_rep = decltype(lhs.count() * rhs.count());
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(lhs.count() * rhs.count());
+   }
+
+   template<Scalar Value, ll_quantity_concept Q>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Value& v, const Q& q)
+     requires std::regular_invocable<std::divides<>, Value, typename Q::rep>
+   {
+     Expects(q.count() != 0);
+
+     using dim = dim_invert<typename Q::dimension>;
+     using ratio = ratio<Q::unit::ratio::den, Q::unit::ratio::num, -Q::unit::ratio::exp>;
+     using unit = downcast_unit<dim, ratio>;
+     using common_rep = decltype(v / q.count());
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(v / q.count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Q& q, const Value& v)
+     requires std::regular_invocable<std::divides<>, typename Q::rep, Value>
+   {
+     Expects(v != Value{0});
+
+     using common_rep = decltype(q.count() / v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() / v);
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Scalar AUTO operator/(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep> &&
+              equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>
+   {
+     Expects(rhs.count() != 0);
+
+     using common_rep = decltype(lhs.count() / rhs.count());
+     using cq = common_quantity<Lhs,Rhs, common_rep>;
+     return cq(lhs).count() / cq(rhs).count();
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     Expects(rhs.count() != 0);
+
+     using common_rep = decltype(lhs.count() / rhs.count());
+     using dim = dimension_divide<typename Lhs::dimension, typename Rhs::dimension>;
+     using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
+     using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
+     using ratio = ratio_multiply<ratio_divide<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
+     using unit = downcast_unit<dim, ratio>;
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(lhs.count() / rhs.count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator%(const Q& q, const Value& v)
+     requires (!treat_as_floating_point<typename Q::rep>) &&
+              (!treat_as_floating_point<Value>) &&
+              std::regular_invocable<std::modulus<>, typename Q::rep, Value>
+   {
+     using common_rep = decltype(q.count() % v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() % v);
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator%(const Lhs& lhs, const Rhs& rhs)
+     requires (!treat_as_floating_point<typename Lhs::rep>) &&
+              (!treat_as_floating_point<typename Rhs::rep>) &&
+              equivalent_dim<typename Lhs::dimension,typename Rhs::dimension> &&
+              std::regular_invocable<std::modulus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() % rhs.count());
+     using ret = common_quantity<Lhs,Rhs, common_rep>;
+     return ret(ret(lhs).count() % ret(rhs).count());
+   }
+
+};
+
 } // namespace detail
 
 /**
@@ -61,7 +213,7 @@ concept safe_divisible = // exposition only
  * @tparam Rep a type to be used to represent values of a quantity
  */
 template<Dimension D, UnitOf<D> U, Scalar Rep = double>
-class quantity {
+class quantity : detail::quantity_friend_operations {
   Rep value_{};
 
 public:
@@ -304,155 +456,12 @@ public:
   }
 };
 
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator+(const Lhs& lhs, const Rhs& rhs)
-  requires 
-         equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
-         std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using common_rep = decltype(lhs.count() + rhs.count());
-  using ret = common_quantity<Lhs, Rhs, common_rep>;
-  return ret(ret(lhs).count() + ret(rhs).count());
-}
-
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator-(const Lhs& lhs, const Rhs& rhs)
-  requires 
-         equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
-         std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using common_rep = decltype(lhs.count() + rhs.count());
-  using ret = common_quantity<Lhs, Rhs, common_rep>;
-  return ret(ret(lhs).count() - ret(rhs).count());
-}
-
-template<Quantity Q, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Q& q, const Value& v)
-  requires std::regular_invocable<std::multiplies<>, typename Q::rep, Value>
-{
-  using common_rep = decltype(q.count() * v);
-  using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
-  return ret(q.count() * v);
-}
-
-template<Scalar Value, Quantity Q>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const Q& q)
-  requires std::regular_invocable<std::multiplies<>, Value, typename Q::rep>
-{
-  return q * v;
-}
-
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Scalar AUTO operator*(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep> &&
-           equivalent_dim<typename Lhs::dimension, dim_invert<typename Rhs::dimension>>
-{
-  using common_rep = decltype(lhs.count() * rhs.count());
-  using ratio = ratio_multiply<typename Lhs::unit::ratio, typename Rhs::unit::ratio>;
-  if constexpr (treat_as_floating_point<common_rep>) {
-    return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * fpow10(ratio::exp) / common_rep(ratio::den);
-  } else {
-    return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * ipow10(ratio::exp) / common_rep(ratio::den);
-  }
-}
-
-template<Quantity Lhs, Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using dim = dimension_multiply<typename Lhs::dimension, typename Rhs::dimension>;
-  using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
-  using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
-  using ratio = ratio_multiply<ratio_multiply<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
-  using unit = downcast_unit<dim, ratio>;
-  using common_rep = decltype(lhs.count() * rhs.count());
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(lhs.count() * rhs.count());
-}
-
-template<Scalar Value, Quantity Q>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Value& v, const Q& q)
-  requires std::regular_invocable<std::divides<>, Value, typename Q::rep>
-{
-  Expects(q.count() != 0);
-
-  using dim = dim_invert<typename Q::dimension>;
-  using ratio = ratio<Q::unit::ratio::den, Q::unit::ratio::num, -Q::unit::ratio::exp>;
-  using unit = downcast_unit<dim, ratio>;
-  using common_rep = decltype(v / q.count());
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(v / q.count());
-}
-
-template<Quantity Q, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Q& q, const Value& v)
-  requires std::regular_invocable<std::divides<>, typename Q::rep, Value>
-{
-  Expects(v != Value{0});
-
-  using common_rep = decltype(q.count() / v);
-  using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
-  return ret(q.count() / v);
-}
-
-template<Quantity Lhs , Quantity Rhs>
-[[nodiscard]] constexpr Scalar AUTO operator/(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep> &&
-           equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>
-{
-  Expects(rhs.count() != 0);
-
-  using common_rep = decltype(lhs.count() / rhs.count());
-  using cq = common_quantity<Lhs,Rhs, common_rep>;
-  return cq(lhs).count() / cq(rhs).count();
-}
-
-template<Quantity Lhs , Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Lhs& lhs, const Rhs& rhs)
-  requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep>
-{
-  Expects(rhs.count() != 0);
-
-  using common_rep = decltype(lhs.count() / rhs.count());
-  using dim = dimension_divide<typename Lhs::dimension, typename Rhs::dimension>;
-  using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
-  using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
-  using ratio = ratio_multiply<ratio_divide<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
-  using unit = downcast_unit<dim, ratio>;
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(lhs.count() / rhs.count());
-}
-
-template<Quantity Q, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator%(const Q& q, const Value& v)
-  requires (!treat_as_floating_point<typename Q::rep>) &&
-           (!treat_as_floating_point<Value>) &&
-           std::regular_invocable<std::modulus<>, typename Q::rep, Value>
-{
-  using common_rep = decltype(q.count() % v);
-  using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
-  return ret(q.count() % v);
-}
-
-template<Quantity Lhs , Quantity Rhs>
-[[nodiscard]] constexpr Quantity AUTO operator%(const Lhs& lhs, const Rhs& rhs)
-  requires (!treat_as_floating_point<typename Lhs::rep>) &&
-           (!treat_as_floating_point<typename Rhs::rep>) &&
-           equivalent_dim<typename Lhs::dimension,typename Rhs::dimension> &&
-           std::regular_invocable<std::modulus<>, typename Lhs::rep, typename Rhs::rep>
-{
-  using common_rep = decltype(lhs.count() % rhs.count());
-  using ret = common_quantity<Lhs,Rhs, common_rep>;
-  return ret(ret(lhs).count() % ret(rhs).count());
-}
-
 namespace detail {
 
 template<typename D, typename U, typename Rep>
 inline constexpr bool is_quantity<quantity<D, U, Rep>> = true;
 
 }  // namespace detail
-
 
 
 }  // namespace units


### PR DESCRIPTION
Demonstration of using functions with concept signatures to integrate std::chronos duration with units::quantity. [See the chrono_duration_compat example for details](https://github.com/kwikius/units/blob/kwikius_quantity_concept_operator_signatures_v3/example/chrono_duration_compat.cpp#L60)