### PR TITLE
[WIP] Identify reference/origin point in quantity_point -> enable temperature conversions

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -35,6 +35,7 @@ add_example(custom_systems)
 add_example(experimental_angle)
 add_example(foot_pound_second)
 add_example(kalman_filter-alpha_beta_filter_example2)
+add_example(temperature)
 
 add_example(measurement)
 add_example(unknown_dimension)

--- a/example/temperature.cpp
+++ b/example/temperature.cpp
@@ -1,0 +1,143 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Yves Delley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <units/origin.h>
+#include <units/physical/si/base/thermodynamic_temperature.h>
+#include <units/physical/si/prefixes.h>
+#include <units/quantity_io.h>
+#include <units/quantity_point.h>
+#include <units/ratio.h>
+#include <iostream>
+
+using namespace units;
+
+namespace si = units::physical::si;
+
+namespace detail {
+
+struct centikelvin : scaled_unit<ratio(1, 100), si::kelvin> {
+};
+
+}  // namespace detail
+
+struct celsius : alias_unit<si::kelvin, "\u00b0C", no_prefix> {
+};
+
+struct celsius_temperature_origin : point_origin<celsius_temperature_origin> {
+  using reference_origin = si::kelvin_temperature_origin;
+  static constexpr auto reference_offset = si::thermodynamic_temperature<::detail::centikelvin, long int>(27315);
+};
+
+template<UnitOf<si::dim_thermodynamic_temperature> U = celsius, QuantityValue Rep = double>
+using celsius_temperature_point = quantity_point<si::dim_thermodynamic_temperature, U, Rep, celsius_temperature_origin>;
+
+struct fahrenheit : named_scaled_unit<fahrenheit, "\u00b0F", no_prefix, ratio(5, 9), si::kelvin> {
+};
+
+namespace detail {
+
+struct millifahrenheit : scaled_unit<ratio(5, 9000), si::kelvin> {
+};
+
+}  // namespace detail
+
+struct fahrenheit_temperature_origin : point_origin<fahrenheit_temperature_origin> {
+  using reference_origin = si::kelvin_temperature_origin;
+  static constexpr auto reference_offset =
+      si::thermodynamic_temperature<::detail::millifahrenheit, long int>(273150 * 9 / 5 + 32000);
+};
+
+template<UnitOf<si::dim_thermodynamic_temperature> U = fahrenheit, QuantityValue Rep = double>
+using fahrenheit_temperature_point =
+    quantity_point<si::dim_thermodynamic_temperature, U, Rep, fahrenheit_temperature_origin>;
+
+
+namespace detail {
+
+template<typename Org>
+concept DerivedPointOrigin = PointOrigin<Org>&& requires
+{
+  typename Org::reference_origin;
+};
+
+template<PointOrigin Org>
+struct reference_origin {
+  using type = typename Org::reference_origin;
+};
+
+template<PointOrigin Org>
+using reference_origin_t =
+    typename std::conditional_t<DerivedPointOrigin<Org>, reference_origin<Org>, std::type_identity<Org>>::type;
+
+template<QuantityPoint P>
+auto offset_to_reference_origin()
+{
+  using Org = typename P::origin;
+  if constexpr (DerivedPointOrigin<Org>) {
+    return Org::reference_offset;
+  } else {
+    return typename P::quantity_type(0);
+  }
+}
+
+}  // namespace detail
+
+template<QuantityPoint QP1, QuantityPoint QP2>
+ requires(
+    std::is_same_v<::detail::reference_origin_t<typename QP1::origin>,
+                   ::detail::reference_origin_t<typename QP2::origin>>)
+QP1 quantity_point_offset_cast(const QP2& qp)
+{
+  using Q = typename QP1::quantity_type;
+  return QP1(quantity_cast<Q>(qp.relative() + ::detail::offset_to_reference_origin<QP2>() -
+         ::detail::offset_to_reference_origin<QP1>()));
+}
+
+using namespace si::literals;
+using namespace si::unit_constants;
+
+template<typename T>
+void debug_type()
+{
+  static_assert(!std::is_same_v<T, T>);
+}
+
+
+int main()
+{
+  // somehow my GCC 10.2 is ICEing in CTAD here, so I specify them explicitly.
+  celsius_temperature_point<> freezing(0 * K);
+  celsius_temperature_point<> boiling(100 * K);
+
+  auto f_C = quantity_point_offset_cast<celsius_temperature_point<>>(freezing);
+  auto b_C = quantity_point_offset_cast<celsius_temperature_point<>>(boiling);
+
+  auto f_F = quantity_point_offset_cast<fahrenheit_temperature_point<>>(freezing);
+  auto b_F = quantity_point_offset_cast<fahrenheit_temperature_point<>>(boiling);
+
+  auto f_K = quantity_point_offset_cast<si::kelvin_temperature_point<>>(freezing);
+  auto b_K = quantity_point_offset_cast<si::kelvin_temperature_point<>>(boiling);
+
+  std::cout << "Freezing point: " << f_C.relative() << "; Boiling point: " << b_C.relative() << std::endl;
+  std::cout << "Freezing point: " << f_F.relative() << "; Boiling point: " << b_F.relative() << std::endl;
+  std::cout << "Freezing point: " << f_K.relative() << "; Boiling point: " << b_K.relative() << std::endl;
+}

--- a/src/include/units/bits/basic_concepts.h
+++ b/src/include/units/bits/basic_concepts.h
@@ -246,6 +246,32 @@ struct _point_kind_base;
 template<typename T>
 concept PointKind = kind_impl_<T, detail::_point_kind_base>;
 
+// PointOrigin
+namespace detail {
+
+template <typename>
+struct _origin_base;
+
+}  // namespace detail
+
+template<typename T, template<typename...> typename Base>
+concept origin_impl_ =
+is_derived_from_specialization_of<T, Base> &&
+requires(T* t) {
+  typename T::base_origin;
+};
+
+/**
+ * @brief A concept matching all point origin types
+ *
+ * Satisfied by all point origin types derived from an specialization of @c point_origin.
+ */
+template<typename T>
+concept PointOrigin =
+  origin_impl_<T, detail::_origin_base> &&
+  origin_impl_<typename T::base_origin, detail::_origin_base> &&
+  std::same_as<typename T::base_origin, typename T::base_origin::base_origin>;
+
 // Quantity, QuantityPoint, QuantityKind, QuantityPointKind
 namespace detail {
 

--- a/src/include/units/bits/quantity_of.h
+++ b/src/include/units/bits/quantity_of.h
@@ -96,10 +96,10 @@ concept QuantityPointOf = QuantityPoint<QP> && Dimension<Dim> && equivalent<type
 /**
  * @brief A concept matching two equivalent quantity points
  *
- * Satisfied by quantity points having equivalent dimensions.
+ * Satisfied by quantity points having equivalent dimensions and the same reference point
  */
 template<typename QP1, typename QP2>
-concept QuantityPointEquivalentTo = QuantityPoint<QP1> && QuantityPointOf<QP2, typename QP1::dimension>;
+concept QuantityPointEquivalentTo = QuantityPoint<QP1> && QuantityPointOf<QP2, typename QP1::dimension> && std::is_same_v<typename QP2::origin, typename QP1::origin>;
 
 /**
  * @brief A concept matching only quantity kinds of a specific kind.
@@ -130,10 +130,10 @@ concept QuantityPointKindOf = QuantityPointKind<QPK> && PointKind<PK> && equival
 /**
  * @brief A concept matching two equivalent quantity point kinds
  *
- * Satisfied by quantity point kinds having equivalent kinds.
+ * Satisfied by quantity point kinds having equivalent kinds and the same reference point.
  */
 template<typename QPK1, typename QPK2>
 concept QuantityPointKindEquivalentTo =
-  QuantityPointKind<QPK1> && QuantityPointKindOf<QPK2, typename QPK1::point_kind_type>;
+  QuantityPointKind<QPK1> && QuantityPointKindOf<QPK2, typename QPK1::point_kind_type>  && std::is_same_v<typename QPK2::origin, typename QPK1::origin>;
 
 }  // namespace units

--- a/src/include/units/chrono.h
+++ b/src/include/units/chrono.h
@@ -23,6 +23,7 @@
 #pragma once
 
 #include <units/customization_points.h>
+#include <units/origin.h>
 #include <units/physical/si/base/time.h>
 #include <chrono>
 
@@ -36,11 +37,15 @@ struct quantity_like_traits<std::chrono::duration<Rep, Period>> {
   [[nodiscard]] static constexpr rep count(const std::chrono::duration<Rep, Period>& q) { return q.count(); }
 };
 
+template <typename C>
+struct chrono_clock_point_origin : point_origin<chrono_clock_point_origin<C>> {};
+
 template<typename C, typename Rep, typename Period>
 struct quantity_point_like_traits<std::chrono::time_point<C, std::chrono::duration<Rep, Period>>> {
   using dimension = physical::si::dim_time;
   using unit = downcast_unit<dimension, ratio(Period::num, Period::den)>;
   using rep = Rep;
+  using origin = chrono_clock_point_origin<typename std::chrono::time_point<C, std::chrono::duration<Rep, Period>>::clock>;
   [[nodiscard]] static constexpr auto relative(
     const std::chrono::time_point<C, std::chrono::duration<Rep, Period>>& qp) {
     return qp.time_since_epoch();

--- a/src/include/units/customization_points.h
+++ b/src/include/units/customization_points.h
@@ -88,7 +88,7 @@ struct quantity_like_traits;
 /**
  * @brief Provides support for external quantity point-like types
  * 
- * The type trait should provide the following nested type aliases: @c dimension, @c unit, @c rep,
+ * The type trait should provide the following nested type aliases: @c dimension, @c unit, @c rep, @c origin
  * and a static member function @c relative(T) that will return the quantity-like value of the quantity point.
  * 
  * Usage example can be found in @c units/chrono.h header file.

--- a/src/include/units/origin.h
+++ b/src/include/units/origin.h
@@ -1,0 +1,56 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Yves Delley
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/bits/basic_concepts.h>
+#include <units/bits/external/downcasting.h>
+
+namespace units {
+
+namespace detail {
+
+template<typename Org>
+struct _origin_base : downcast_base<_origin_base<Org>> {
+  using base_origin = Org;
+};
+
+}  // namespace detail
+
+template<PointOrigin Org>
+  requires Kind<downcast<detail::_origin_base<typename Org::base_origin>>>
+using downcast_origin = downcast<detail::_origin_base<typename Org::base_origin>>;
+
+template<typename Org>
+struct point_origin : downcast_dispatch<Org, detail::_origin_base<Org>> {};
+
+/**
+ * @brief A "default" point origin for scales associated with the base unit of a dimension
+ *
+ * This is mostly used as a fall-back so code that does not explicitly specify an origin still works.
+ *
+ * @tparam U the base unit for measurements with respect to this origin.
+ */
+template <Unit U>
+struct default_point_origin : point_origin<default_point_origin<U>> {};
+
+}  // namespace units

--- a/src/include/units/physical/si/base/thermodynamic_temperature.h
+++ b/src/include/units/physical/si/base/thermodynamic_temperature.h
@@ -25,6 +25,8 @@
 #include <units/one_rep.h>
 #include <units/physical/dimensions/thermodynamic_temperature.h>
 #include <units/quantity.h>
+#include <units/quantity_point.h>
+#include <units/origin.h>
 
 namespace units::physical::si {
 
@@ -34,6 +36,11 @@ struct dim_thermodynamic_temperature : physical::dim_thermodynamic_temperature<k
 
 template<UnitOf<dim_thermodynamic_temperature> U, QuantityValue Rep = double>
 using thermodynamic_temperature = quantity<dim_thermodynamic_temperature, U, Rep>;
+
+struct kelvin_temperature_origin : point_origin<kelvin_temperature_origin> {};
+
+template<UnitOf<dim_thermodynamic_temperature> U = kelvin, QuantityValue Rep = double>
+using kelvin_temperature_point = quantity_point<dim_thermodynamic_temperature, U, Rep, kelvin_temperature_origin>;
 
 inline namespace literals {
 

--- a/src/include/units/quantity_cast.h
+++ b/src/include/units/quantity_cast.h
@@ -39,13 +39,13 @@ namespace units {
 template<Dimension D, UnitOf<D> U, QuantityValue Rep>
 class quantity;
 
-template<Dimension D, UnitOf<D> U, QuantityValue Rep>
+template<Dimension D, UnitOf<D> U, QuantityValue Rep, PointOrigin Org>
 class quantity_point;
 
 template<Kind K, UnitOf<typename K::dimension> U, QuantityValue Rep>
 class quantity_kind;
 
-template<PointKind PK, UnitOf<typename PK::dimension> U, QuantityValue Rep>
+template<PointKind PK, UnitOf<typename PK::dimension> U, QuantityValue Rep, PointOrigin Org>
 class quantity_point_kind;
 
 namespace detail {
@@ -231,10 +231,10 @@ template<QuantityValue ToRep, typename D, typename U, scalable_with_<ToRep> Rep>
  *
  * @tparam CastSpec a target quantity point type to cast to or anything that works for quantity_cast
  */
-template<typename CastSpec, typename D, typename U, typename Rep>
+template<typename CastSpec, typename D, typename U, typename Rep, typename O>
   requires is_specialization_of<CastSpec, quantity_point> ||
            requires(quantity<D, U, Rep> q) { quantity_cast<CastSpec>(q); }
-[[nodiscard]] constexpr auto quantity_point_cast(const quantity_point<D, U, Rep>& qp)
+[[nodiscard]] constexpr auto quantity_point_cast(const quantity_point<D, U, Rep, O>& qp)
 {
   if constexpr (is_specialization_of<CastSpec, quantity_point>)
     return quantity_point(quantity_cast<typename CastSpec::quantity_type>(qp.relative()));
@@ -258,11 +258,11 @@ template<typename CastSpec, typename D, typename U, typename Rep>
  * @tparam ToD a dimension type to use for a target quantity
  * @tparam ToU a unit type to use for a target quantity
  */
-template<Dimension ToD, Unit ToU, typename D, typename U, typename Rep>
+template<Dimension ToD, Unit ToU, typename D, typename U, typename Rep, typename O>
   requires equivalent<ToD, D> && UnitOf<ToU, ToD>
-[[nodiscard]] constexpr auto quantity_point_cast(const quantity_point<D, U, Rep>& q)
+[[nodiscard]] constexpr auto quantity_point_cast(const quantity_point<D, U, Rep, O>& q)
 {
-  return quantity_point_cast<quantity_point<ToD, ToU, Rep>>(q);
+  return quantity_point_cast<quantity_point<ToD, ToU, Rep, O>>(q);
 }
 
 /**
@@ -341,8 +341,8 @@ template<Kind ToK, Unit ToU, typename K, typename U, typename Rep>
  *
  * @tparam CastSpec a target (quantity) point kind type to cast to or anything that works for quantity_kind_cast
  */
-template<typename CastSpec, typename PK, typename U, typename Rep>
-[[nodiscard]] constexpr QuantityPointKind auto quantity_point_kind_cast(const quantity_point_kind<PK, U, Rep>& qpk)
+template<typename CastSpec, typename PK, typename U, typename Rep, typename Org>
+[[nodiscard]] constexpr QuantityPointKind auto quantity_point_kind_cast(const quantity_point_kind<PK, U, Rep, Org>& qpk)
   requires (is_specialization_of<CastSpec, quantity_point_kind> &&
               requires { quantity_kind_cast<typename CastSpec::quantity_kind_type>(qpk.relative()); }) ||
            (PointKind<CastSpec> && UnitOf<U, typename CastSpec::dimension>) ||
@@ -371,11 +371,11 @@ template<typename CastSpec, typename PK, typename U, typename Rep>
  * @tparam ToPK the point kind type to use for the target quantity
  * @tparam ToU the unit type to use for the target quantity
  */
-template<PointKind ToPK, Unit ToU, typename PK, typename U, typename Rep>
+template<PointKind ToPK, Unit ToU, typename PK, typename U, typename Rep, typename Org>
   requires equivalent<typename ToPK::dimension, typename PK::dimension> && UnitOf<ToU, typename ToPK::dimension>
-[[nodiscard]] constexpr QuantityPointKind auto quantity_point_kind_cast(const quantity_point_kind<PK, U, Rep>& qpk)
+[[nodiscard]] constexpr QuantityPointKind auto quantity_point_kind_cast(const quantity_point_kind<PK, U, Rep, Org>& qpk)
 {
-  return quantity_point_kind_cast<quantity_point_kind<ToPK, ToU, Rep>>(qpk);
+  return quantity_point_kind_cast<quantity_point_kind<ToPK, ToU, Rep, Org>>(qpk);
 }
 
 }  // namespace units

--- a/src/include/units/quantity_point_kind.h
+++ b/src/include/units/quantity_point_kind.h
@@ -38,7 +38,7 @@ namespace units {
  * @tparam U the measurement unit of the quantity point kind
  * @tparam Rep the type to be used to represent values of the quantity point kind
  */
-template<PointKind PK, UnitOf<typename PK::dimension> U, QuantityValue Rep = double>
+template<PointKind PK, UnitOf<typename PK::dimension> U, QuantityValue Rep = double, PointOrigin Org = default_point_origin<typename dimension_unit<typename PK::dimension>::reference>>
 class quantity_point_kind {
 public:
   using point_kind_type = PK;
@@ -48,6 +48,7 @@ public:
   using dimension = typename quantity_type::dimension;
   using unit = typename quantity_type::unit;
   using rep = typename quantity_type::rep;
+  using origin = Org;
 
 private:
   quantity_kind_type qk_;
@@ -68,10 +69,10 @@ public:
   constexpr explicit quantity_point_kind(const Q& q) : qk_{q} {}
 
   template<QuantityPointLike QP>
-    requires std::is_constructible_v<quantity_point<dimension, U, Rep>, QP>
+    requires std::is_constructible_v<quantity_point<dimension, U, Rep, Org>, QP>
   constexpr explicit quantity_point_kind(const QP& qp) : qk_{quantity_point_like_traits<QP>::relative(qp)} {}
 
-  constexpr explicit quantity_point_kind(const quantity_point<dimension, U, Rep>& qp) : qk_{qp.relative()} {}
+  constexpr explicit quantity_point_kind(const quantity_point<dimension, U, Rep, Org>& qp) : qk_{qp.relative()} {}
 
   constexpr explicit quantity_point_kind(const quantity_kind_type& qk) : qk_{qk} {}
 
@@ -188,8 +189,8 @@ quantity_point_kind(QK) ->
 
 namespace detail {
 
-template<typename PK, typename U, typename Rep>
-inline constexpr bool is_quantity_point_kind<quantity_point_kind<PK, U, Rep>> = true;
+template<typename PK, typename U, typename Rep, typename Org>
+inline constexpr bool is_quantity_point_kind<quantity_point_kind<PK, U, Rep, Org>> = true;
 
 }  // namespace detail
 

--- a/test/unit_test/static/chrono_test.cpp
+++ b/test/unit_test/static/chrono_test.cpp
@@ -31,10 +31,12 @@ using namespace units;
 using namespace units::physical;
 using namespace units::physical::si::literals;
 using namespace std::chrono_literals;
+using sys_clock_origin = chrono_clock_point_origin<std::chrono::system_clock>;
 using sys_seconds = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
 using sys_days = std::chrono::time_point<std::chrono::system_clock,
   std::chrono::duration<long, std::ratio_multiply<std::ratio<24>, std::chrono::hours::period>>>;
-template<typename U, typename Rep = double> using time_point = quantity_point<si::dim_time, U, Rep>;
+template<typename U, typename Rep = double, typename Org = sys_clock_origin> using time_point
+  = quantity_point<si::dim_time, U, Rep, Org>;
 
 static_assert(QuantityLike<std::chrono::seconds>);
 static_assert(QuantityPointLike<sys_seconds>);
@@ -82,7 +84,7 @@ static_assert(is_same_v<decltype(quantity_point{sys_days{sys_days::duration{1}}}
 static_assert(quantity{1s} + 1_q_s == 2_q_s);
 static_assert(quantity{1s} + 1_q_min == 61_q_s);
 static_assert(10_q_m / quantity{2s} == 5_q_m_per_s);
-static_assert(quantity_point{sys_seconds{1s}} + 1_q_s == quantity_point{2_q_s});
-static_assert(quantity_point{sys_seconds{1s}} + 1_q_min == quantity_point{61_q_s});
+static_assert(quantity_point{sys_seconds{1s}} + 1_q_s == quantity_point{sys_seconds{2s}});
+static_assert(quantity_point{sys_seconds{1s}} + 1_q_min == quantity_point{sys_seconds{61s}});
 
 }  // namespace

--- a/test/unit_test/static/quantity_point_kind_test.cpp
+++ b/test/unit_test/static/quantity_point_kind_test.cpp
@@ -39,6 +39,7 @@ using namespace units;
 namespace si = physical::si;
 using namespace si;
 using namespace unit_constants;
+using sys_clock_origin = chrono_clock_point_origin<std::chrono::system_clock>;
 using sys_seconds = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
 
 constexpr auto cgs_cm = cgs::unit_constants::cm;
@@ -119,8 +120,8 @@ concept invalid_types = requires {
   requires !requires { typename quantity_point_kind<Abscissa, metre, quantity_point<dim_length, metre>>; };  // quantity point used as Rep
   requires !requires { typename quantity_point_kind<Abscissa, metre, width<metre>>; };  // quantity kind used as Rep
   requires !requires { typename quantity_point_kind<Abscissa, metre, abscissa<metre>>; };  // quantity point kind used as Rep
-  requires !requires { typename quantity_point_kind<metre, Abscissa, double>; };  // reordered arguments
-  requires !requires { typename quantity_point_kind<metre, double, Abscissa>; };  // reordered arguments
+  requires !requires { typename quantity_point_kind<metre, Abscissa, double, default_point_origin<metre>>; };  // reordered arguments
+  requires !requires { typename quantity_point_kind<metre, double, Abscissa, default_point_origin<metre>>; };  // reordered arguments
 };
 static_assert(invalid_types<width_kind, abscissa_kind>);
 
@@ -305,7 +306,7 @@ static_assert(!constructible_or_convertible_from<nth_apple<one, int>>(quantity_p
 static_assert(!constructible_or_convertible_from<nth_apple<one, int>>(quantity_point(dimensionless<percent, double>(1))));
 static_assert(!constructible_or_convertible_from<nth_apple<one, double>>(quantity_point(1.0 * s)));
 
-static_assert(construct_from_only<quantity_point_kind<time_point_kind, second, int>>(sys_seconds{42s}).relative().common() == 42 * s);
+static_assert(construct_from_only<quantity_point_kind<time_point_kind, second, int, sys_clock_origin>>(sys_seconds{42s}).relative().common() == 42 * s);
 // clang-format on
 
 

--- a/test/unit_test/static/quantity_point_test.cpp
+++ b/test/unit_test/static/quantity_point_test.cpp
@@ -36,6 +36,7 @@ using namespace units;
 using namespace physical::si;
 using namespace unit_constants;
 using namespace std::chrono_literals;
+using sys_clock_origin = chrono_clock_point_origin<std::chrono::system_clock>;
 using sys_seconds = std::chrono::time_point<std::chrono::system_clock, std::chrono::seconds>;
 
 // class invariants


### PR DESCRIPTION
## Overview

This is a design study to represent the origin/reference point with respect to which `quantity_points` measure their value. If there is a well-defined relation between origins of scales of compatible dimensions, the library can be enabled to convert between such quantity points that are specified with respect to different origins. The most common example are the three temperature scales Kelvin, degree Celsius and degree Fahrenheit. (Personally, my favourite use is to represent sensor readings from electronic sensors in embedded systems as physical quantities without any runtime conversions; such sensors may represent results with respect to some arbitrary, but fixed origin).

## Changes to `quantity_point`

This PR implements a concept `PointOrigin`, and extends the template arguments of `quantity_point` to `template <Dimension D, UnitOf<D> U, QuantityValue Rep = double, PointOrigin Org = default_point_origin<typename dimension_unit<D>::type>>` (and similarly for `quantity_point_kind`) . In particular, a `default_point_origin` is defined to allow existing code to continue to work.

## `PointOrigin` concept

Currently, the `PointOrigin` concept does not relate to a specific dimension, it is simply a tag type that references an abstract origin. The underlying notion however *is* usually tied tied to a dimension (or even a kind of quantity - I'm not that experienced with that notion). I had initially designed the concept as `PointOrigin<D>`, but that caused trouble with the tests where quantity points are liberally converted between kinds with differing dimensions but compatible units (e.g. `cgd::dim_length` vs. `si::dim_length`). Further exploration might be needed here.

Also, in this PR, `PointOrigin` are compares through type identity (`std::is_same_v`) though there might be a need for something slightly more lenient.

## `std::chrono::time_point`
`std::chrono::time_point` has an implicit notion of the origin / reference too,
 through the [`time_point::clock` member type: "Clock, the clock on which this time point is measured"](https://en.cppreference.com/w/cpp/chrono/time_point).
Therefore, this PR handles `std::chrono` interoperability through the introduction
of a `chrono_clock_point_origin<Clock>`.

## Compatibility  between quantity points measured against different references

In this PR, quantity_points with differing origins are incompatible and cannot be assigned / constructed from each other,
not even explicitly. Imho, that is the sensible thing to do, as in most cases that would result in a change of the value. 
If one really needs to do that, one can do so explicitly using `quantity_point_2(qp1.relative())`.

## Casting / converting between quantity points measured against different references (temperatures!)

This PR does not yet implement any explicit casts or conversion routines. The example `temperature.cpp` does highlight the three temperature scales, and implements a simple `quantity_point_offset_cast`, correctly converting between those temperatures. This could be implemented into `quantity_cast` and it's relatives, though there is ambiguity if that should cast by just copying the numeric value, converting the relative part properly, or fully convert the scale.

### Side remark (rant?) on `quantity_cast`
In general, I think the `quantity_cast` and friends are already somewhat mis-designed, in that their names say to what they apply rather than what they do: They convert representations imprecisely, but also replace quantity kinds with unrelated ones, and potentially more. This is somewhat akin to a C-style cast, which "magically" selects what to do, rather than the C++ casts which all just do one thing which is clearly and explicitly stated by the name. Maybe I should open a separate issue [(see also a previous comment to another issue)](https://github.com/mpusz/units/issues/120#issuecomment-653513282).

## Tests
The existing tests have been adapted and pass on my machine (somehow they fail in CI in Debug mode - unable to reproduce yet). No explicit tests on compatibility / incompatibility between unrelated origins yet.

## Documentation
Not in the PR yet - sorry.

## Bike-shedding

Feel free.