### PR TITLE
fix: constraint recursion in GCC 11 for the linear algebra examples

### DIFF
--- a/src/core/include/units/quantity.h
+++ b/src/core/include/units/quantity.h
@@ -312,18 +312,16 @@ public:
     return units::quantity(lhs - rhs.number());
   }
 
-  template<typename Value>
-    requires (!Quantity<Value>) &&
-          invoke_result_convertible_to_<rep, std::multiplies<>, rep, const Value&>
+  template<Representation Value>
+    requires invoke_result_convertible_to_<rep, std::multiplies<>, rep, const Value&>
   [[nodiscard]] friend constexpr Quantity auto operator*(const quantity& q, const Value& v)
   {
     using ret = quantity<D, U, std::invoke_result_t<std::multiplies<>, rep, Value>>;
     return ret(q.number() * v);
   }
 
-  template<typename Value>
-    requires (!Quantity<Value>) &&
-          invoke_result_convertible_to_<rep, std::multiplies<>, const Value&, rep>
+  template<Representation Value>
+    requires invoke_result_convertible_to_<rep, std::multiplies<>, const Value&, rep>
   [[nodiscard]] friend constexpr Quantity auto operator*(const Value& v, const quantity& q)
   {
     using ret = quantity<D, U, std::invoke_result_t<std::multiplies<>, Value, rep>>;


### PR DESCRIPTION
As discussed at https://github.com/mpusz/units/commit/80abffc0582f55643a1d9a6d9c58eefe74d5c9e0#commitcomment-56633803.
I believe at some point I questioned why these where constrained with `!Quantity` rather than `Representation`.
This only fixes it for the linear algebra example; there remain other uses of `!Quantity`.

Unrelatedly, this came up while compiling all the static tests with the glob `*.cpp`:
```C++
/home/johel/Documents/C++/Forks/mpusz/units/test/unit_test/static/si_hep_test.cpp:24:10: fatal error: units/isq/si/hep/area.h: No such file or directory
   24 | #include <units/isq/si/hep/area.h>
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated.
```