### PR TITLE
quantity concept operator signatures v4

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -35,6 +35,7 @@ add_example(foot_pound_second)
 add_example(glide_computer)
 add_example(hello_units)
 add_example(kalman_filter-alpha_beta_filter_example2)
+add_example(chrono_duration_compat)
 
 conan_check_testing(linear_algebra)
 add_example(linear_algebra)

--- a/example/alternative_namespaces/conversion_factor.cpp
+++ b/example/alternative_namespaces/conversion_factor.cpp
@@ -15,7 +15,6 @@
  along with this program. If not, see http://www.gnu.org/licenses./
 */
 
-
 #include "./units_str.h"
 #include "./length.h"
 #include <iostream>
@@ -28,13 +27,13 @@
 namespace {
 
 template<units::Quantity Target, units::Quantity Source>
-  requires units::equivalent_dim<typename Source::dimension, typename Target::dimension>
+  requires units::equivalent_dim<typename units::get_dimension<Source>::type, typename units::get_dimension<Target>::type>
 inline constexpr std::common_type_t<typename Target::rep, typename Source::rep> conversion_factor(Target, Source)
 {
   // get quantities looking like inputs but with Q::rep that doesn't have narrowing conversion
   typedef std::common_type_t<typename Target::rep, typename Source::rep> rep;
-  typedef units::quantity<typename Source::dimension, typename Source::unit, rep> source;
-  typedef units::quantity<typename Target::dimension, typename Target::unit, rep> target;
+  typedef units::quantity<typename units::get_dimension<Source>::type, typename units::get_unit<Source>::type, rep> source;
+  typedef units::quantity<typename units::get_dimension<Target>::type, typename units::get_unit<Target>::type, rep> target;
   return target{source{1}}.count();
 }
 

--- a/example/alternative_namespaces/units_str.h
+++ b/example/alternative_namespaces/units_str.h
@@ -7,5 +7,8 @@
 inline auto constexpr units_str(const units::Quantity AUTO& q)
 {
   typedef std::remove_cvref_t<decltype(q)> qtype;
-  return units::detail::unit_text<typename qtype::dimension, typename qtype::unit>();
+  return units::detail::unit_text<
+      typename units::get_dimension<qtype>::type, 
+      typename units::get_unit<qtype>::type
+  >();
 }

--- a/example/chrono_duration_compat.cpp
+++ b/example/chrono_duration_compat.cpp
@@ -1,0 +1,65 @@
+
+
+/*
+   By using the in_quantity concept for quantity operator signatures rather tha type direct,
+   we can make stdL::chrono duration a model of quantity
+*/
+#include <units/physical/si/speed.h>
+#include <units/physical/si/time.h>
+
+#include <chrono>
+
+namespace units{ 
+
+ // Here we  make chrono::duration fit the requirements for units::in_quantity conscept
+
+   namespace detail{
+
+      // make std::chrono::duration a model of quantity
+      template< typename Rep, typename Period >
+      inline constexpr bool is_quantity<std::chrono::duration<Rep, Period> > = true;
+   }
+
+   // N.B. These metafunctions are used to access the traits in models of quantity rather than poking the class template direct
+   // In practise it would be best to add a get_count(q) function to requirements rather than use q.count();
+   template <typename Rep>
+   struct get_dimension<std::chrono::duration<Rep> >{
+      using type = typename get_dimension<units::physical::si::time<units::physical::si::second> >::type; 
+   };
+
+   template <typename Rep>
+   struct get_unit<std::chrono::duration<Rep> >{
+      using type = typename get_unit<units::physical::si::time<units::physical::si::second> >::type; 
+   };
+
+}
+
+#include <iostream>
+namespace {
+template <typename Rep>
+std::ostream & operator << (std::ostream & os, std::chrono::duration<Rep> const & v)
+{
+      return os << v.count() << " s";
+}
+}
+
+using namespace units::physical::si::literals;
+using namespace std::literals::chrono_literals;
+
+int main()
+{
+   std::cout << "Demonstration of superiority of concept operator function signatures.\n"
+                "Here we make std::chrono::duration a model of units::in_quantity concept\n\n";
+   auto v1 = 1000.0q_m_per_s;  // units_quantity
+   auto v2 = 25.s;           // std::chrono::duration
+
+   std::cout << "v1 = " << v1 <<'\n';
+
+   std::cout << "v2 = " << v2 <<'\n';
+
+   auto v3 = v1 * v2;       // <-- here we multiply a velocity by a chrono duration
+
+   std::cout << v1 << " * " << v2 << " = " << v3 <<'\n';
+   
+}
+

--- a/example/chrono_duration_compat.cpp
+++ b/example/chrono_duration_compat.cpp
@@ -52,14 +52,30 @@ int main()
                 "Here we make std::chrono::duration a model of units::in_quantity concept\n\n";
    auto v1 = 1000.0q_m_per_s;  // units_quantity
    auto v2 = 25.s;           // std::chrono::duration
-
    std::cout << "v1 = " << v1 <<'\n';
-
    std::cout << "v2 = " << v2 <<'\n';
-
    auto v3 = v1 * v2;       // <-- here we multiply a velocity by a chrono duration
-
    std::cout << v1 << " * " << v2 << " = " << v3 <<'\n';
+   auto v4 = v1 / v2;
+   std::cout << v1 << " / " << v2 << " = " << v4 <<'\n';
+
+   auto v5 = v2 + v2 ;
+   std::cout << "(chrono + chrono)" <<  v2 << " + " << v2 << " = " << v5 <<'\n';
+
+   auto v6 = 100.0s + 3.0q_s;
+   std::cout << "(chrono + units)" << 100.0s << " + " << 3.0q_s << " = " << v6 <<'\n';
+
+   auto v7 = 1.0q_s + 1.0s;
+   std::cout << "(units + chrono)" << 1.0q_s << " + " << 1.0s << " = " << v7 <<'\n';
+
+   auto v8 = v2 - v2 ;
+   std::cout << "(chrono - chrono)" <<  v2 << " - " << v2 << " = " << v8 <<'\n';
+
+   auto v9 = 100.0s - 3.0q_s;
+   std::cout << "(chrono - units)" << 100.0s << " - " << 3.0q_s << " = " << v9 <<'\n';
+
+   auto v10 = 1.0q_ms - 1.0s;
+   std::cout << "(units - chrono)" << 1.0q_ms << " - " << 1.0s << " = " << v10 <<'\n';
    
 }
 

--- a/example/conversion_factor.cpp
+++ b/example/conversion_factor.cpp
@@ -27,13 +27,13 @@
 namespace {
 
 template<units::Quantity Target, units::Quantity Source>
-  requires units::equivalent_dim<typename Source::dimension, typename Target::dimension>
+  requires units::equivalent_dim<typename units::get_dimension<Source>::type, typename units::get_dimension<Target>::type>
 inline constexpr std::common_type_t<typename Target::rep, typename Source::rep> conversion_factor(Target, Source)
 {
   // get quantities looking like inputs but with Q::rep that doesn't have narrowing conversion
   typedef std::common_type_t<typename Target::rep, typename Source::rep> rep;
-  typedef units::quantity<typename Source::dimension, typename Source::unit, rep> source;
-  typedef units::quantity<typename Target::dimension, typename Target::unit, rep> target;
+  typedef units::quantity<typename units::get_dimension<Source>::type, typename units::get_unit<Source>::type, rep> source;
+  typedef units::quantity<typename units::get_dimension<Target>::type, typename units::get_unit<Target>::type, rep> target;
   return target{source{1}}.count();
 }
 

--- a/example/glide_computer.cpp
+++ b/example/glide_computer.cpp
@@ -180,7 +180,7 @@ template<typename Q1, typename Q2, direction D>
 
 template<typename Q1, typename Q2, direction D1, direction D2>
 [[nodiscard]] constexpr double operator/(const vector<Q1, D1>& lhs, const vector<Q2, D2>& rhs)
-  requires equivalent_dim<typename Q1::dimension, typename Q2::dimension> &&
+  requires equivalent_dim<typename units::get_dimension<Q1>::type, typename units::get_dimension<Q2>::type> &&
            requires { lhs.magnitude() / rhs.magnitude(); }
 {
   return lhs.magnitude() / rhs.magnitude();

--- a/src/include/units/bits/common_quantity.h
+++ b/src/include/units/bits/common_quantity.h
@@ -37,6 +37,23 @@ namespace detail {
 template<typename Q1, typename Q2, typename Rep>
 struct common_quantity_impl;
 
+template<Quantity Lhs, Quantity Rhs, typename Rep>
+   requires same_unit_reference<
+      dimension_unit< typename get_dimension<Lhs>::type>, 
+      dimension_unit< typename get_dimension<Rhs>::type>
+   >::value
+struct common_quantity_impl<Lhs,Rhs, Rep> {
+  using D = typename get_dimension<Lhs>::type;
+  using U = downcast_unit<
+      D, 
+      common_ratio<
+         typename get_unit<Lhs>::type::ratio, 
+         typename get_unit<Rhs>::type::ratio 
+      >
+  >;
+  using type = quantity<D, U, Rep>;
+};
+
 template<typename D, typename U, typename Rep1, typename Rep2, typename Rep>
 struct common_quantity_impl<quantity<D, U, Rep1>, quantity<D, U, Rep2>, Rep> {
   using type = quantity<D, U, Rep>;
@@ -66,7 +83,7 @@ quantity_point<D, U, Rep> common_quantity_point_impl(quantity<D, U, Rep>);
 }  // namespace detail
 
 template<Quantity Q1, Quantity Q2, Scalar Rep = std::common_type_t<typename Q1::rep, typename Q2::rep>>
-  requires equivalent_dim<typename Q1::dimension, typename Q2::dimension>
+  requires equivalent_dim<typename get_dimension<Q1>::type, typename get_dimension<Q2>::type>
 using common_quantity = detail::common_quantity_impl<Q1, Q2, Rep>::type;
 
 template<QuantityPoint QP1, QuantityPoint QP2>
@@ -87,7 +104,7 @@ namespace concepts {
 #endif
 
 template<units::Quantity Q1, units::Quantity Q2>
-  requires units::equivalent_dim<typename Q1::dimension, typename Q2::dimension>
+  requires units::equivalent_dim<typename units::get_dimension<Q1>::type, typename units::get_dimension<Q2>::type>
 struct common_type<Q1, Q2> {
   using type = units::common_quantity<Q1, Q2>;
 };

--- a/src/include/units/bits/to_string.h
+++ b/src/include/units/bits/to_string.h
@@ -169,7 +169,7 @@ std::basic_string<CharT> to_string(const Q& q)
 {
   std::basic_ostringstream<CharT, Traits> s;
   s << q.count();
-  constexpr auto symbol = unit_text<typename Q::dimension, typename Q::unit>();
+  constexpr auto symbol = unit_text<typename get_dimension<Q>::type, typename get_unit<Q>::type>();
   if constexpr (symbol.standard().size()) {
     s << " " << symbol.standard();
   }

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -171,6 +171,9 @@ concept DerivedDimension = is_instantiation<downcast_base_t<T>, detail::derived_
 template<typename T>
 concept Dimension = BaseDimension<T> || DerivedDimension<T>;
 
+template <typename T> struct get_dimension;
+template <typename T> struct get_unit;
+
 // UnitOf
 namespace detail {
 

--- a/src/include/units/math.h
+++ b/src/include/units/math.h
@@ -43,8 +43,8 @@ template<std::intmax_t N, Quantity Q>
 inline Quantity AUTO pow(const Q& q) noexcept
   requires requires { std::pow(q.count(), N); }
 {
-  using dim = dimension_pow<typename Q::dimension, N>;
-  using ratio = ratio_pow<typename Q::unit::ratio, N>;
+  using dim = dimension_pow<typename get_dimension<Q>::type, N>;
+  using ratio = ratio_pow<typename get_unit<Q>::type::ratio, N>;
   using unit = downcast_unit<dim, ratio>;
   using rep = Q::rep;
   return quantity<dim, unit, rep>(static_cast<rep>(std::pow(q.count(), N)));
@@ -74,8 +74,8 @@ template<Quantity Q>
 inline Quantity AUTO sqrt(const Q& q) noexcept
   requires requires { std::sqrt(q.count()); }
 {
-  using dim = dimension_sqrt<typename Q::dimension>;
-  using ratio = ratio_sqrt<typename Q::unit::ratio>;
+  using dim = dimension_sqrt<typename get_dimension<Q>::type>;
+  using ratio = ratio_sqrt<typename get_unit<Q>::type::ratio>;
   using unit = downcast_unit<dim, ratio>;
   using rep = Q::rep;
   return quantity<dim, unit, rep>(static_cast<rep>(std::sqrt(q.count())));

--- a/src/include/units/physical/dimensions.h
+++ b/src/include/units/physical/dimensions.h
@@ -33,7 +33,7 @@ template<typename Dim, template<typename...> typename DimTemplate>
 concept DimensionOf = Dimension<Dim> && is_derived_from_instantiation<Dim, DimTemplate>;
 
 template<typename Q, template<typename...> typename DimTemplate>
-concept QuantityOf = Quantity<Q> && is_derived_from_instantiation<typename Q::dimension, DimTemplate>;
+concept QuantityOf = Quantity<Q> && is_derived_from_instantiation<typename get_dimension<Q>::type, DimTemplate>;
 
 // ------------------------ base dimensions -----------------------------
 

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -48,6 +48,163 @@ concept safe_divisible = // exposition only
     treat_as_floating_point<Rep> ||
     ratio_divide<typename UnitFrom::ratio, typename UnitTo::ratio>::is_integral();
 
+//  constrain operators to mpusz::units::quantity only
+template<typename T>
+concept ll_quantity_concept = detail::is_quantity<T>;
+
+// base class for quantity
+// no increase in size of derived object , see https://en.cppreference.com/w/cpp/language/ebo
+struct quantity_friend_operations{
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator+(const Lhs& lhs, const Rhs& rhs)
+     requires 
+            equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
+            std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() + rhs.count());
+     using ret = common_quantity<Lhs, Rhs, common_rep>;
+     return ret(ret(lhs).count() + ret(rhs).count());
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend  constexpr Quantity AUTO operator-(const Lhs& lhs, const Rhs& rhs)
+     requires 
+            equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>  &&
+            std::regular_invocable<std::plus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() + rhs.count());
+     using ret = common_quantity<Lhs, Rhs, common_rep>;
+     return ret(ret(lhs).count() - ret(rhs).count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Q& q, const Value& v)
+     requires std::regular_invocable<std::multiplies<>, typename Q::rep, Value>
+   {
+     using common_rep = decltype(q.count() * v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() * v);
+   }
+
+   template<Scalar Value, ll_quantity_concept Q>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Value& v, const Q& q)
+     requires std::regular_invocable<std::multiplies<>, Value, typename Q::rep>
+   {
+     return q * v;
+   }
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Scalar AUTO operator*(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep> &&
+              equivalent_dim<typename Lhs::dimension, dim_invert<typename Rhs::dimension>>
+   {
+     using common_rep = decltype(lhs.count() * rhs.count());
+     using ratio = ratio_multiply<typename Lhs::unit::ratio, typename Rhs::unit::ratio>;
+     if constexpr (treat_as_floating_point<common_rep>) {
+       return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * fpow10(ratio::exp) / common_rep(ratio::den);
+     } else {
+       return common_rep(lhs.count()) * common_rep(rhs.count()) * common_rep(ratio::num) * ipow10(ratio::exp) / common_rep(ratio::den);
+     }
+   }
+
+
+   template<ll_quantity_concept Lhs, ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator*(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::multiplies<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using lhs_dimension = typename get_dimension<Lhs>::type;
+     using rhs_dimension = typename get_dimension<Rhs>::type;
+     using dim = dimension_multiply<lhs_dimension, rhs_dimension>;
+     using lhs_unit = typename get_unit<Lhs>::type;
+     using rhs_unit = typename get_unit<Rhs>::type;
+     using ratio1 = ratio_divide<typename lhs_unit::ratio, typename dimension_unit<lhs_dimension>::ratio>;
+     using ratio2 = ratio_divide<typename rhs_unit::ratio, typename dimension_unit<rhs_dimension>::ratio>;
+     using ratio = ratio_multiply<ratio_multiply<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
+     using unit = downcast_unit<dim, ratio>;
+     using common_rep = decltype(lhs.count() * rhs.count());
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(lhs.count() * rhs.count());
+   }
+
+   template<Scalar Value, ll_quantity_concept Q>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Value& v, const Q& q)
+     requires std::regular_invocable<std::divides<>, Value, typename Q::rep>
+   {
+     Expects(q.count() != 0);
+
+     using dim = dim_invert<typename Q::dimension>;
+     using ratio = ratio<Q::unit::ratio::den, Q::unit::ratio::num, -Q::unit::ratio::exp>;
+     using unit = downcast_unit<dim, ratio>;
+     using common_rep = decltype(v / q.count());
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(v / q.count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Q& q, const Value& v)
+     requires std::regular_invocable<std::divides<>, typename Q::rep, Value>
+   {
+     Expects(v != Value{0});
+
+     using common_rep = decltype(q.count() / v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() / v);
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Scalar AUTO operator/(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep> &&
+              equivalent_dim<typename Lhs::dimension,typename Rhs::dimension>
+   {
+     Expects(rhs.count() != 0);
+
+     using common_rep = decltype(lhs.count() / rhs.count());
+     using cq = common_quantity<Lhs,Rhs, common_rep>;
+     return cq(lhs).count() / cq(rhs).count();
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator/(const Lhs& lhs, const Rhs& rhs)
+     requires std::regular_invocable<std::divides<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     Expects(rhs.count() != 0);
+
+     using common_rep = decltype(lhs.count() / rhs.count());
+     using dim = dimension_divide<typename Lhs::dimension, typename Rhs::dimension>;
+     using ratio1 = ratio_divide<typename Lhs::unit::ratio, typename dimension_unit<typename Lhs::dimension>::ratio>;
+     using ratio2 = ratio_divide<typename Rhs::unit::ratio, typename dimension_unit<typename Rhs::dimension>::ratio>;
+     using ratio = ratio_multiply<ratio_divide<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
+     using unit = downcast_unit<dim, ratio>;
+     using ret = quantity<dim, unit, common_rep>;
+     return ret(lhs.count() / rhs.count());
+   }
+
+   template<ll_quantity_concept Q, Scalar Value>
+   [[nodiscard]] friend constexpr Quantity AUTO operator%(const Q& q, const Value& v)
+     requires (!treat_as_floating_point<typename Q::rep>) &&
+              (!treat_as_floating_point<Value>) &&
+              std::regular_invocable<std::modulus<>, typename Q::rep, Value>
+   {
+     using common_rep = decltype(q.count() % v);
+     using ret = quantity<typename Q::dimension, typename Q::unit, common_rep>;
+     return ret(q.count() % v);
+   }
+
+   template<ll_quantity_concept Lhs , ll_quantity_concept Rhs>
+   [[nodiscard]] friend constexpr Quantity AUTO operator%(const Lhs& lhs, const Rhs& rhs)
+     requires (!treat_as_floating_point<typename Lhs::rep>) &&
+              (!treat_as_floating_point<typename Rhs::rep>) &&
+              equivalent_dim<typename Lhs::dimension,typename Rhs::dimension> &&
+              std::regular_invocable<std::modulus<>, typename Lhs::rep, typename Rhs::rep>
+   {
+     using common_rep = decltype(lhs.count() % rhs.count());
+     using ret = common_quantity<Lhs,Rhs, common_rep>;
+     return ret(ret(lhs).count() % ret(rhs).count());
+   }
+
+};
+
 } // namespace detail
 
 /**
@@ -61,7 +218,7 @@ concept safe_divisible = // exposition only
  * @tparam Rep a type to be used to represent values of a quantity
  */
 template<Dimension D, UnitOf<D> U, Scalar Rep = double>
-class quantity {
+class quantity : detail::quantity_friend_operations {
   Rep value_{};
 
 public:
@@ -304,142 +461,13 @@ public:
   }
 };
 
-template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator+(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
-  requires std::regular_invocable<std::plus<>, Rep1, Rep2>
-{
-  using common_rep = decltype(lhs.count() + rhs.count());
-  using ret = common_quantity<quantity<D, U1, Rep1>, quantity<D, U2, Rep2>, common_rep>;
-  return ret(ret(lhs).count() + ret(rhs).count());
-}
+template <typename D, typename U, typename V> struct get_dimension<quantity<U,D,V> >{ 
+    using type = quantity<U,D,V>::dimension;
+};
 
-template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator-(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
-  requires std::regular_invocable<std::minus<>, Rep1, Rep2>
-{
-  using common_rep = decltype(lhs.count() - rhs.count());
-  using ret = common_quantity<quantity<D, U1, Rep1>, quantity<D, U2, Rep2>, common_rep>;
-  return ret(ret(lhs).count() - ret(rhs).count());
-}
-
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::multiplies<>, Rep, Value>
-{
-  using common_rep = decltype(q.count() * v);
-  using ret = quantity<D, U, common_rep>;
-  return ret(q.count() * v);
-}
-
-template<Scalar Value, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator*(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::multiplies<>, Value, Rep>
-{
-  return q * v;
-}
-
-template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Scalar AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
-  requires std::regular_invocable<std::multiplies<>, Rep1, Rep2> &&
-           equivalent_dim<D1, dim_invert<D2>>
-{
-  using common_rep = decltype(lhs.count() * rhs.count());
-  using ratio = ratio_multiply<typename U1::ratio, typename U2::ratio>;
-    if constexpr (treat_as_floating_point<common_rep>) {
-      return lhs.count() * rhs.count() * static_cast<common_rep>(ratio::num * fpow10(ratio::exp)) / static_cast<common_rep>(ratio::den);
-    } else {
-      return lhs.count() * rhs.count() * static_cast<common_rep>(ratio::num * ipow10(ratio::exp)) / static_cast<common_rep>(ratio::den);
-    }
-}
-
-template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator*(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
-  requires std::regular_invocable<std::multiplies<>, Rep1, Rep2>
-{
-  using dim = dimension_multiply<D1, D2>;
-  using ratio1 = ratio_divide<typename U1::ratio, typename dimension_unit<D1>::ratio>;
-  using ratio2 = ratio_divide<typename U2::ratio, typename dimension_unit<D2>::ratio>;
-  using ratio = ratio_multiply<ratio_multiply<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
-  using unit = downcast_unit<dim, ratio>;
-  using common_rep = decltype(lhs.count() * rhs.count());
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(lhs.count() * rhs.count());
-}
-
-template<Scalar Value, typename D, typename U, typename Rep>
-[[nodiscard]] constexpr Quantity AUTO operator/(const Value& v, const quantity<D, U, Rep>& q)
-  requires std::regular_invocable<std::divides<>, Value, Rep>
-{
-  Expects(q.count() != 0);
-
-  using dim = dim_invert<D>;
-  using ratio = ratio<U::ratio::den, U::ratio::num, -U::ratio::exp>;
-  using unit = downcast_unit<dim, ratio>;
-  using common_rep = decltype(v / q.count());
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(v / q.count());
-}
-
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D, U, Rep>& q, const Value& v)
-  requires std::regular_invocable<std::divides<>, Rep, Value>
-{
-  Expects(v != Value{0});
-
-  using common_rep = decltype(q.count() / v);
-  using ret = quantity<D, U, common_rep>;
-  return ret(q.count() / v);
-}
-
-template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Scalar AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
-  requires std::regular_invocable<std::divides<>, Rep1, Rep2> &&
-           equivalent_dim<D1, D2>
-{
-  Expects(rhs.count() != 0);
-
-  using common_rep = decltype(lhs.count() / rhs.count());
-  using cq = common_quantity<quantity<D1, U1, Rep1>, quantity<D2, U2, Rep2>, common_rep>;
-  return cq(lhs).count() / cq(rhs).count();
-}
-
-template<typename D1, typename U1, typename Rep1, typename D2, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator/(const quantity<D1, U1, Rep1>& lhs, const quantity<D2, U2, Rep2>& rhs)
-  requires std::regular_invocable<std::divides<>, Rep1, Rep2>
-{
-  Expects(rhs.count() != 0);
-
-  using common_rep = decltype(lhs.count() / rhs.count());
-  using dim = dimension_divide<D1, D2>;
-  using ratio1 = ratio_divide<typename U1::ratio, typename dimension_unit<D1>::ratio>;
-  using ratio2 = ratio_divide<typename U2::ratio, typename dimension_unit<D2>::ratio>;
-  using ratio = ratio_multiply<ratio_divide<ratio1, ratio2>, typename dimension_unit<dim>::ratio>;
-  using unit = downcast_unit<dim, ratio>;
-  using ret = quantity<dim, unit, common_rep>;
-  return ret(lhs.count() / rhs.count());
-}
-
-template<typename D, typename U, typename Rep, Scalar Value>
-[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U, Rep>& q, const Value& v)
-  requires (!treat_as_floating_point<Rep>) &&
-           (!treat_as_floating_point<Value>) &&
-           std::regular_invocable<std::modulus<>, Rep, Value>
-{
-  using common_rep = decltype(q.count() % v);
-  using ret = quantity<D, U, common_rep>;
-  return ret(q.count() % v);
-}
-
-template<typename D, typename U1, typename Rep1, typename U2, typename Rep2>
-[[nodiscard]] constexpr Quantity AUTO operator%(const quantity<D, U1, Rep1>& lhs, const quantity<D, U2, Rep2>& rhs)
-  requires (!treat_as_floating_point<Rep1>) &&
-           (!treat_as_floating_point<Rep2>) &&
-           std::regular_invocable<std::modulus<>, Rep1, Rep2>
-{
-  using common_rep = decltype(lhs.count() % rhs.count());
-  using ret = common_quantity<quantity<D, U1, Rep1>, quantity<D, U2, Rep2>, common_rep>;
-  return ret(ret(lhs).count() % ret(rhs).count());
-}
+template< typename D, typename U, typename V> struct get_unit<quantity<U,D,V> >{
+   using type = quantity<U,D,V>::unit;
+};
 
 namespace detail {
 
@@ -447,5 +475,6 @@ template<typename D, typename U, typename Rep>
 inline constexpr bool is_quantity<quantity<D, U, Rep>> = true;
 
 }  // namespace detail
+
 
 }  // namespace units


### PR DESCRIPTION
Use Concept names rather than class-template names for units::Quantity operator function signatures.
- The resulting function signature is shorter and easier to read and understand.
- The functions are not restricted to quantity<...> type, but can be reused by other models of Quantity.
- Derive quantity class template from base class 'quantity_friend_operations' and put operator functions there as friend functions.
     Solves problem with uneven weight of arguments and ODR violations etc
- Provide a local concept 'll_quantity_concept' representing only units::quantity<...> class template.

See https://github.com/mpusz/units/issues/93#issuecomment-647977970
examples :
[Integrate std::chrono::duration as a model of units::Quantity](https://github.com/kwikius/units/blob/kwikius_quantity_concept_operator_signatures_v4/example/chrono_duration_compat.cpp#L60)
The model of `units::Quantity` now requires `get_dimension<Q>::type` and `get_unit<Q>::type` traits rather than peeking the type directly.
In example/chrono_duration_compat.cpp we make chrono::duration a model of units::Quantity.
N.B This is a proof of concept and only the minimal work is done here to get this working for this minimal example.
Upgrading the rest is left as an exercise...