### PR TITLE
fix: downcasting facility for non-default-constructible types

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@
   - fix: quantity's operators fixed to behave like the underlying types do
   - fix: `quantity_cast()` fixed to work correctly with representation types not convertible from `std::intmax_t`
   - fix: ambiguous case for empty type list resolved
+  - fix: downcasting facility for non-default-constructible types
   - (!) build: `BUILD_DOCS` CMake option renamed to `UNITS_BUILD_DOCS`
   - build: doxygen updated to 1.8.20
   - build: catch2 updated to 2.13.4

--- a/src/include/units/bits/external/downcasting.h
+++ b/src/include/units/bits/external/downcasting.h
@@ -56,7 +56,7 @@ concept has_downcast_poison_pill = requires(T t) { downcast_poison_pill(t); };
 template<typename Target, Downcastable T>
 struct downcast_child : T {
   friend auto downcast_guide(typename T::downcast_base)
-  { return Target(); }
+  { return std::type_identity<Target>(); }
 };
 
 template<Downcastable T>
@@ -89,13 +89,13 @@ constexpr auto downcast_impl()
   if constexpr(has_downcast_guide<T> && !has_downcast_poison_pill<T>)
     return decltype(downcast_guide(std::declval<downcast_base<T>>()))();
   else
-    return T();
+    return std::type_identity<T>();
 }
 
 }  // namespace detail
 
 template<Downcastable T>
-using downcast = decltype(detail::downcast_impl<T>());
+using downcast = TYPENAME decltype(detail::downcast_impl<T>())::type;
 
 template<Downcastable T>
 using downcast_base_t = TYPENAME T::downcast_base_type;


### PR DESCRIPTION
Fixes a point mentioned in https://github.com/mpusz/units/issues/199#issue-777819614.