### PR TITLE
corrected copy-paste error in mole definition

### DIFF
--- a/src/include/units/physical/si/substance.h
+++ b/src/include/units/physical/si/substance.h
@@ -28,7 +28,7 @@
 
 namespace units::physical::si {
 
-struct mole : named_unit<metre, "mol", prefix> {};
+struct mole : named_unit<mole, "mol", prefix> {};
 
 struct dim_substance : physical::dim_substance<mole> {};
 


### PR DESCRIPTION
moles are moles