### PR TITLE
Feat: minimal support for localization

### DIFF
--- a/docs/framework/text_output.rst
+++ b/docs/framework/text_output.rst
@@ -72,7 +72,7 @@ Grammar
 
 In the above grammar:
 
-- ``fill-and-align``, ``width``, ``sign``, ``#``, and ``precision`` tokens and
+- ``fill-and-align``, ``width``, ``sign``, ``#``, ``precision`` and ``L`` tokens and
   individual tokens of :token:`units-rep-type` are defined in the
   `format.string.std <https://wg21.link/format.string.std>`_ chapter of the C++
   standard specification,

--- a/docs/framework/text_output.rst
+++ b/docs/framework/text_output.rst
@@ -66,7 +66,7 @@ Grammar
     units-type: [units-rep-modifier] 'Q'
               : [units-unit-modifier] 'q'
               : one of "nt%"
-    units-rep-modifier: [sign] [#] [precision] [units-rep-type]
+    units-rep-modifier: [sign] [#] [precision] [L] [units-rep-type]
     units-rep-type: one of "aAbBdeEfFgGoxX"
     units-unit-modifier: 'A'
 

--- a/src/include/units/format.h
+++ b/src/include/units/format.h
@@ -147,8 +147,8 @@ namespace units {
 
       // parse L to enable the locale-specific form
       if (*begin == 'L') {
-          handler.on_locale();
-          ++begin;
+        handler.on_locale();
+        ++begin;
       }
 
       if(begin != end && *begin != '}' && *begin != '%') {

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -1118,7 +1118,7 @@ TEST_CASE("type specification", "[text][fmt]")
   }
 }
 
-TEST_CASE("different base types with the # specifier")
+TEST_CASE("different base types with the # specifier", "[text][fmt]")
 {
   SECTION("full format {:%Q %q} on a quantity")
   {
@@ -1136,6 +1136,30 @@ TEST_CASE("different base types with the # specifier")
     CHECK(fmt::format("{:%#oQ}", 42_q_m) == "052");
     CHECK(fmt::format("{:%#xQ}", 42_q_m) == "0x2a");
     CHECK(fmt::format("{:%#XQ}", 42_q_m) == "0X2A");
+  }
+}
+
+TEST_CASE("localization with the 'L' specifier", "[text][fmt][localization]")
+{
+  struct group2 : std::numpunct<char>
+  {
+      char        do_thousands_sep() const override { return  '_'; }
+      std::string do_grouping()      const override { return "\2"; }
+  };
+
+  struct group3 : std::numpunct<char>
+  {
+      char        do_thousands_sep() const override { return '\''; }
+      std::string do_grouping()      const override { return "\3"; }
+  };
+
+  std::locale grp2{std::locale::classic(), new group2};
+  std::locale grp3{std::locale::classic(), new group3};
+
+  SECTION("full format {:%LQ %q} on a quantity")
+  {
+    CHECK(fmt::format(grp2, "{:%LQ %q}", 299792458_q_m_per_s) == "2_99_79_24_58 m/s");
+    CHECK(fmt::format(grp3, "{:%LQ %q}", 299792458_q_m_per_s) == "299'792'458 m/s");
   }
 }
 

--- a/test/unit_test/runtime/fmt_test.cpp
+++ b/test/unit_test/runtime/fmt_test.cpp
@@ -1143,14 +1143,14 @@ TEST_CASE("localization with the 'L' specifier", "[text][fmt][localization]")
 {
   struct group2 : std::numpunct<char>
   {
-      char        do_thousands_sep() const override { return  '_'; }
-      std::string do_grouping()      const override { return "\2"; }
+    char        do_thousands_sep() const override { return  '_'; }
+    std::string do_grouping()      const override { return "\2"; }
   };
 
   struct group3 : std::numpunct<char>
   {
-      char        do_thousands_sep() const override { return '\''; }
-      std::string do_grouping()      const override { return "\3"; }
+    char        do_thousands_sep() const override { return '\''; }
+    std::string do_grouping()      const override { return "\3"; }
   };
 
   std::locale grp2{std::locale::classic(), new group2};


### PR DESCRIPTION
These changes allows to enable localization via the `'L'` _units-rep-modifier_ in format strings like `"{:%LQ %q}"`, as requested in #34.1.
Do you think something is missing?