### PR TITLE
Revert "refactor: <gsl/gsl_assert> to <gsl/assert>"

### DIFF
--- a/src/include/units/bits/ratio_maths.h
+++ b/src/include/units/bits/ratio_maths.h
@@ -31,7 +31,7 @@
 #include <numeric>
 #include <tuple>
 #include <type_traits>
-#include <gsl/assert>
+#include <gsl/gsl_assert>
 
 namespace units::detail {
 

--- a/src/include/units/ratio.h
+++ b/src/include/units/ratio.h
@@ -29,7 +29,7 @@
 #include <type_traits>
 #include <tuple>
 #include <algorithm>
-#include <gsl/assert>
+#include <gsl/gsl_assert>
 
 namespace units {
 

--- a/src/include/units/symbol_text.h
+++ b/src/include/units/symbol_text.h
@@ -24,7 +24,7 @@
 
 #include <units/bits/external/fixed_string.h>
 #include <units/bits/external/hacks.h>
-#include <gsl/assert>
+#include <gsl/gsl_assert>
 #include <compare>
 
 namespace units {


### PR DESCRIPTION
Reverts mpusz/units#181

The next version of GSL will have the headers with redundant `gsl_` in their names deprecated.

IIRC, you don't mind not using the `revert:` conventional commit.