### PR TITLE
adding missing/required (?) '#defines' for compiler-explorer examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ static_assert(10 * km / (5 * km) == 2);
 static_assert(1000 / (1 * s) == 1 * kHz);
 ```
 
-_Try it on the [Compiler Explorer](https://godbolt.org/z/ToTaoxKPa)._
+_Try it on the [Compiler Explorer](https://godbolt.org/z/53bTahKd8)._
 
 This library requires some C++20 features (concepts, classes as NTTPs, ...). Thanks to
 them the user gets a powerful but still easy to use interface and all unit conversions
@@ -106,4 +106,4 @@ int main()
 }
 ```
 
-_Try it on the [Compiler Explorer](https://godbolt.org/z/YodshMKac)._
+_Try it on the [Compiler Explorer](https://godbolt.org/z/a956fb64o)._

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ and dimensional analysis can be performed without sacrificing on accuracy. Pleas
 the below example for a quick preview of basic library features:
 
 ```cpp
+#define UNITS_UDLS 1
 #define UNITS_REFERENCES
 #define UNITS_LITERALS
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ and dimensional analysis can be performed without sacrificing on accuracy. Pleas
 the below example for a quick preview of basic library features:
 
 ```cpp
-#define UNITS_UDLS 1
 #define UNITS_REFERENCES
 #define UNITS_LITERALS
 
@@ -107,4 +106,4 @@ int main()
 }
 ```
 
-_Try it on the [Compiler Explorer](https://godbolt.org/z/a956fb64o)._
+_Try it on the [Compiler Explorer](https://godbolt.org/z/7sshE7o58)._

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -42,7 +42,6 @@ but still easy to use interface where all unit conversions and dimensional analy
 performed without sacrificing on accuracy. Please see the below example for a quick preview
 of basic library features::
 
-    #define UNITS_UDLS 1
     #define UNITS_REFERENCES
     #define UNITS_LITERALS
 
@@ -84,7 +83,7 @@ of basic library features::
 
 .. admonition:: Try it on Compiler Explorer
 
-    `Example #2 <https://godbolt.org/z/a956fb64o>`_
+    `Example #2 <https://godbolt.org/z/7sshE7o58>`_
 
 .. seealso::
 

--- a/docs/quick_start.rst
+++ b/docs/quick_start.rst
@@ -34,7 +34,7 @@ Here is a small example of possible operations::
 
 .. admonition:: Try it on Compiler Explorer
 
-    `Example #1 <https://godbolt.org/z/ToTaoxKPa>`_
+    `Example #1 <https://godbolt.org/z/53bTahKd8>`_
 
 This library requires some C++20 features (concepts, classes as
 :abbr:`NTTP (Non-Type Template Parameter)`, ...). Thanks to them the user gets a powerful
@@ -42,6 +42,7 @@ but still easy to use interface where all unit conversions and dimensional analy
 performed without sacrificing on accuracy. Please see the below example for a quick preview
 of basic library features::
 
+    #define UNITS_UDLS 1
     #define UNITS_REFERENCES
     #define UNITS_LITERALS
 
@@ -83,7 +84,7 @@ of basic library features::
 
 .. admonition:: Try it on Compiler Explorer
 
-    `Example #2 <https://godbolt.org/z/YodshMKac>`_
+    `Example #2 <https://godbolt.org/z/a956fb64o>`_
 
 .. seealso::
 


### PR DESCRIPTION
While testing I found some very minor missing/required (?) defines. It's not much and seasoned units users might easily miss this but I reckoned that other new users of your library might stumble across it as well. Feel free to merge, modify, or close.

The compiler explorer examples seem to miss the following
```
#define UNITS_REFERENCES
#define UNITS_LITERALS
```
defines to execute and recompile slightly modified versions.

Haven't changed anything else other than the updated compiler-explorer links.