### PR TITLE
refactor: remove Expects macro

### DIFF
--- a/src/include/units/bits/external/hacks.h
+++ b/src/include/units/bits/external/hacks.h
@@ -31,13 +31,6 @@
 #define COMP_GCC_MINOR __GNUC_MINOR__
 #endif
 
-#ifdef NDEBUG
-#define Expects(cond) (void)(cond);
-#else
-#include <cassert>
-#define Expects(cond) assert(cond);
-#endif
-
 #if COMP_GCC >= 10
 
 #include <concepts>


### PR DESCRIPTION
It was removed from the wrong header: https://github.com/mpusz/units/commit/51b6d2f974ef2ab081d229a1f8e5484247195963#diff-caa17227b73152074e21c79360e64abf.