### PR TITLE
feat: enable GCC modules compilation of header units

### DIFF
--- a/src/include/units/bits/pow.h
+++ b/src/include/units/bits/pow.h
@@ -25,7 +25,7 @@
 #include <cstdint>
 #include <cassert>
 
-namespace units {
+namespace units::detail {
 
 constexpr std::intmax_t ipow10(std::intmax_t exp)
 {
@@ -58,4 +58,4 @@ constexpr Rep fpow10(std::intmax_t exp)
   return result;
 }
 
-}  // namespace units
+}  // namespace units::detail

--- a/src/include/units/pow.h
+++ b/src/include/units/pow.h
@@ -1,0 +1,61 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <cstdint>
+#include <cassert>
+
+namespace units {
+
+constexpr std::intmax_t ipow10(std::intmax_t exp)
+{
+  assert(exp >= 0);
+  if (exp == 0) return 1;
+  std::intmax_t result = 1;
+  while (exp > 0) {
+    result *= 10;
+    --exp;
+  }
+  return result;
+}
+
+template<typename Rep>
+constexpr Rep fpow10(std::intmax_t exp)
+{
+  if (exp == 0) return Rep(1.0);
+  Rep result = Rep(1.0);
+  if (exp < 0) {
+    while (exp < 0) {
+      result = result / Rep(10.0);
+      ++exp;
+    }
+  } else {
+    while (exp > 0) {
+      result = result * Rep(10.0);
+      --exp;
+    }
+  }
+  return result;
+}
+
+}  // namespace units

--- a/src/include/units/prefix.h
+++ b/src/include/units/prefix.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <units/bits/external/downcasting.h>
+#include <units/concepts.h>
 #include <units/ratio.h>
 #include <units/symbol_text.h>
 

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -25,8 +25,8 @@
 
 #include <units/bits/common_quantity.h>
 #include <units/bits/dimension_op.h>
+#include <units/bits/pow.h>
 #include <units/bits/to_string.h>
-#include <units/pow.h>
 #include <units/quantity_cast.h>
 
 #if COMP_MSVC || COMP_GCC >= 10
@@ -343,9 +343,9 @@ template<typename D1, typename U1, typename Rep1, typename D2, typename U2, type
   using common_rep = decltype(lhs.count() * rhs.count());
   const ratio r = U1::ratio * U2::ratio;
     if constexpr (treat_as_floating_point<common_rep>) {
-      return lhs.count() * rhs.count() * static_cast<common_rep>(r.num * fpow10<common_rep>(r.exp)) / static_cast<common_rep>(r.den);
+      return lhs.count() * rhs.count() * static_cast<common_rep>(r.num * detail::fpow10<common_rep>(r.exp)) / static_cast<common_rep>(r.den);
     } else {
-      return lhs.count() * rhs.count() * static_cast<common_rep>(r.num * ipow10(r.exp)) / static_cast<common_rep>(r.den);
+      return lhs.count() * rhs.count() * static_cast<common_rep>(r.num * detail::ipow10(r.exp)) / static_cast<common_rep>(r.den);
     }
 }
 

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -26,6 +26,7 @@
 #include <units/bits/common_quantity.h>
 #include <units/bits/dimension_op.h>
 #include <units/bits/to_string.h>
+#include <units/pow.h>
 #include <units/quantity_cast.h>
 
 #if COMP_MSVC || COMP_GCC >= 10

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -26,6 +26,7 @@
 #include <units/customization_points.h>
 #include <units/bits/dimension_op.h>
 #include <units/bits/external/type_traits.h>
+#include <units/pow.h>
 #include <units/quantity.h>
 #include <units/quantity_point.h>
 #include <cassert>
@@ -36,38 +37,6 @@
 #endif //_MSC_VER
 
 namespace units {
-
-constexpr std::intmax_t ipow10(std::intmax_t exp)
-{
-  assert(exp >= 0);
-  if (exp == 0) return 1;
-  std::intmax_t result = 1;
-  while (exp > 0) {
-    result *= 10;
-    --exp;
-  }
-  return result;
-}
-
-template<typename Rep>
-constexpr Rep fpow10(std::intmax_t exp)
-{
-  if (exp == 0) return Rep(1.0);
-  Rep result = Rep(1.0);
-  if (exp < 0) {
-    while (exp < 0) {
-      result = result / Rep(10.0);
-      ++exp;
-    }
-  } else {
-    while (exp > 0) {
-      result = result * Rep(10.0);
-      --exp;
-    }
-  }
-  return result;
-}
-
 
 // QuantityOf
 template<typename T, typename Dim>

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -26,7 +26,7 @@
 #include <units/customization_points.h>
 #include <units/bits/dimension_op.h>
 #include <units/bits/external/type_traits.h>
-#include <units/pow.h>
+#include <units/bits/pow.h>
 #include <units/quantity.h>
 #include <units/quantity_point.h>
 #include <cassert>
@@ -63,13 +63,13 @@ struct quantity_cast_impl<To, CRatio, CRep, true, true, false> {
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
-      return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(fpow10<CRep>(CRatio.exp))));
+      return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(detail::fpow10<CRep>(CRatio.exp))));
     } else {
       if constexpr (CRatio.exp > 0) {
-        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(ipow10(CRatio.exp))));
+        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(detail::ipow10(CRatio.exp))));
       }
       else {
-        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) / static_cast<CRep>(ipow10(-CRatio.exp))));
+        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) / static_cast<CRep>(detail::ipow10(-CRatio.exp))));
       }
     }
   }
@@ -93,21 +93,21 @@ struct quantity_cast_impl<To, CRatio, CRep, false, false, false> {
   {
     if constexpr (treat_as_floating_point<CRep>) {
       return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) *
-                                     static_cast<CRep>(fpow10<CRep>(CRatio.exp)) *
+                                     static_cast<CRep>(detail::fpow10<CRep>(CRatio.exp)) *
                                      (static_cast<CRep>(CRatio.num) /
                                       static_cast<CRep>(CRatio.den))));
     } else {
       if constexpr (CRatio.exp > 0) {
         return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) *
                                       static_cast<CRep>(CRatio.num) *
-                                      static_cast<CRep>(ipow10(CRatio.exp)) /
+                                      static_cast<CRep>(detail::ipow10(CRatio.exp)) /
                                       static_cast<CRep>(CRatio.den)));
       }
       else {
         return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) *
                                       static_cast<CRep>(CRatio.num) /
                                       (static_cast<CRep>(CRatio.den) *
-                                       static_cast<CRep>(ipow10(-CRatio.exp)))));
+                                       static_cast<CRep>(detail::ipow10(-CRatio.exp)))));
       }
     }
   }
@@ -128,13 +128,13 @@ struct quantity_cast_impl<To, CRatio, CRep, true, false, false> {
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
-      return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(fpow10<CRep>(CRatio.exp)) * (CRep{1} / static_cast<CRep>(CRatio.den))));
+      return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(detail::fpow10<CRep>(CRatio.exp)) * (CRep{1} / static_cast<CRep>(CRatio.den))));
     } else {
       if constexpr (CRatio.exp > 0) {
-        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(ipow10(CRatio.exp)) / static_cast<CRep>(CRatio.den)));
+        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(detail::ipow10(CRatio.exp)) / static_cast<CRep>(CRatio.den)));
       }
       else {
-        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) / (static_cast<CRep>(ipow10(-CRatio.exp)) * static_cast<CRep>(CRatio.den))));
+        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) / (static_cast<CRep>(detail::ipow10(-CRatio.exp)) * static_cast<CRep>(CRatio.den))));
       }
     }
   }
@@ -155,13 +155,13 @@ struct quantity_cast_impl<To, CRatio, CRep, false, true, false> {
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
-      return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(CRatio.num) * static_cast<CRep>(fpow10<CRep>(CRatio.exp))));
+      return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(CRatio.num) * static_cast<CRep>(detail::fpow10<CRep>(CRatio.exp))));
     } else {
       if constexpr (CRatio.exp > 0) {
-        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(CRatio.num) * static_cast<CRep>(ipow10(CRatio.exp))));
+        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(CRatio.num) * static_cast<CRep>(detail::ipow10(CRatio.exp))));
       }
       else {
-        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(CRatio.num) / static_cast<CRep>(ipow10(-CRatio.exp))));
+        return To(static_cast<TYPENAME To::rep>(static_cast<CRep>(q.count()) * static_cast<CRep>(CRatio.num) / static_cast<CRep>(detail::ipow10(-CRatio.exp))));
       }
     }
   }
@@ -173,13 +173,13 @@ struct quantity_cast_impl<To, CRatio, CRep, true, true, false> {
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
-      return To(static_cast<TYPENAME To::rep>(q.count() * fpow10<CRep>(CRatio.exp)));
+      return To(static_cast<TYPENAME To::rep>(q.count() * detail::fpow10<CRep>(CRatio.exp)));
     } else {
       if constexpr (CRatio.exp > 0) {
-        return To(static_cast<TYPENAME To::rep>(q.count() * ipow10(CRatio.exp)));
+        return To(static_cast<TYPENAME To::rep>(q.count() * detail::ipow10(CRatio.exp)));
       }
       else {
-        return To(static_cast<TYPENAME To::rep>(q.count() / ipow10(-CRatio.exp)));
+        return To(static_cast<TYPENAME To::rep>(q.count() / detail::ipow10(-CRatio.exp)));
       }
     }
   }
@@ -200,13 +200,13 @@ struct quantity_cast_impl<To, CRatio, CRep, false, false, false> {
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
-      return To(static_cast<TYPENAME To::rep>(q.count() * fpow10<CRep>(CRatio.exp) * (CRatio.num / CRatio.den)));
+      return To(static_cast<TYPENAME To::rep>(q.count() * detail::fpow10<CRep>(CRatio.exp) * (CRatio.num / CRatio.den)));
     } else {
       if constexpr (CRatio.exp > 0) {
-        return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num * ipow10(CRatio.exp) / CRatio.den));
+        return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num * detail::ipow10(CRatio.exp) / CRatio.den));
       }
       else {
-        return To(static_cast<TYPENAME To::rep>(q.count()) * CRatio.num / (CRatio.den * ipow10(-CRatio.exp)));
+        return To(static_cast<TYPENAME To::rep>(q.count()) * CRatio.num / (CRatio.den * detail::ipow10(-CRatio.exp)));
       }
     }
   }
@@ -227,13 +227,13 @@ struct quantity_cast_impl<To, CRatio, CRep, true, false, false> {
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
-      return To(static_cast<TYPENAME To::rep>(q.count() * fpow10<CRep>(CRatio.exp) / CRatio.den));
+      return To(static_cast<TYPENAME To::rep>(q.count() * detail::fpow10<CRep>(CRatio.exp) / CRatio.den));
     } else {
       if constexpr (CRatio.exp > 0) {
-        return To(static_cast<TYPENAME To::rep>(q.count() * ipow10(CRatio.exp) / CRatio.den));
+        return To(static_cast<TYPENAME To::rep>(q.count() * detail::ipow10(CRatio.exp) / CRatio.den));
       }
       else {
-        return To(static_cast<TYPENAME To::rep>(q.count() / (ipow10(-CRatio.exp) * CRatio.den)));
+        return To(static_cast<TYPENAME To::rep>(q.count() / (detail::ipow10(-CRatio.exp) * CRatio.den)));
       }
     }
   }
@@ -254,13 +254,13 @@ struct quantity_cast_impl<To, CRatio, CRep, false, true, false> {
   static constexpr To cast(const Q& q)
   {
     if constexpr (treat_as_floating_point<CRep>) {
-      return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num * fpow10<CRep>(CRatio.exp)));
+      return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num * detail::fpow10<CRep>(CRatio.exp)));
     } else {
       if constexpr (CRatio.exp > 0) {
-        return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num * ipow10(CRatio.exp)));
+        return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num * detail::ipow10(CRatio.exp)));
       }
       else {
-        return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num / ipow10(-CRatio.exp)));
+        return To(static_cast<TYPENAME To::rep>(q.count() * CRatio.num / detail::ipow10(-CRatio.exp)));
       }
     }
   }

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -26,6 +26,8 @@
 #include <units/customization_points.h>
 #include <units/bits/dimension_op.h>
 #include <units/bits/external/type_traits.h>
+#include <units/quantity.h>
+#include <units/quantity_point.h>
 #include <cassert>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
All that's left is `format.h`, which results in an ICE. I'll report that to the developers. `quantity_cast.h` and `quantity.h` have a mutual dependency, which is ["exciting"](https://gcc.gnu.org/git/?p=gcc.git;a=commit;h=6bdbf0f37bda2587a4e82cbb956de7a159a397ae).