### PR TITLE
feat: conversion between `duration` and `quantity`

### DIFF
--- a/src/include/units/physical/si/base/time.h
+++ b/src/include/units/physical/si/base/time.h
@@ -143,7 +143,7 @@ constexpr auto to_chrono_duration(units::physical::si::time<U, Rep> const & n)
  *  @tparam Duration a target std::chrono::duration type to cast to
  */
 template <typename Duration, units::Unit U, units::ScalableNumber Rep>
-  requires requires{{ std::chrono::duration_cast<Duration>(std::chrono::seconds{}) };}
+  requires requires{ std::chrono::duration_cast<Duration>(std::chrono::seconds{}); }
 constexpr auto to_chrono_duration(units::physical::si::time<U, Rep> const & n)
 {
   return std::chrono::duration_cast<Duration>(to_chrono_duration(n));

--- a/test/unit_test/static/CMakeLists.txt
+++ b/test/unit_test/static/CMakeLists.txt
@@ -24,6 +24,7 @@ cmake_minimum_required(VERSION 3.12)
 
 add_library(unit_tests_static
     cgs_test.cpp
+    chrono_compat_test.cpp
     custom_rep_min_req_test.cpp
     custom_unit_test.cpp
     data_test.cpp

--- a/test/unit_test/static/chrono_compat_test.cpp
+++ b/test/unit_test/static/chrono_compat_test.cpp
@@ -1,0 +1,57 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <units/physical/si/base/time.h>
+#include <utility>
+
+namespace {
+
+template <typename A, typename B>
+consteval bool same(A && a, B && b)
+{
+    return units::equivalent<A, B> and a.count() == b.count();
+}
+
+using units::physical::si::time;
+using namespace units::physical::si;
+using namespace units::physical::si::literals;
+
+constexpr static auto t1 = 123456789_q_us;
+static_assert(to_chrono_duration(t1) == std::chrono::microseconds{123456789});
+static_assert(to_chrono_duration<std::chrono::seconds>(t1)      == std::chrono::seconds{123});
+static_assert(to_chrono_duration<std::chrono::milliseconds>(t1) == std::chrono::milliseconds{123456});
+static_assert(to_chrono_duration<std::chrono::nanoseconds>(t1)  == std::chrono::nanoseconds{123456789000});
+
+constexpr static auto t2 = 123456789._q_us;
+static_assert(to_chrono_duration(t1) == std::chrono::duration<long double, std::micro>{123456789});
+static_assert(to_chrono_duration<std::chrono::seconds>(t1)      == std::chrono::seconds{123});
+static_assert(to_chrono_duration<std::chrono::milliseconds>(t1) == std::chrono::milliseconds{123456});
+static_assert(to_chrono_duration<std::chrono::nanoseconds>(t1)  == std::chrono::nanoseconds{123456789000});
+
+constexpr static auto t3 = std::chrono::milliseconds{123456789};
+static_assert(same(from_chrono_duration(t3), time<millisecond, decltype(t3)::rep>{123456789}));
+static_assert(same(from_chrono_duration<time<second, int>>(t3), time<second, int>{123456}));
+static_assert(same(from_chrono_duration<time<second>>(t3), time<second>{123456.789}));
+
+}
+
+


### PR DESCRIPTION
This is an attempt to make it possible to convert a `physical::si::time` into a `std::chrono::duration` and vice versa, as proposed in #33.
It adds a lot of stuff to the `time.h` header, and also implicitly `#include`s `<chrono>` whenever you want to use a time unit, so maybe I should move all of this into a separate header, or guard it using a macro?
Furthermore these are free functions, but since `time` and `duration` both represent a time, perhaps it would make sense to implement an implicit cast between the two.