### PR TITLE
Fix CMake target link to gsl::gsl-lite

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -37,7 +37,7 @@ check_libcxx_in_use(${projectPrefix}LIBCXX)
 add_library(mp-units-core INTERFACE)
 target_compile_features(mp-units-core INTERFACE cxx_std_20)
 target_link_libraries(mp-units-core INTERFACE
-    gsl-lite::gsl-lite
+    gsl::gsl-lite
 )
 target_include_directories(mp-units-core ${unitsAsSystem} INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>


### PR DESCRIPTION
Replace wrong `gsl-lite::gsl-lite` by correct `gsl::gsl-lite`.

Previously linking with `mp-units::mp-units` didn't work, because the generated target file linked to the non-existing `gsl-lite::gsl-lite`.

Not sure when `gsl-lite::gsl-lite` has been remove, but with gsl-lite 0.39.0 is doesn't work and in the [release notes of version 0.40.0](https://github.com/gsl-lite/gsl-lite/releases/tag/v0.40.0) it is also named non-existing.