### PR TITLE
feat: Downcasting with UNITS_DOWNCAST OFF

### DIFF
--- a/src/include/units/physical/dimensions.h
+++ b/src/include/units/physical/dimensions.h
@@ -24,16 +24,25 @@
 
 #include <units/base_dimension.h>
 #include <units/bits/external/type_traits.h>
+#include <units/derived_dimension.h>
 #include <units/quantity.h>
 #include <units/unit.h>
 
 namespace units::physical {
 
+namespace detail {
+
+template<template<typename...> typename DimTemplate, typename Child, Unit U, Exponent... Es>
+  requires requires { typename DimTemplate<Child, U, typename Es::dimension...>; }
+void to_base_derived_dimension_of(const volatile derived_dimension<Child, U, Es...>*);
+
+} // namespace detail
+
 template<typename Dim, template<typename...> typename DimTemplate>
-concept DimensionOf = Dimension<Dim> && is_derived_from_specialization_of<Dim, DimTemplate>;
+concept DimensionOf = Dimension<Dim> && (is_derived_from_specialization_of<Dim, DimTemplate> || requires(const volatile Dim* x) { detail::to_base_derived_dimension_of<DimTemplate>(x); });
 
 template<typename Q, template<typename...> typename DimTemplate>
-concept QuantityOf = Quantity<Q> && is_derived_from_specialization_of<typename Q::dimension, DimTemplate>;
+concept QuantityOf = Quantity<Q> && DimensionOf<typename Q::dimension, DimTemplate>;
 
 // ------------------------ base dimensions -----------------------------
 


### PR DESCRIPTION
Continuation of johelegp@22e6107.

What do you think we should do in this case?
```
hello_units.cpp: In function ‘int main()’:
hello_units.cpp:40:57: error: no matching function for call to ‘quantity_cast<units::physical::si::metre_per_second>(units::quantity<units::unknown_dimension<units::exp<units::physical::si::dim_length, 1, 1>, units::exp<units::physical::si::dim_time, -1, 1> >, units::scaled_unit<units::ratio{1397, 3125, 0}, units::unknown_coherent_unit>, double>&)’
   40 |   Speed AUTO v3 = quantity_cast<si::metre_per_second>(v2);
```
I'm still wrapping my head about things, so I can't make an immediate call. What should the behavior be here? What should the type of `v3` be?