### PR TITLE
fix: restore user-warnings within the library implementation

### DIFF
--- a/cmake/warnings.cmake
+++ b/cmake/warnings.cmake
@@ -67,6 +67,7 @@ function(set_warnings target scope)
         /w14928 # illegal copy-initialization; more than one user-defined
                 # conversion has been implicitly applied
         /permissive- # standards conformance mode for MSVC compiler.
+        /wd4244 #
     )
 
     set(CLANG_WARNINGS
@@ -82,8 +83,8 @@ function(set_warnings target scope)
         -Wunused # warn on anything being unused
         -Woverloaded-virtual # warn if you overload (not override) a virtual function
         -Wcast-qual # warn on dropping const or volatile qualifiers
-        -Wconversion # warn on type conversions that may lose data
-        -Wsign-conversion # warn on sign conversions
+    #   -Wconversion # warn on type conversions that may lose data
+    #   -Wsign-conversion # warn on sign conversions
         -Wnull-dereference # warn if a null dereference is detected
         -Wdouble-promotion # warn if float is implicit promoted to double
         -Wformat=2 # warn on security issues around functions that format output (ie printf)

--- a/src/include/units/quantity.h
+++ b/src/include/units/quantity.h
@@ -134,7 +134,7 @@ public:
 
   template<safe_convertible_to_<rep> Value>
   explicit(!(is_same_v<dimension, dim_one> && is_same_v<unit, ::units::one>))
-  constexpr quantity(const Value& v) : value_(static_cast<rep>(v)) {}
+  constexpr quantity(const Value& v) : value_(v) {}
 
   template<safe_castable_to_<quantity> Q>
   constexpr quantity(const Q& q) : value_(quantity_cast<quantity>(q).count()) {}

--- a/test/unit_test/static/CMakeLists.txt
+++ b/test/unit_test/static/CMakeLists.txt
@@ -51,5 +51,3 @@ target_link_libraries(unit_tests_static
     PRIVATE
         mp::units
 )
-
-set_source_files_properties(quantity_test.cpp PROPERTIES COMPILE_OPTIONS $<IF:$<CXX_COMPILER_ID:MSVC>,/wd4244,-Wno-conversion>)


### PR DESCRIPTION
Potentially addresses #202.