### PR TITLE
fixed -Wsign-conversion warning in doubtful conversion between std::clock_t and std::time_t

### DIFF
--- a/example/alternative_namespaces/timer.h
+++ b/example/alternative_namespaces/timer.h
@@ -51,7 +51,7 @@ namespace units{ namespace experimental{
             static constexpr auto divider = 1000.0 / CLOCKS_PER_SEC;
            
             return q_time::ms<>( 
-                difftime(wanted , start_time) 
+                static_cast<double>(wanted - start_time)
             ) * divider;
         }
         bool is_running() const {return running;}


### PR DESCRIPTION
On my machine, the CTest CMake target fails with `-Werror=sign-compare` without that fix. The reason is [`std::difftime`](https://en.cppreference.com/w/cpp/chrono/c/difftime) operates on `std::time_t`, while the rest of that example uses `std::clock_t`. These two types are not related in semantics as far as I can tell. However [`std::clock_t`](https://en.cppreference.com/w/cpp/chrono/c/clock_t) is specified as an "arithmetic type", so simply subtracting should be ok. Furthermore, the corresponding [C `clock_t` example](https://en.cppreference.com/w/c/chrono/clock_t) explicitly highlights subtraction and conversion to double.