### PR TITLE
Add SI prefix to bit unit

### DIFF
--- a/src/include/units/data/base/information.h
+++ b/src/include/units/data/base/information.h
@@ -24,6 +24,7 @@
 
 #include <units/one_rep.h>
 #include <units/base_dimension.h>
+#include <units/physical/si/prefixes.h>
 #include <units/data/prefixes.h>
 #include <units/unit.h>
 #include <units/quantity.h>
@@ -36,6 +37,13 @@ struct mebibit : prefixed_unit<mebibit, mebi, bit> {};
 struct gibibit : prefixed_unit<gibibit, gibi, bit> {};
 struct tebibit : prefixed_unit<tebibit, tebi, bit> {};
 struct pebibit : prefixed_unit<pebibit, pebi, bit> {};
+
+struct si_bit : alias_unit<bit, "b", units::physical::si::prefix> {};
+struct kilobit : prefixed_unit<kilobit, units::physical::si::kilo, si_bit> {};
+struct megabit : prefixed_unit<megabit, units::physical::si::mega, si_bit> {};
+struct gigabit : prefixed_unit<gigabit, units::physical::si::giga, si_bit> {};
+struct terabit : prefixed_unit<terabit, units::physical::si::tera, si_bit> {};
+struct petabit : prefixed_unit<petabit, units::physical::si::peta, si_bit> {};
 
 struct byte : named_scaled_unit<byte, "B", prefix, ratio(8), bit> {};
 struct kibibyte : prefixed_unit<kibibyte, kibi, byte> {};
@@ -62,6 +70,13 @@ constexpr auto operator"" _q_Gib(unsigned long long l) { return information<gibi
 constexpr auto operator"" _q_Tib(unsigned long long l) { return information<tebibit, std::int64_t>(l); }
 constexpr auto operator"" _q_Pib(unsigned long long l) { return information<pebibit, std::int64_t>(l); }
 
+// bits (SI)
+constexpr auto operator"" _q_kb(unsigned long long l) { return information<kilobit, std::int64_t>(l); }
+constexpr auto operator"" _q_Mb(unsigned long long l) { return information<megabit, std::int64_t>(l); }
+constexpr auto operator"" _q_Gb(unsigned long long l) { return information<gigabit, std::int64_t>(l); }
+constexpr auto operator"" _q_Tb(unsigned long long l) { return information<terabit, std::int64_t>(l); }
+constexpr auto operator"" _q_Pb(unsigned long long l) { return information<petabit, std::int64_t>(l); }
+
 // bytes
 constexpr auto operator"" _q_B(unsigned long long l) { return information<byte, std::int64_t>(l); }
 constexpr auto operator"" _q_KiB(unsigned long long l) { return information<kibibyte, std::int64_t>(l); }
@@ -80,6 +95,12 @@ inline constexpr auto Mib = information<mebibit, one_rep>{};
 inline constexpr auto Gib = information<gibibit, one_rep>{};
 inline constexpr auto Tib = information<tebibit, one_rep>{};
 inline constexpr auto Pib = information<pebibit, one_rep>{};
+
+inline constexpr auto kb = information<kilobit, one_rep>{};
+inline constexpr auto Mb = information<megabit, one_rep>{};
+inline constexpr auto Gb = information<gigabit, one_rep>{};
+inline constexpr auto Tb = information<terabit, one_rep>{};
+inline constexpr auto Pb = information<petabit, one_rep>{};
 
 inline constexpr auto B = information<byte, one_rep>{};
 inline constexpr auto KiB = information<kibibyte, one_rep>{};

--- a/src/include/units/data/derived/bitrate.h
+++ b/src/include/units/data/derived/bitrate.h
@@ -38,6 +38,12 @@ struct gibibit_per_second : deduced_unit<gibibit_per_second, dim_bitrate, gibibi
 struct tebibit_per_second : deduced_unit<tebibit_per_second, dim_bitrate, tebibit, physical::si::second> {};
 struct pebibit_per_second : deduced_unit<pebibit_per_second, dim_bitrate, pebibit, physical::si::second> {};
 
+struct kilobit_per_second : deduced_unit<kilobit_per_second, dim_bitrate, kilobit, physical::si::second> {};
+struct megabit_per_second : deduced_unit<megabit_per_second, dim_bitrate, megabit, physical::si::second> {};
+struct gigabit_per_second : deduced_unit<gigabit_per_second, dim_bitrate, gigabit, physical::si::second> {};
+struct terabit_per_second : deduced_unit<terabit_per_second, dim_bitrate, terabit, physical::si::second> {};
+struct petabit_per_second : deduced_unit<petabit_per_second, dim_bitrate, petabit, physical::si::second> {};
+
 template<typename T>
 concept Bitrate = QuantityOf<T, dim_bitrate>;
 
@@ -54,6 +60,12 @@ constexpr auto operator"" _q_Gib_per_s(unsigned long long l) { return bitrate<gi
 constexpr auto operator"" _q_Tib_per_s(unsigned long long l) { return bitrate<tebibit_per_second, std::int64_t>(l); }
 constexpr auto operator"" _q_Pib_per_s(unsigned long long l) { return bitrate<pebibit_per_second, std::int64_t>(l); }
 
+constexpr auto operator"" _q_kb_per_s(unsigned long long l) { return bitrate<kilobit_per_second, std::int64_t>(l); }
+constexpr auto operator"" _q_Mb_per_s(unsigned long long l) { return bitrate<megabit_per_second, std::int64_t>(l); }
+constexpr auto operator"" _q_Gb_per_s(unsigned long long l) { return bitrate<gigabit_per_second, std::int64_t>(l); }
+constexpr auto operator"" _q_Tb_per_s(unsigned long long l) { return bitrate<terabit_per_second, std::int64_t>(l); }
+constexpr auto operator"" _q_Pb_per_s(unsigned long long l) { return bitrate<petabit_per_second, std::int64_t>(l); }
+
 }  // namespace literals
 
 namespace unit_constants {
@@ -64,6 +76,12 @@ inline constexpr auto Mib_per_s = bitrate<mebibit_per_second, one_rep>{};
 inline constexpr auto Gib_per_s = bitrate<gibibit_per_second, one_rep>{};
 inline constexpr auto Tib_per_s = bitrate<tebibit_per_second, one_rep>{};
 inline constexpr auto Pib_per_s = bitrate<pebibit_per_second, one_rep>{};
+
+inline constexpr auto kb_per_s = bitrate<kilobit_per_second, one_rep>{};
+inline constexpr auto Mb_per_s = bitrate<megabit_per_second, one_rep>{};
+inline constexpr auto Gb_per_s = bitrate<gigabit_per_second, one_rep>{};
+inline constexpr auto Tb_per_s = bitrate<terabit_per_second, one_rep>{};
+inline constexpr auto Pb_per_s = bitrate<petabit_per_second, one_rep>{};
 
 }  // namespace unit_constants
 

--- a/test/unit_test/runtime/digital_info_test.cpp
+++ b/test/unit_test/runtime/digital_info_test.cpp
@@ -56,5 +56,9 @@ TEST_CASE("operator<< on a data quantity", "[text][ostream]")
       stream << 8_q_Kib * 8_q_Kib / 2_q_b;
       REQUIRE(stream.str() == "32 Mib");
     }
+    SECTION("prefixed coherent unit (SI)") {
+      stream << 32_q_kb;
+      REQUIRE(stream.str() == "32 kb");
+    }
   }
 }

--- a/test/unit_test/static/data_test.cpp
+++ b/test/unit_test/static/data_test.cpp
@@ -36,6 +36,9 @@ static_assert(1024_q_B == 1_q_KiB);
 static_assert(8 * 1024_q_b == 1_q_KiB);
 static_assert(8 * 1_q_Kib == 1_q_KiB);
 
+static_assert(1_q_kb == 1000_q_b);
+static_assert(2000_q_Mib == 2097152_q_kb);
+
 static_assert(1_q_Kib == 1024_q_b);
 static_assert(1_q_Mib == 1024_q_Kib);
 static_assert(1_q_Gib == 1024_q_Mib);


### PR DESCRIPTION
This PR add a si prefix based bit unit. This is often used in low level calculations of bit rates in conjunction with symbol rates or frequencies. (e.g. 1000Mb Ethernet, 10Gbit optical link)

Closes #186.