### PR TITLE
refactor: simplify dimension_unit

### DIFF
--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -173,9 +173,9 @@ template<Dimension D>
 auto default_unit()
 {
   if constexpr (BaseDimension<D>)
-    return TYPENAME D::base_unit{};
+    return typename D::base_unit{};
   else
-    return TYPENAME D::coherent_unit{};
+    return typename D::coherent_unit{};
 }
 
 } // namespace detail

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -206,7 +206,7 @@ concept UnitOf =
   Dimension<D> &&
   std::same_as<typename U::reference, typename dimension_unit<D>::reference>;
 
-// Quantity
+// Quantity, QuantityPoint
 namespace detail {
 
 template<typename T>

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -172,10 +172,10 @@ namespace detail {
 template<Dimension D>
 auto default_unit()
 {
-    if constexpr (BaseDimension<D>)
-        return TYPENAME D::base_unit{};
-    else
-        return TYPENAME D::coherent_unit{};
+  if constexpr (BaseDimension<D>)
+    return TYPENAME D::base_unit{};
+  else
+    return TYPENAME D::coherent_unit{};
 }
 
 } // namespace detail

--- a/src/include/units/concepts.h
+++ b/src/include/units/concepts.h
@@ -170,17 +170,13 @@ concept Dimension = BaseDimension<T> || DerivedDimension<T>;
 namespace detail {
 
 template<Dimension D>
-struct dimension_unit_impl;
-
-template<BaseDimension D>
-struct dimension_unit_impl<D> {
-  using type = TYPENAME D::base_unit;
-};
-
-template<DerivedDimension D>
-struct dimension_unit_impl<D> {
-  using type = TYPENAME D::coherent_unit;
-};
+auto default_unit()
+{
+    if constexpr (BaseDimension<D>)
+        return TYPENAME D::base_unit{};
+    else
+        return TYPENAME D::coherent_unit{};
+}
 
 } // namespace detail
 
@@ -193,7 +189,7 @@ struct dimension_unit_impl<D> {
  * @tparam D Dimension type to get the unit from.
  */
 template<Dimension D>
-using dimension_unit = TYPENAME detail::dimension_unit_impl<D>::type;
+using dimension_unit = decltype(detail::default_unit<D>());
 
 /**
  * @brief A concept matching only units of a specified dimension.


### PR DESCRIPTION
With VS 2019 16.8, it could have been
```C++
template<Dimension D>
using dimension_unit = decltype([]{
    if constexpr (BaseDimension<D>)
        return TYPENAME D::base_unit{};
    else
        return TYPENAME D::coherent_unit{};
}());
```