### PR TITLE
Feat: Overloads for floor and ceil accepting quantities

### DIFF
--- a/src/core/include/units/math.h
+++ b/src/core/include/units/math.h
@@ -188,6 +188,21 @@ template<Unit To, typename D, typename U, typename Rep>
 }
 
 /**
+ * @brief Overload of @c ::units::floor<Unit>() using the unit type of To
+ *
+ * @tparam q Quantity being the base of the operation
+ * @return Quantity The rounded quantity with unit type of quantity To
+ */
+template<Quantity To, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr quantity<D, typename To::unit, Rep> floor(const quantity<D, U, Rep>& q) noexcept
+  requires requires {
+      ::units::floor<typename To::unit>(q);
+    }
+{
+  return ::units::floor<typename To::unit>(q);
+}
+
+/**
  * @brief Computes the smallest quantity with integer representation and unit type To with its number not less than q
  *
  * @tparam q Quantity being the base of the operation
@@ -225,6 +240,21 @@ template<Unit To, typename D, typename U, typename Rep>
       return handle_signed_results(quantity_cast<To>(q));
     }
   }
+}
+
+/**
+ * @brief Overload of @c ::units::ceil<Unit>() using the unit type of To
+ *
+ * @tparam q Quantity being the base of the operation
+ * @return Quantity The rounded quantity with unit type of quantity To
+ */
+template<Quantity To, typename D, typename U, typename Rep>
+[[nodiscard]] constexpr quantity<D, typename To::unit, Rep> ceil(const quantity<D, U, Rep>& q) noexcept
+  requires requires {
+      ::units::ceil<typename To::unit>(q);
+    }
+{
+  return ::units::ceil<typename To::unit>(q);
 }
 
 }  // namespace units

--- a/src/core/include/units/math.h
+++ b/src/core/include/units/math.h
@@ -195,7 +195,9 @@ template<Unit To, typename D, typename U, typename Rep>
  */
 template<Quantity To, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr quantity<D, typename To::unit, Rep> floor(const quantity<D, U, Rep>& q) noexcept
-  requires requires {
+  requires std::same_as<typename To::dimension, D> &&
+    std::same_as<typename To::rep, Rep> &&
+    requires {
       ::units::floor<typename To::unit>(q);
     }
 {
@@ -250,7 +252,9 @@ template<Unit To, typename D, typename U, typename Rep>
  */
 template<Quantity To, typename D, typename U, typename Rep>
 [[nodiscard]] constexpr quantity<D, typename To::unit, Rep> ceil(const quantity<D, U, Rep>& q) noexcept
-  requires requires {
+  requires std::same_as<typename To::dimension, D> &&
+    std::same_as<typename To::rep, Rep> &&
+    requires {
       ::units::ceil<typename To::unit>(q);
     }
 {

--- a/test/unit_test/runtime/math_test.cpp
+++ b/test/unit_test/runtime/math_test.cpp
@@ -148,6 +148,9 @@ TEST_CASE("floor functions", "[floor]")
   SECTION ("floor -999. milliseconds with target unit second should be -1 second") {
     REQUIRE(floor<si::second>(-999._q_ms) == -1_q_s);
   }
+  SECTION ("floor 1 second with target quantity with unit type second should be 1 second") {
+    REQUIRE(floor<si::time<si::second>>(1_q_s) == 1_q_s);
+  }
 }
 
 TEST_CASE("ceil functions", "[ceil]")
@@ -188,6 +191,9 @@ TEST_CASE("ceil functions", "[ceil]")
 //   }
   SECTION ("ceil -999. milliseconds with target unit second should be 0 seconds") {
     REQUIRE(ceil<si::second>(-999._q_ms) == 0_q_s);
+  }
+  SECTION ("ceil 1 second with target quantity with unit type second should be 1 second") {
+    REQUIRE(ceil<si::time<si::second>>(1_q_s) == 1_q_s);
   }
 }
 

--- a/test/unit_test/runtime/math_test.cpp
+++ b/test/unit_test/runtime/math_test.cpp
@@ -149,7 +149,7 @@ TEST_CASE("floor functions", "[floor]")
     REQUIRE(floor<si::second>(-999._q_ms) == -1_q_s);
   }
   SECTION ("floor 1 second with target quantity with unit type second should be 1 second") {
-    REQUIRE(floor<si::time<si::second>>(1_q_s) == 1_q_s);
+    REQUIRE(floor<si::time<si::second, long int>>(1_q_s) == 1_q_s);
   }
 }
 
@@ -193,7 +193,7 @@ TEST_CASE("ceil functions", "[ceil]")
     REQUIRE(ceil<si::second>(-999._q_ms) == 0_q_s);
   }
   SECTION ("ceil 1 second with target quantity with unit type second should be 1 second") {
-    REQUIRE(ceil<si::time<si::second>>(1_q_s) == 1_q_s);
+    REQUIRE(ceil<si::time<si::second, long int>>(1_q_s) == 1_q_s);
   }
 }
 

--- a/test/unit_test/runtime/math_test.cpp
+++ b/test/unit_test/runtime/math_test.cpp
@@ -149,7 +149,8 @@ TEST_CASE("floor functions", "[floor]")
     REQUIRE(floor<si::second>(-999._q_ms) == -1_q_s);
   }
   SECTION ("floor 1 second with target quantity with unit type second should be 1 second") {
-    REQUIRE(floor<si::time<si::second, long int>>(1_q_s) == 1_q_s);
+    using showtime = si::time<si::second, int>;
+    REQUIRE(floor<showtime>(showtime::one()) == showtime::one());
   }
 }
 
@@ -193,7 +194,8 @@ TEST_CASE("ceil functions", "[ceil]")
     REQUIRE(ceil<si::second>(-999._q_ms) == 0_q_s);
   }
   SECTION ("ceil 1 second with target quantity with unit type second should be 1 second") {
-    REQUIRE(ceil<si::time<si::second, long int>>(1_q_s) == 1_q_s);
+    using showtime = si::time<si::second, int>;
+    REQUIRE(ceil<showtime>(showtime::one()) == showtime::one());
   }
 }
 

--- a/test/unit_test/static/math_test.cpp
+++ b/test/unit_test/static/math_test.cpp
@@ -78,6 +78,9 @@ static_assert(floor<si::second>(1999._q_ms) == 1_q_s);
 static_assert(floor<si::second>(-1000._q_ms) == -1_q_s);
 static_assert(floor<si::second>(-999._q_ms) == -1_q_s);
 
+// floor with quantity
+static_assert(compare<decltype(floor<si::time<si::second>>(1_q_s)), decltype(1_q_s)>);
+
 // ceil
 // integral types
 static_assert(compare<decltype(ceil<si::second>(1_q_s)), decltype(1_q_s)>);
@@ -97,6 +100,9 @@ static_assert(ceil<si::second>(1001._q_ms) == 2_q_s);
 static_assert(ceil<si::second>(1999._q_ms) == 2_q_s);
 static_assert(ceil<si::second>(-1000._q_ms) == -1_q_s);
 static_assert(ceil<si::second>(-999._q_ms) == 0_q_s);
+
+// ceil with quantity
+static_assert(compare<decltype(ceil<si::time<si::second>>(1_q_s)), decltype(1_q_s)>);
 #endif
 
 }  // namespace


### PR DESCRIPTION
Relates to #307 

Overloads for `floor` and `ceil` for quantitiy types. I will include the overload for `round` in #313 