### PR TITLE
refactor: avoid always false comparison

### DIFF
--- a/src/include/units/bits/external/fixed_string.h
+++ b/src/include/units/bits/external/fixed_string.h
@@ -44,7 +44,8 @@ struct basic_fixed_string {
 
   constexpr basic_fixed_string(const CharT (&txt)[N + 1]) noexcept
   {
-    for (std::size_t i = 0; i < N; ++i) data_[i] = txt[i];
+    if constexpr (N != 0)
+      for (std::size_t i = 0; i < N; ++i) data_[i] = txt[i];
   }
 
   [[nodiscard]] constexpr std::size_t size() const noexcept { return N; }

--- a/src/include/units/symbol_text.h
+++ b/src/include/units/symbol_text.h
@@ -13,8 +13,9 @@ template<std::size_t P>
 constexpr void validate_ascii_string([[maybe_unused]] const char (&s)[P + 1]) noexcept
 {
 #ifndef NDEBUG
-  for (size_t i = 0; i < P; ++i)
-    validate_ascii_char(s[i]);
+  if constexpr (P != 0)
+    for (size_t i = 0; i < P; ++i)
+      validate_ascii_char(s[i]);
 #endif
 }
 


### PR DESCRIPTION
From GCC11:
```
_deps/mp-units-src/src/include/units/bits/external/fixed_string.h: In instantiation of ‘constexpr units::basic_fixed_string<CharT, N>::basic_fixed_string(const CharT (&)[(N + 1)]) [with CharT = char; long unsigned int N = 0]’:
_deps/mp-units-src/src/include/units/bits/external/text_tools.h:32:58:   required from here
<src>/build/_deps/mp-units-src/src/include/units/bits/external/fixed_string.h:47: warning: comparison of unsigned expression in ‘< 0’ is always false [-Wtype-limits]
   47 |     for (std::size_t i = 0; i < N; ++i) data_[i] = txt[i];
      |                             ~~^~~
```
Caused by:
```C++
template<std::intmax_t Value>
  requires (0 <= Value) && (Value < 10)
inline constexpr basic_fixed_string superscript_number = "";
```