### PR TITLE
Ratio multiplication for large ratios

### DIFF
--- a/src/include/units/ratio.h
+++ b/src/include/units/ratio.h
@@ -131,14 +131,14 @@ constexpr ratio_pair reduceNumeratorForMul(const ratio_pair& rp)
   bool got_reduced = false;
   while ((bsr) >= (sizeof(long long) * 8 - 2)) {
     got_reduced = false;
-    if (a.den < ((long long)1 << (sizeof(long long) * 8 / 2)) && (a.den % 10 != 0)) {
+    if (a.den < ((long long)1 << (sizeof(long long) * 8 / 2 - 6)) && (a.den % 10 != 0)) {
       // force a denominator, maybe it helps with gdc
       // reduce without information loss
       a.den *= 10;
       a.exp += 1;
       got_reduced = true;
     }
-    if (b.den < ((long long)1 << (sizeof(long long) * 8 / 2)) && (b.den % 10 != 0)) {
+    if (b.den < ((long long)1 << (sizeof(long long) * 8 / 2 - 6)) && (b.den % 10 != 0)) {
       b.den *= 10;
       a.exp += 1;
       got_reduced = true;

--- a/src/include/units/ratio.h
+++ b/src/include/units/ratio.h
@@ -116,22 +116,47 @@ long constexpr bitScanReverse(long long a)
 // works on positive and negative rations
 constexpr ratio mul(const ratio& ra, const ratio& rb)
 {
-  bool result_is_even = !(is_positive(ra) ^ is_positive(rb));
+  bool result_is_positive = !(is_positive(ra) ^ is_positive(rb));
   ratio a(abs(ra));
   ratio b(abs(rb));
   long long exp = a.exp + b.exp;
   long bsr = bitScanReverse(a.num) + bitScanReverse(b.num);
   while ((bsr) >= (sizeof(long long) * 8 - 1)) {
-    if (a.num > b.num)
+    if (a.den < ((long long)1 << (sizeof(long long) / 2))) {
+      a.den *= 10000;
+      exp += 4;
+      long long gcd = std::gcd(a.num, a.den);
+      a.num = a.num / gcd;
+      a.den = a.den / gcd;
+    } else if (b.den < ((long long)1 << (sizeof(long long) / 2))) {
+      b.den *= 10000;
+      exp += 4;
+      long long gcd = std::gcd(b.num, b.den);
+      b.num = b.num / gcd;
+      b.den = b.den / gcd;
+    } else if (a.num > b.num) {
       a.num = a.num / 10;
-    else
+    } else {
       b.num = b.num / 10;
-    bsr -= 3;
+    }
+    bsr = bitScanReverse(a.num) + bitScanReverse(b.num);
     exp += 1;
   }
   bsr = bitScanReverse(a.den) + bitScanReverse(b.den);
   while (bsr >= (sizeof(long long) * 8 - 1)) {
-    if (a.den > b.den)
+    if (a.num < ((long long)1 << (sizeof(long long) / 2))) {
+      a.num *= 10000;
+      exp -= 4;
+      long long gcd = std::gcd(a.num, a.den);
+      a.num = a.num / gcd;
+      a.den = a.den / gcd;
+    } else if (b.num < ((long long)1 << (sizeof(long long) / 2))) {
+      b.num *= 10000;
+      exp -= 4;
+      long long gcd = std::gcd(b.num, b.den);
+      b.num = b.num / gcd;
+      b.den = b.den / gcd;
+    } else if (a.den > b.den)
       a.den = a.den / 10;
     else
       b.den = b.den / 10;

--- a/src/include/units/ratio.h
+++ b/src/include/units/ratio.h
@@ -36,8 +36,6 @@ namespace units {
 struct ratio;
 constexpr ratio inverse(const ratio& r);
 
-namespace detail { constexpr ratio mul(ratio a, ratio b); }
-
 /**
  * @brief Provides compile-time rational arithmetic support.
  * 

--- a/src/include/units/ratio.h
+++ b/src/include/units/ratio.h
@@ -92,8 +92,8 @@ template<std::intmax_t N>
     return pow<N-1>(r) * r;
 }
 
-constexpr bool is_even(const ratio& r) { 
-  return (r.num >= 0) ^ (r.den >= 0); 
+constexpr bool is_positive(const ratio& r) { 
+  return !((r.num >= 0) ^ (r.den >= 0)); 
 }
 
 constexpr ratio abs(const ratio& r) { 
@@ -116,7 +116,7 @@ long constexpr bitScanReverse(long long a)
 // works on positive and negative rations
 constexpr ratio mul(const ratio& ra, const ratio& rb)
 {
-  bool result_is_even = is_even(ra) ^ is_even(rb);
+  bool result_is_even = !(is_positive(ra) ^ is_positive(rb));
   ratio a(abs(ra));
   ratio b(abs(rb));
   long long exp = a.exp + b.exp;
@@ -138,7 +138,7 @@ constexpr ratio mul(const ratio& ra, const ratio& rb)
     bsr -= 3;
     exp -= 1;
   }
-  return ratio{result_is_even ? (a.num * b.num) : (-a.num * b.num), a.den * b.den, exp};
+  return ratio{result_is_positive ? (a.num * b.num) : (-a.num * b.num), a.den * b.den, exp};
 }
 
 // sqrt_impl avoids overflow and recursion


### PR DESCRIPTION
Adding ratio multiplication for ratios with large values.
fixes the following problem:
`constexpr auto cubic_au = 1_q_au * 1_q_au * 1_q_au;`
The relative error of the result is within 8.5E-8%