### PR TITLE
fix: Output formatted in days has right scaling but wrong unit symbol (`h` instead of `d`)

### DIFF
--- a/src/include/units/physical/si/time.h
+++ b/src/include/units/physical/si/time.h
@@ -39,7 +39,7 @@ struct microsecond : prefixed_unit<microsecond, micro, second> {};
 struct millisecond : prefixed_unit<millisecond, milli, second> {};
 struct minute : named_scaled_unit<minute, "min", no_prefix, ratio(60), second> {};
 struct hour : named_scaled_unit<hour, "h", no_prefix, ratio(60), minute> {};
-struct day : named_scaled_unit<hour, "d", no_prefix, ratio(24), hour> {};
+struct day : named_scaled_unit<day, "d", no_prefix, ratio(24), hour> {};
 
 struct dim_time : physical::dim_time<second> {};
 


### PR DESCRIPTION
I was playing around with custom temporal "rate" units, and noticed that the following code:

```cpp
Time auto all_day_long = 1_q_d;
fmt::print("hours = {}\n", quantity_cast<si::hour>(all_day_long));
fmt::print("days  = {}\n", quantity_cast<si::day>(all_day_long));
```
produced the following output:
```
hours = 24 h
days  = 1 h
```

This led me to discover a typo in the definition of the `day` unit.

Thanks for the great work on the library!