### PR TITLE
extended is_quantity<T> to support quantity-derived classes

### DIFF
--- a/src/core/include/units/bits/basic_concepts.h
+++ b/src/core/include/units/bits/basic_concepts.h
@@ -269,7 +269,7 @@ concept Reference = detail::is_reference<T>;
 namespace detail {
 
 template<typename T>
-inline constexpr bool is_quantity = false;
+inline constexpr bool is_quantity = requires { typename T::dimension;  typename T::unit;  typename T::rep;};
 
 template<typename T>
 inline constexpr bool is_quantity_point = false;

--- a/src/core/include/units/bits/basic_concepts.h
+++ b/src/core/include/units/bits/basic_concepts.h
@@ -269,7 +269,7 @@ concept Reference = detail::is_reference<T>;
 namespace detail {
 
 template<typename T>
-inline constexpr bool is_quantity = requires { typename T::dimension;  typename T::unit;  typename T::rep;};
+inline constexpr bool is_quantity = false;
 
 template<typename T>
 inline constexpr bool is_quantity_point = false;

--- a/src/core/include/units/quantity.h
+++ b/src/core/include/units/quantity.h
@@ -465,6 +465,17 @@ namespace detail {
 template<typename D, typename U, typename Rep>
 inline constexpr bool is_quantity<quantity<D, U, Rep>> = true;
 
+template<typename T>
+requires units::is_derived_from_specialization_of<T, units::quantity> &&
+        requires {
+    typename T::dimension;
+    typename T::unit;
+    typename T::rep;
+    requires Dimension<typename T::dimension>;
+    requires Unit<typename T::unit>;
+    requires Representation<typename T::rep>; }
+inline constexpr bool is_quantity<T> = true;
+
 }  // namespace detail
 
 }  // namespace units

--- a/src/core/include/units/quantity.h
+++ b/src/core/include/units/quantity.h
@@ -466,14 +466,7 @@ template<typename D, typename U, typename Rep>
 inline constexpr bool is_quantity<quantity<D, U, Rep>> = true;
 
 template<typename T>
-requires units::is_derived_from_specialization_of<T, units::quantity> &&
-        requires {
-    typename T::dimension;
-    typename T::unit;
-    typename T::rep;
-    requires Dimension<typename T::dimension>;
-    requires Unit<typename T::unit>;
-    requires Representation<typename T::rep>; }
+requires units::is_derived_from_specialization_of<T, units::quantity>
 inline constexpr bool is_quantity<T> = true;
 
 }  // namespace detail

--- a/test/unit_test/static/quantity_test.cpp
+++ b/test/unit_test/static/quantity_test.cpp
@@ -234,6 +234,18 @@ static_assert(length<kilometre, int>(2_q_km).number() == 2);
 static_assert(length<metre, int>(2_q_km).number() == 2000);
 static_assert(length<kilometre>(1500_q_m).number() == 1.5);
 
+///////////////////////////////////////
+// derived quantities
+///////////////////////////////////////
+
+template<Representation Rep, units::Quantity Q, const units::basic_fixed_string additional_nttp_argument>
+struct derived_quantity : quantity<typename Q::dimension, typename Q::unit, Rep> {
+    using dimension = typename Q::dimension;
+    using unit = typename Q::unit;
+    using rep = Rep;
+};
+
+static_assert(units::detail::is_quantity<derived_quantity<double, si::length<metre>, "NTTP type description">>);
 
 /////////
 // CTAD


### PR DESCRIPTION
This PR allows to inherit from the `quantity` template class definition and to provide additional NTTP-type annotations and/or change the signature of the derived class (e.g. ordering of parameter types). For details see also #271

N.B. inheritance is preferred to composition/delegate class to avoid duplication of and also inherent the various required operators ('+','-',..., '+=', ...) 

Up for comments, improvements, and/or suggestions. Thanks again for this great library. :+1: