### PR TITLE
Add vector space representation for magnitudes

### DIFF
--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -26,7 +26,7 @@
 #include <cstdint>
 #include <numbers>
 
-namespace units::mag {
+namespace units {
 
 /**
  * @brief  Any type which can be used as a basis vector in a BasePower.
@@ -339,8 +339,7 @@ constexpr Magnitude auto as_magnitude() {
     / detail::prime_factorization_v<R.den>;
 }
 
-namespace detail
-{
+namespace detail {
 // Default implementation.
 template<std::intmax_t N>
   requires (N > 0)
@@ -358,4 +357,4 @@ template<>
 struct prime_factorization<1> { static constexpr magnitude<> value{}; };
 } // namespace detail
 
-} // namespace units::mag
+} // namespace units

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -128,9 +128,8 @@ constexpr bool operator==(T t, U u) {
 /**
  * @brief  A BasePower, raised to a rational power E.
  */
-template<ratio E>
-constexpr auto pow(BasePower auto bp) {
-  bp.power = bp.power * E;
+constexpr auto pow(BasePower auto bp, ratio p) {
+  bp.power = bp.power * p;
   return bp;
 }
 
@@ -274,7 +273,7 @@ constexpr bool operator==(magnitude<LeftBPs...>, magnitude<RightBPs...>) {
 template<ratio E, BasePower auto... BPs>
 constexpr auto pow(magnitude<BPs...>) {
   if constexpr (E == 0) { return magnitude<>{}; }
-  else { return magnitude<pow<E>(BPs)...>{}; }
+  else { return magnitude<pow(BPs, E)...>{}; }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -85,6 +85,11 @@ constexpr auto make_ratio() {
   return quotient_t<detail::prime_factorization_t<N>, detail::prime_factorization_t<D>>{};
 }
 
+template <typename T, std::intmax_t N = 1, std::intmax_t D = 1>
+constexpr auto make_base_power() {
+  return magnitude<base_power<T, ratio{N, D}>>{};
+}
+
 struct pi {
   static inline constexpr long double value = std::numbers::pi_v<long double>;
 };

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -333,7 +333,9 @@ constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * pow<-1
 template<ratio R>
   requires (R.num > 0)
 constexpr Magnitude auto as_magnitude() {
-  return detail::prime_factorization_v<R.num> / detail::prime_factorization_v<R.den>;
+  return pow<R.exp>(detail::prime_factorization_v<10>)
+    * detail::prime_factorization_v<R.num>
+    / detail::prime_factorization_v<R.den>;
 }
 
 namespace detail

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -331,14 +331,6 @@ constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * pow<-1
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // `as_magnitude()` implementation.
 
-template<ratio R>
-  requires (R.num > 0)
-constexpr Magnitude auto as_magnitude() {
-  return pow<R.exp>(detail::prime_factorization_v<10>)
-    * detail::prime_factorization_v<R.num>
-    / detail::prime_factorization_v<R.den>;
-}
-
 namespace detail {
 // Default implementation.
 template<std::intmax_t N>
@@ -356,5 +348,13 @@ struct prime_factorization {
 template<>
 struct prime_factorization<1> { static constexpr magnitude<> value{}; };
 } // namespace detail
+
+template<ratio R>
+  requires (R.num > 0)
+constexpr Magnitude auto as_magnitude() {
+  return pow<R.exp>(detail::prime_factorization_v<10>)
+    * detail::prime_factorization_v<R.num>
+    / detail::prime_factorization_v<R.den>;
+}
 
 } // namespace units

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -49,18 +49,18 @@ struct int_base : std::integral_constant<std::intmax_t, n> {};
 template <std::intmax_t n, std::intmax_t num = 1, std::intmax_t den = 1>
 using int_base_power = base_power<int_base<n>, ratio{num, den}>;
 
-template <typename mag_t>
+template <Magnitude M>
 struct inverse;
-template <typename mag_t>
-using inverse_t = typename inverse<mag_t>::type;
+template <Magnitude M>
+using inverse_t = typename inverse<M>::type;
 
-template <typename... mags>
+template <Magnitude... Mags>
 struct product;
-template <typename... mags>
-using product_t = typename product<mags...>::type;
+template <Magnitude... Mags>
+using product_t = typename product<Mags...>::type;
 
-template <typename mag1, typename mag2>
-using quotient_t = product_t<mag1, inverse_t<mag2>>;
+template <Magnitude T, Magnitude U>
+using quotient_t = product_t<T, inverse_t<U>>;
 
 namespace detail
 {
@@ -129,10 +129,10 @@ struct inverse<magnitude<base_power<bases, powers>...>> {
 // Convenience utility to prepend a base_power to a magnitude.
 //
 // Assumes that the prepended power has a smaller base than every base power in the magnitude.
-template <typename new_base, typename mag_t>
+template <typename new_base, Magnitude M>
 struct prepend_base;
-template <typename new_base, typename mag_t>
-using prepend_base_t = typename prepend_base<new_base, mag_t>::type;
+template <typename new_base, Magnitude M>
+using prepend_base_t = typename prepend_base<new_base, M>::type;
 template <typename new_base, typename... old_bases>
 struct prepend_base<new_base, magnitude<old_bases...>> {
   using type = magnitude<new_base, old_bases...>;
@@ -143,12 +143,12 @@ template <>
 struct product<> { using type = magnitude<>; };
 
 // Unary case.
-template <typename mag_t>
-struct product<mag_t> { using type = mag_t; };
+template <Magnitude M>
+struct product<M> { using type = M; };
 
 // Binary case, where right argument is null magnitude.
-template <typename mag_t>
-struct product<mag_t, magnitude<>> { using type = mag_t; };
+template <Magnitude M>
+struct product<M, magnitude<>> { using type = M; };
 
 // Binary case, where left argument is null magnitude, and right is non-null.
 template <typename head, typename... tail>
@@ -187,10 +187,10 @@ struct product<magnitude<base_power<base, pow1>, tail1...>,
 };
 
 // N-ary case (N > 2).
-template <typename mag_a, typename mag_b, typename... tail>
-struct product<mag_a, mag_b, tail...>
+template <Magnitude T, Magnitude U, typename... tail>
+struct product<T, U, tail...>
 {
-  using type = product_t<product_t<mag_a, mag_b>, tail...>;
+  using type = product_t<product_t<T, U>, tail...>;
 };
 
 } // namespace units::mag

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -170,7 +170,7 @@ constexpr std::intmax_t remove_power(std::intmax_t base, std::intmax_t pow, std:
 
 // Helpers to perform prime factorization at compile time.
 template<std::intmax_t N>
-  requires requires { N > 0; }
+  requires (N > 0)
 struct prime_factorization;
 
 template<std::intmax_t N>
@@ -248,7 +248,7 @@ concept Magnitude = detail::is_magnitude<T>::value;
  * manually adding base powers.
  */
 template<ratio R>
-  requires requires { R.num > 0; }
+  requires (R.num > 0)
 constexpr Magnitude auto as_magnitude();
 
 /**
@@ -328,7 +328,7 @@ constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * invers
 // `as_magnitude()` implementation.
 
 template<ratio R>
-  requires requires { R.num > 0; }
+  requires (R.num > 0)
 constexpr Magnitude auto as_magnitude() {
   return detail::prime_factorization_v<R.num> / detail::prime_factorization_v<R.den>;
 }
@@ -337,7 +337,7 @@ namespace detail
 {
 // Default implementation.
 template<std::intmax_t N>
-  requires requires { N > 0; }
+  requires (N > 0)
 struct prime_factorization {
   static constexpr int first_base = find_first_factor(N);
   static constexpr std::intmax_t first_power = multiplicity(first_base, N);

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -103,9 +103,9 @@ base_power(T) -> base_power<int>;
 // Implementation for BasePower concept (below).
 namespace detail {
 template<typename T>
-struct is_base_power : std::false_type {};
+static constexpr bool is_base_power = false;
 template<BaseRep T>
-struct is_base_power<base_power<T>> : std::true_type {};
+static constexpr bool is_base_power<base_power<T>> = true;
 } // namespace detail
 
 /**
@@ -115,7 +115,7 @@ struct is_base_power<base_power<T>> : std::true_type {};
  * `magnitude<...>`.  We will defer that second check to the constraints on the `magnitude` template.
  */
 template<typename T>
-concept BasePower = detail::is_base_power<T>::value;
+concept BasePower = detail::is_base_power<T>;
 
 /**
  * @brief  Equality detection for two base powers.
@@ -230,16 +230,16 @@ struct magnitude {};
 // Implementation for Magnitude concept (below).
 namespace detail {
 template<typename T>
-struct is_magnitude : std::false_type {};
+static constexpr bool is_magnitude = false;
 template<BasePower auto... BPs>
-struct is_magnitude<magnitude<BPs...>> : std::true_type {};
+static constexpr bool is_magnitude<magnitude<BPs...>> = true;
 } // namespace detail
 
 /**
  * @brief  Concept to detect whether T is a valid Magnitude.
  */
 template<typename T>
-concept Magnitude = detail::is_magnitude<T>::value;
+concept Magnitude = detail::is_magnitude<T>;
 
 /**
  * @brief  Convert any positive integer to a Magnitude.

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -287,12 +287,14 @@ constexpr auto operator*(Magnitude auto m, magnitude<>) { return m; }
 // Recursive case for the product of any two non-identity Magnitudes.
 template<BasePower auto H1, BasePower auto... T1, BasePower auto H2, BasePower auto... T2>
 constexpr auto operator*(magnitude<H1, T1...>, magnitude<H2, T2...>) {
-  // Shortcut for the "pure prepend" case, which makes it easier to implement some of the other cases.
-  if constexpr ((sizeof...(T1) == 0) && H1.get_base() < H2.get_base()) { return magnitude<H1, H2, T2...>{}; }
-
   // Case for when H1 has the smaller base.
   if constexpr(H1.get_base() < H2.get_base()){
-    return magnitude<H1>{} * (magnitude<T1...>{} * magnitude<H2, T2...>{});
+    if constexpr (sizeof...(T1) == 0) {
+      // Shortcut for the "pure prepend" case, which makes it easier to implement some of the other cases.
+      return magnitude<H1, H2, T2...>{};
+    } else {
+      return magnitude<H1>{} * (magnitude<T1...>{} * magnitude<H2, T2...>{});
+    }
   }
 
   // Case for when H2 has the smaller base.

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -167,14 +167,6 @@ constexpr std::intmax_t remove_power(std::intmax_t base, std::intmax_t pow, std:
   return n;
 }
 
-// Helpers to perform prime factorization at compile time.
-template<std::intmax_t N>
-  requires (N > 0)
-struct prime_factorization;
-
-template<std::intmax_t N>
-static constexpr auto prime_factorization_v = prime_factorization<N>::value;
-
 // A way to check whether a number is prime at compile time.
 constexpr bool is_prime(std::intmax_t n) { return (n > 1) && (find_first_factor(n) == n); }
 
@@ -325,7 +317,7 @@ constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * pow<-1
 // `as_magnitude()` implementation.
 
 namespace detail {
-// Default implementation.
+// Helper to perform prime factorization at compile time.
 template<std::intmax_t N>
   requires (N > 0)
 struct prime_factorization {
@@ -340,6 +332,9 @@ struct prime_factorization {
 // Specialization for the prime factorization of 1 (base case).
 template<>
 struct prime_factorization<1> { static constexpr magnitude<> value{}; };
+
+template<std::intmax_t N>
+static constexpr auto prime_factorization_v = prime_factorization<N>::value;
 } // namespace detail
 
 template<ratio R>

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -261,10 +261,11 @@ struct product<magnitude<base_power<Base, Pow1>, Tail1...>,
                magnitude<base_power<Base, Pow2>, Tail2...>>
 {
   using tail_product = product_t<magnitude<Tail1...>, magnitude<Tail2...>>;
+  static inline constexpr auto Pow = Pow1 + Pow2;
   using type = std::conditional_t<
-    ((Pow1 + Pow2).num == 0),
+    Pow.num == 0,
     tail_product,
-    prepend_base_t<base_power<Base, Pow1 + Pow2>, tail_product>>;
+    prepend_base_t<base_power<Base, Pow>, tail_product>>;
 };
 
 // N-ary case (N > 2).

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -26,37 +26,49 @@
 #include <cstdint>
 #include <numbers>
 
-namespace units::mag
-{
+namespace units::mag {
 
-namespace detail
-{
-// Helpers to perform prime factorization at compile time.
-template<std::intmax_t N>
-  requires requires { N > 0; }
-struct prime_factorization;
-template<std::intmax_t N>
-static constexpr auto prime_factorization_v = prime_factorization<N>::value;
-
-// A way to check whether a number is prime at compile time.
-constexpr bool is_prime(std::intmax_t n);
-} // namespace detail
-
-// Integer rep is for prime numbers; long double is for any irrational base we permit.
+/**
+ * @brief  Any type which can be used as a basis vector in a BasePower.
+ *
+ * We have two categories.
+ *
+ * The first is just an `int`.  This is for prime number bases.  These can always be used directly as NTTPs.
+ *
+ * The second category is a _custom type_, which has a static member variable of type `long double` that holds its
+ * value.  We choose `long double` to get the greatest degree of precision; users who need a different type can convert
+ * from this at compile time.  This category is for any irrational base we admit into our representation (on which, more
+ * details below).
+ *
+ * The reason we can't hold the value directly for floating point bases is so that we can support some compilers (e.g.,
+ * GCC 10) which don't yet permit floating point NTTPs.
+ */
 template<typename T>
 concept BaseRep = std::is_same_v<T, int> || std::is_same_v<std::remove_cvref_t<decltype(T::value)>, long double>;
 
 /**
  * @brief  A basis vector in our magnitude representation, raised to some rational power.
  *
- * The set of basis vectors must be linearly independent: that is, no product of basis powers can ever equal 1, unless
- * all exponents are zero.  To achieve this, we use the following kinds of basis vectors.
+ * The public API is that there is a `power` member variable (of type `ratio`), and a `get_base()` member function (of
+ * type either `int` or `long double`, as appropriate), for any specialization.
+ *
+ * These types exist to be used as NTTPs for the variadic `magnitude<...>` template.  We represent a magnitude (which is
+ * a positive real number) as the product of rational powers of "basis vectors", where each "basis vector" is a positive
+ * real number.  "Addition" in this vector space corresponds to _multiplying_ two real numbers.  "Scalar multiplication"
+ * corresponds to _raising_ a real number to a _rational power_.  Thus, this representation of positive real numbers
+ * maps them onto a vector space over the rationals, supporting the operations of products and rational powers.
+ *
+ * (Note that this is the same representation we already use for dimensions.)
+ *
+ * As in any vector space, the set of basis vectors must be linearly independent: that is, no product of basis powers
+ * can ever give the null vector (which in this case represents the number 1), unless all scalars (again, in this case,
+ * _powers_) are zero.  To achieve this, we use the following kinds of basis vectors.
  *   - Prime numbers.  (These are the only allowable values for `int` base.)
  *   - Certain selected irrational numbers, such as pi.
  *
  * Before allowing a new irrational base, make sure that it _cannot_ be represented as the product of rational powers of
- * _existing_ bases, including both prime numbers and any other irrational bases.  For example, even though sqrt(2) is
- * irrational, we must not ever use it as a base
+ * _existing_ bases, including both prime numbers and any other irrational bases.  For example, even though `sqrt(2)` is
+ * irrational, we must not ever use it as a base; instead, we would use `base_power{2, ratio{1, 2}}`.
  */
 template<BaseRep T>
 struct base_power {
@@ -66,9 +78,12 @@ struct base_power {
   constexpr long double get_base() const { return T::value; }
 };
 
+/**
+ * @brief  Specialization for prime number bases.
+ */
 template<>
 struct base_power<int> {
-  // The value of the basis "vector".
+  // The value of the basis "vector".  Must be prime to be used with `magnitude` (below).
   int base;
 
   // The rational power to which the base is raised.
@@ -77,103 +92,88 @@ struct base_power<int> {
   constexpr int get_base() const { return base; }
 };
 
-template<BaseRep T, std::convertible_to<ratio> U>
-base_power(T, U) -> base_power<T>;
+/**
+ * @brief  Deduction guides for base_power: only permit deducing integral bases.
+ */
+template<std::integral T, std::convertible_to<ratio> U>
+base_power(T, U) -> base_power<int>;
+template<std::integral T>
+base_power(T) -> base_power<int>;
 
-template<BaseRep T>
-base_power(T) -> base_power<T>;
-
-template<typename T, typename U>
-constexpr bool operator==(base_power<T> t, base_power<U> u) {
-  return std::is_same_v<T, U> && (t.get_base() == u.get_base()) && (t.power == u.power);
-}
-
-template<BaseRep T>
-constexpr auto inverse(base_power<T> bp) {
-  bp.power = -bp.power;
-  return bp;
-}
-
-namespace detail
-{
-template<BaseRep T>
-constexpr bool is_valid_base_power(const base_power<T> &bp) {
-  if (bp.power == 0) { return false; }
-
-  if constexpr (std::is_same_v<T, int>) { return is_prime(bp.get_base()); }
-  else if constexpr (std::is_same_v<T, long double>) { return bp.get_base() > 0; }
-  else { return false; }  // Unreachable.
-}
-
+// Implementation for BasePower concept (below).
+namespace detail {
 template<typename T>
 struct is_base_power : std::false_type {};
 template<BaseRep T>
 struct is_base_power<base_power<T>> : std::true_type {};
 } // namespace detail
 
+/**
+ * @brief  Concept to detect whether a _type_ is a valid base power.
+ *
+ * Note that this is somewhat incomplete.  We must also detect whether a _value_ of that type is valid for use with
+ * `magnitude<...>`.  We will defer that second check to the constraints on the `magnitude` template.
+ */
 template<typename T>
 concept BasePower = detail::is_base_power<T>::value;
 
+/**
+ * @brief  Equality detection for two base powers.
+ */
+template<BasePower T, BasePower U>
+constexpr bool operator==(T t, U u) {
+  return std::is_same_v<T, U> && (t.get_base() == u.get_base()) && (t.power == u.power);
+}
+
+/**
+ * @brief  The (multiplicative) inverse of a BasePower.
+ */
+template<BasePower BP>
+constexpr auto inverse(BP bp) {
+  bp.power = -bp.power;
+  return bp;
+}
+
+// Implementation helpers for `magnitude<...>` constraints (below).
+namespace detail {
+constexpr bool is_valid_base_power(const BasePower auto &bp);
+
 template<typename... Ts>
 constexpr bool strictly_increasing(Ts&&... ts);
+} // namespace detail
 
 /**
  * @brief  A representation for positive real numbers which optimizes taking products and rational powers.
  *
  * Magnitudes can be treated as values.  Each type encodes exactly one value.  Users can multiply, divide, and compare
- * for equality using this value API.
+ * for equality.
  */
 template<BasePower auto... BPs>
   requires requires {
-    (detail::is_valid_base_power(BPs) && ... && strictly_increasing(BPs.get_base()...));
+    (detail::is_valid_base_power(BPs) && ... && detail::strictly_increasing(BPs.get_base()...));
   }
 struct magnitude {};
 
-template<BasePower auto... LeftBPs, BasePower auto... RightBPs>
-constexpr bool operator==(magnitude<LeftBPs...>, magnitude<RightBPs...>) {
-  if constexpr (sizeof...(LeftBPs) == sizeof...(RightBPs)) { return ((LeftBPs == RightBPs) && ...); }
-  else { return false; }
-}
-
+// Implementation for Magnitude concept (below).
+namespace detail {
+template<typename T>
+struct is_magnitude : std::false_type {};
 template<BasePower auto... BPs>
-constexpr auto inverse(magnitude<BPs...>) { return magnitude<inverse(BPs)...>{}; }
+struct is_magnitude<magnitude<BPs...>> : std::true_type {};
+} // namespace detail
 
-constexpr auto operator*(magnitude<>, magnitude<>) { return magnitude<>{}; }
+/**
+ * @brief  Concept to detect whether T is a valid Magnitude.
+ */
+template<typename T>
+concept Magnitude = detail::is_magnitude<T>::value;
 
-template<BasePower auto... BPs>
-constexpr auto operator*(magnitude<>, magnitude<BPs...> m) { return m; }
-
-template<BasePower auto... BPs>
-constexpr auto operator*(magnitude<BPs...> m, magnitude<>) { return m; }
-
-template<BasePower auto H1, BasePower auto... T1, BasePower auto H2, BasePower auto... T2>
-constexpr auto operator*(magnitude<H1, T1...>, magnitude<H2, T2...>) {
-  // Shortcut for prepending, which makes it easier to implement some of the other cases.
-  if constexpr ((sizeof...(T1) == 0) && H1.get_base() < H2.get_base()) { return magnitude<H1, H2, T2...>{}; }
-
-  if constexpr (H1.get_base() == H2.get_base()) {
-    constexpr auto partial_product = magnitude<T1...>{} * magnitude<T2...>{};
-
-    // Make a new base_power with the common base of H1 and H2, whose power is their powers' sum.
-    constexpr auto new_head = [&](auto head) {
-      head.power = H1.power + H2.power;
-      return head;
-    }(H1);
-
-    if constexpr (new_head.power == 0) {
-      return partial_product;
-    } else {
-      return magnitude<new_head>{} * partial_product;
-    }
-  } else if constexpr(H1.get_base() < H2.get_base()){
-    return magnitude<H1>{} * (magnitude<T1...>{} * magnitude<H2, T2...>{});
-  } else { // We know H2.get_base() < H1.get_base()
-    return magnitude<H2>{} * (magnitude<H1, T1...>{} * magnitude<T2...>{});
-  }
-}
-
-template<BasePower auto... LeftBPs, BasePower auto... RightBPs>
-constexpr auto operator/(magnitude<LeftBPs...> l, magnitude<RightBPs...> r) { return l * inverse(r); }
+/**
+ * @brief  Convert any positive integer to a Magnitude.
+ */
+template<std::integral auto N>
+  requires requires { N > 0; }
+constexpr Magnitude auto as_magnitude();
 
 /**
  * @brief  Make a Magnitude that is a rational number.
@@ -182,7 +182,7 @@ constexpr auto operator/(magnitude<LeftBPs...> l, magnitude<RightBPs...> r) { re
  * manually adding base powers.
  */
 template<std::intmax_t N, std::intmax_t D = 1>
-constexpr auto make_ratio() { return detail::prime_factorization_v<N> / detail::prime_factorization_v<D>; }
+constexpr auto make_ratio() { return as_magnitude<N>() / as_magnitude<D>(); }
 
 /**
  * @brief  A base to represent pi.
@@ -191,6 +191,9 @@ struct pi_base {
   static constexpr long double value = std::numbers::pi_v<long double>;
 };
 
+/**
+ * @brief  A simple way to create a Magnitude representing a rational power of pi.
+ */
 template<ratio Power>
 constexpr auto pi_to_the() { return magnitude<base_power<pi_base>{Power}>{}; }
 
@@ -198,41 +201,8 @@ constexpr auto pi_to_the() { return magnitude<base_power<pi_base>{Power}>{}; }
 // Implementation details below.
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Magnitude concept implementation.
-
-template<typename Predicate>
-struct pairwise_all {
-  Predicate predicate;
-
-  template<typename... Ts>
-  constexpr bool operator()(Ts&&... ts) const {
-    // Carefully handle different sizes, avoiding unsigned integer underflow.
-    constexpr auto num_comparisons = [](auto num_elements) {
-      return (num_elements > 1) ? (num_elements - 1) : 0;
-    }(sizeof...(Ts));
-
-    // Compare zero or more pairs of neighbours as needed.
-    return [this]<std::size_t... Is>(std::tuple<Ts...> &&t, std::index_sequence<Is...>) {
-      return (predicate(std::get<Is>(t), std::get<Is + 1>(t)) && ...);
-    }(std::make_tuple(std::forward<Ts>(ts)...), std::make_index_sequence<num_comparisons>());
-  }
-};
-
-template<typename T>
-pairwise_all(T) -> pairwise_all<T>;
-
-// Check whether a tuple of (possibly heterogeneously typed) values are strictly increasing.
-template<typename... Ts>
-constexpr bool strictly_increasing(Ts&&... ts) {
-  return pairwise_all{std::less{}}(std::forward<Ts>(ts)...);
-}
-
 namespace detail
 {
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Prime factorization implementation.
 
 // Find the smallest prime factor of `n`.
 constexpr std::intmax_t find_first_factor(std::intmax_t n)
@@ -265,11 +235,7 @@ constexpr std::intmax_t remove_power(std::intmax_t base, std::intmax_t pow, std:
   return n;
 }
 
-// Specialization for the prime factorization of 1 (base case).
-template<>
-struct prime_factorization<1> { static constexpr magnitude<> value{}; };
-
-// Specialization for the prime factorization of larger numbers (recursive case).
+// Helpers to perform prime factorization at compile time.
 template<std::intmax_t N>
   requires requires { N > 0; }
 struct prime_factorization {
@@ -278,10 +244,122 @@ struct prime_factorization {
   static constexpr std::intmax_t remainder = remove_power(first_base, first_power, N);
 
   static constexpr auto value = magnitude<base_power{first_base, first_power}>{}
-      * prime_factorization_v<remainder>;
+      * prime_factorization<remainder>::value;
 };
 
+template<std::intmax_t N>
+static constexpr auto prime_factorization_v = prime_factorization<N>::value;
+
+// Specialization for the prime factorization of 1 (base case).
+template<>
+struct prime_factorization<1> { static constexpr magnitude<> value{}; };
+
+// A way to check whether a number is prime at compile time.
 constexpr bool is_prime(std::intmax_t n) { return (n > 1) && (find_first_factor(n) == n); }
 
+constexpr bool is_valid_base_power(const BasePower auto &bp) {
+  if (bp.power == 0) { return false; }
+
+  if constexpr (std::is_same_v<decltype(bp.get_base()), int>) { return is_prime(bp.get_base()); }
+  else { return bp.get_base() > 0; }
+}
+
+// A function object to apply a predicate to all consecutive pairs of values in a sequence.
+template<typename Predicate>
+struct pairwise_all {
+  Predicate predicate;
+
+  template<typename... Ts>
+  constexpr bool operator()(Ts&&... ts) const {
+    // Carefully handle different sizes, avoiding unsigned integer underflow.
+    constexpr auto num_comparisons = [](auto num_elements) {
+      return (num_elements > 1) ? (num_elements - 1) : 0;
+    }(sizeof...(Ts));
+
+    // Compare zero or more pairs of neighbours as needed.
+    return [this]<std::size_t... Is>(std::tuple<Ts...> &&t, std::index_sequence<Is...>) {
+      return (predicate(std::get<Is>(t), std::get<Is + 1>(t)) && ...);
+    }(std::make_tuple(std::forward<Ts>(ts)...), std::make_index_sequence<num_comparisons>());
+  }
+};
+
+// Deduction guide: permit constructions such as `pairwise_all{std::less{}}`.
+template<typename T>
+pairwise_all(T) -> pairwise_all<T>;
+
+// Check whether a sequence of (possibly heterogeneously typed) values are strictly increasing.
+template<typename... Ts>
+constexpr bool strictly_increasing(Ts&&... ts) {
+  return pairwise_all{std::less{}}(std::forward<Ts>(ts)...);
+}
+
 } // namespace detail
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Magnitude equality implementation.
+
+template<BasePower auto... LeftBPs, BasePower auto... RightBPs>
+constexpr bool operator==(magnitude<LeftBPs...>, magnitude<RightBPs...>) {
+  if constexpr (sizeof...(LeftBPs) == sizeof...(RightBPs)) { return ((LeftBPs == RightBPs) && ...); }
+  else { return false; }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Magnitude inverse implementation.
+
+template<BasePower auto... BPs>
+constexpr auto inverse(magnitude<BPs...>) { return magnitude<inverse(BPs)...>{}; }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Magnitude product implementation.
+
+// Base cases, for when either (or both) inputs are the identity.
+constexpr auto operator*(magnitude<>, magnitude<>) { return magnitude<>{}; }
+constexpr auto operator*(magnitude<>, Magnitude auto m) { return m; }
+constexpr auto operator*(Magnitude auto m, magnitude<>) { return m; }
+
+// Recursive case for the product of any two non-identity Magnitudes.
+template<BasePower auto H1, BasePower auto... T1, BasePower auto H2, BasePower auto... T2>
+constexpr auto operator*(magnitude<H1, T1...>, magnitude<H2, T2...>) {
+  // Shortcut for the "pure prepend" case, which makes it easier to implement some of the other cases.
+  if constexpr ((sizeof...(T1) == 0) && H1.get_base() < H2.get_base()) { return magnitude<H1, H2, T2...>{}; }
+
+  // "Same leading base" case.
+  if constexpr (H1.get_base() == H2.get_base()) {
+    constexpr auto partial_product = magnitude<T1...>{} * magnitude<T2...>{};
+
+    // Make a new base_power with the common base of H1 and H2, whose power is their powers' sum.
+    constexpr auto new_head = [&](auto head) {
+      head.power = H1.power + H2.power;
+      return head;
+    }(H1);
+
+    if constexpr (new_head.power == 0) {
+      return partial_product;
+    } else {
+      return magnitude<new_head>{} * partial_product;
+    }
+  }
+  // Case for when H1 has the smaller base.
+  else if constexpr(H1.get_base() < H2.get_base()){
+    return magnitude<H1>{} * (magnitude<T1...>{} * magnitude<H2, T2...>{});
+  }
+  // Case for when H2 has the smaller base.
+  else {
+    return magnitude<H2>{} * (magnitude<H1, T1...>{} * magnitude<T2...>{});
+  }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Magnitude quotient implementation.
+
+constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * inverse(r); }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// `as_magnitude()` implementation.
+
+template<std::integral auto N>
+  requires requires { N > 0; }
+constexpr Magnitude auto as_magnitude() { return detail::prime_factorization_v<N>; }
+
 } // namespace units::mag

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -306,12 +306,14 @@ constexpr auto operator*(magnitude<H1, T1...>, magnitude<H2, T2...>) {
       return magnitude<new_head>{} * partial_product;
     }
   }
+
   // Case for when H1 has the smaller base.
-  else if constexpr(H1.get_base() < H2.get_base()){
+  if constexpr(H1.get_base() < H2.get_base()){
     return magnitude<H1>{} * (magnitude<T1...>{} * magnitude<H2, T2...>{});
   }
+
   // Case for when H2 has the smaller base.
-  else {
+  if constexpr(H1.get_base() > H2.get_base()){
     return magnitude<H2>{} * (magnitude<H1, T1...>{} * magnitude<T2...>{});
   }
 }

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -54,10 +54,10 @@ inline constexpr bool is_magnitude_v = is_magnitude<T>::value;
 template <typename T>
 concept Magnitude = is_magnitude_v<T>;
 
-template <std::intmax_t n>
-struct int_base : std::integral_constant<std::intmax_t, n> {};
-template <std::intmax_t n, std::intmax_t num = 1, std::intmax_t den = 1>
-using int_base_power = base_power<int_base<n>, ratio{num, den}>;
+template <std::intmax_t N>
+struct int_base : std::integral_constant<std::intmax_t, N> {};
+template <std::intmax_t N, std::intmax_t num = 1, std::intmax_t den = 1>
+using int_base_power = base_power<int_base<N>, ratio{num, den}>;
 
 template <Magnitude M>
 struct inverse;
@@ -74,10 +74,10 @@ using quotient_t = product_t<T, inverse_t<U>>;
 
 namespace detail
 {
-template <std::intmax_t n>
+template <std::intmax_t N>
 struct prime_factorization;
-template <std::intmax_t n>
-using prime_factorization_t = typename prime_factorization<n>::type;
+template <std::intmax_t N>
+using prime_factorization_t = typename prime_factorization<N>::type;
 } // namespace detail
 
 template <std::intmax_t num = 1, std::intmax_t den = 1>

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -211,6 +211,7 @@ pairwise_all(T) -> pairwise_all<T>;
 
 // Check whether a sequence of (possibly heterogeneously typed) values are strictly increasing.
 template<typename... Ts>
+  requires ((std::is_signed_v<Ts> && ...))
 constexpr bool strictly_increasing(Ts&&... ts) {
   return pairwise_all{std::less{}}(std::forward<Ts>(ts)...);
 }

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -81,7 +81,7 @@ using prime_factorization_t = typename prime_factorization<N>::type;
 } // namespace detail
 
 template <std::intmax_t N, std::intmax_t D = 1>
-auto make_ratio() {
+constexpr auto make_ratio() {
   return quotient_t<detail::prime_factorization_t<N>, detail::prime_factorization_t<D>>{};
 }
 
@@ -95,10 +95,14 @@ struct pi {
 
 template <BasePower... Bs>
 struct magnitude {
-  bool operator==(magnitude) const { return true; }
+  template <Magnitude M>
+  constexpr bool operator==(M) const { return std::is_same_v<magnitude, M>; }
 
-  template <BasePower... OtherBs>
-  bool operator==(magnitude<OtherBs...>) const { return false; }
+  template <Magnitude M>
+  constexpr friend auto operator*(magnitude, M) { return product_t<magnitude, M>{}; }
+
+  template <Magnitude M>
+  constexpr friend auto operator/(magnitude, M) { return quotient_t<magnitude, M>{}; }
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -1,0 +1,161 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include <units/ratio.h>
+#include <cstdint>
+
+namespace units::mag
+{
+
+// A `magnitude` represents a positive real number in a format which optimizes taking products and
+// rational powers.
+template <typename... base_powers>
+struct magnitude;
+
+template <typename mag_t>
+struct inverse;
+template <typename mag_t>
+using inverse_t = typename inverse<mag_t>::type;
+
+template <typename... mags>
+struct product;
+template <typename... mags>
+using product_t = typename product<mags...>::type;
+
+template <typename mag1, typename mag2>
+using quotient_t = product_t<mag1, inverse_t<mag2>>;
+
+namespace detail
+{
+template <std::intmax_t n>
+struct prime_factorization;
+template <std::intmax_t n>
+using prime_factorization_t = typename prime_factorization<n>::type;
+} // namespace detail
+
+template <typename... base_powers>
+struct magnitude {
+  bool operator==(magnitude) const { return true; }
+
+  template <typename... other_base_powers>
+  bool operator==(magnitude<other_base_powers...>) const { return false; }
+};
+
+template <std::intmax_t num = 1, std::intmax_t den = 1>
+using ratio_t = quotient_t<detail::prime_factorization_t<num>, detail::prime_factorization_t<den>>;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Implementation details below.
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Base powers.
+
+template <typename base, ratio power = ratio{1}>
+struct base_power;
+
+template <std::intmax_t n>
+struct int_base : std::integral_constant<std::intmax_t, n> {};
+template <std::intmax_t n, std::intmax_t num = 1, std::intmax_t den = 1>
+using int_base_power = base_power<int_base<n>, ratio{num, den}>;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Inverse implementation.
+
+template <typename... bases, ratio... powers>
+struct inverse<magnitude<base_power<bases, powers>...>> {
+  using type = magnitude<base_power<bases, -powers>...>;
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Product implementation.
+
+// Convenience utility to prepend a base_power to a magnitude.
+//
+// Assumes that the prepended power has a smaller base than every base power in the magnitude.
+template <typename new_base, typename mag_t>
+struct prepend_base;
+template <typename new_base, typename mag_t>
+using prepend_base_t = typename prepend_base<new_base, mag_t>::type;
+template <typename new_base, typename... old_bases>
+struct prepend_base<new_base, magnitude<old_bases...>> {
+  using type = magnitude<new_base, old_bases...>;
+};
+
+// Nullary case.
+template <>
+struct product<> { using type = magnitude<>; };
+
+// Unary case.
+template <typename mag_t>
+struct product<mag_t> { using type = mag_t; };
+
+// Binary case, where right argument is null magnitude.
+template <typename mag_t>
+struct product<mag_t, magnitude<>> { using type = mag_t; };
+
+// Binary case, where left argument is null magnitude, and right is non-null.
+template <typename head, typename... tail>
+struct product<magnitude<>, magnitude<head, tail...>> { using type = magnitude<head, tail...>; };
+
+// Binary case, with distinct heads.
+template <
+  typename base1,
+  ratio pow1,
+  typename... tail1,
+  typename base2,
+  ratio pow2,
+  typename... tail2>
+struct product<magnitude<base_power<base1, pow1>, tail1...>,
+               magnitude<base_power<base2, pow2>, tail2...>>
+{
+  using mag1 = magnitude<base_power<base1, pow1>, tail1...>;
+  using mag2 = magnitude<base_power<base2, pow2>, tail2...>;
+
+  using type = std::conditional_t<
+    (base1::value < base2::value),
+    prepend_base_t<base_power<base1, pow1>, product_t<magnitude<tail1...>, mag2>>,
+    prepend_base_t<base_power<base2, pow2>, product_t<mag1, magnitude<tail2...>>>>;
+};
+
+// Binary case, same head.
+template <typename base, ratio pow1, ratio pow2, typename... tail1, typename... tail2>
+struct product<magnitude<base_power<base, pow1>, tail1...>,
+               magnitude<base_power<base, pow2>, tail2...>>
+{
+  using tail_product = product_t<magnitude<tail1...>, magnitude<tail2...>>;
+  using type = std::conditional_t<
+    ((pow1 + pow2).num == 0),
+    tail_product,
+    prepend_base_t<base_power<base, pow1 + pow2>, tail_product>>;
+};
+
+// N-ary case (N > 2).
+template <typename mag_a, typename mag_b, typename... tail>
+struct product<mag_a, mag_b, tail...>
+{
+  using type = product_t<product_t<mag_a, mag_b>, tail...>;
+};
+
+} // namespace units::mag

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -259,12 +259,6 @@ struct pi_base {
   static constexpr long double value = std::numbers::pi_v<long double>;
 };
 
-/**
- * @brief  A simple way to create a Magnitude representing a rational power of pi.
- */
-template<ratio Power>
-constexpr auto pi_to_the() { return magnitude<base_power<pi_base>{Power}>{}; }
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Magnitude equality implementation.
 

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -290,6 +290,16 @@ constexpr auto operator*(magnitude<H1, T1...>, magnitude<H2, T2...>) {
   // Shortcut for the "pure prepend" case, which makes it easier to implement some of the other cases.
   if constexpr ((sizeof...(T1) == 0) && H1.get_base() < H2.get_base()) { return magnitude<H1, H2, T2...>{}; }
 
+  // Case for when H1 has the smaller base.
+  if constexpr(H1.get_base() < H2.get_base()){
+    return magnitude<H1>{} * (magnitude<T1...>{} * magnitude<H2, T2...>{});
+  }
+
+  // Case for when H2 has the smaller base.
+  if constexpr(H1.get_base() > H2.get_base()){
+    return magnitude<H2>{} * (magnitude<H1, T1...>{} * magnitude<T2...>{});
+  }
+
   // "Same leading base" case.
   if constexpr (H1.get_base() == H2.get_base()) {
     constexpr auto partial_product = magnitude<T1...>{} * magnitude<T2...>{};
@@ -305,16 +315,6 @@ constexpr auto operator*(magnitude<H1, T1...>, magnitude<H2, T2...>) {
     } else {
       return magnitude<new_head>{} * partial_product;
     }
-  }
-
-  // Case for when H1 has the smaller base.
-  if constexpr(H1.get_base() < H2.get_base()){
-    return magnitude<H1>{} * (magnitude<T1...>{} * magnitude<H2, T2...>{});
-  }
-
-  // Case for when H2 has the smaller base.
-  if constexpr(H1.get_base() > H2.get_base()){
-    return magnitude<H2>{} * (magnitude<H1, T1...>{} * magnitude<T2...>{});
   }
 }
 

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -170,19 +170,13 @@ concept Magnitude = detail::is_magnitude<T>::value;
 
 /**
  * @brief  Convert any positive integer to a Magnitude.
- */
-template<std::integral auto N>
-  requires requires { N > 0; }
-constexpr Magnitude auto as_magnitude();
-
-/**
- * @brief  Make a Magnitude that is a rational number.
  *
  * This will be the main way end users create Magnitudes.  They should rarely (if ever) create a magnitude<...> by
  * manually adding base powers.
  */
-template<std::intmax_t N, std::intmax_t D = 1>
-constexpr auto make_ratio() { return as_magnitude<N>() / as_magnitude<D>(); }
+template<ratio R>
+  requires requires { R.num > 0; }
+constexpr Magnitude auto as_magnitude();
 
 /**
  * @brief  A base to represent pi.
@@ -358,8 +352,10 @@ constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * invers
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // `as_magnitude()` implementation.
 
-template<std::integral auto N>
-  requires requires { N > 0; }
-constexpr Magnitude auto as_magnitude() { return detail::prime_factorization_v<N>; }
+template<ratio R>
+  requires requires { R.num > 0; }
+constexpr Magnitude auto as_magnitude() {
+  return detail::prime_factorization_v<R.num> / detail::prime_factorization_v<R.den>;
+}
 
 } // namespace units::mag

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -42,7 +42,7 @@ namespace units::mag
 template<typename Base, ratio Power = ratio{1}>
 struct base_power {
   using base = Base;
-  static inline constexpr ratio power = Power;
+  static constexpr ratio power = Power;
 };
 
 /**
@@ -147,7 +147,7 @@ constexpr auto make_base_power() {
  * @brief  A base to represent pi.
  */
 struct pi {
-  static inline constexpr long double value = std::numbers::pi_v<long double>;
+  static constexpr long double value = std::numbers::pi_v<long double>;
 };
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -261,7 +261,7 @@ struct product<magnitude<base_power<Base, Pow1>, Tail1...>,
                magnitude<base_power<Base, Pow2>, Tail2...>>
 {
   using tail_product = product_t<magnitude<Tail1...>, magnitude<Tail2...>>;
-  static inline constexpr auto Pow = Pow1 + Pow2;
+  static constexpr auto Pow = Pow1 + Pow2;
   using type = std::conditional_t<
     Pow.num == 0,
     tail_product,
@@ -318,9 +318,9 @@ template<std::intmax_t N>
 struct prime_factorization {
   static_assert(N > 1, "Can only factor positive integers.");
 
-  static inline constexpr std::intmax_t first_base = find_first_factor(N);
-  static inline constexpr std::intmax_t first_power = multiplicity(first_base, N);
-  static inline constexpr std::intmax_t remainder = remove_power(first_base, first_power, N);
+  static constexpr std::intmax_t first_base = find_first_factor(N);
+  static constexpr std::intmax_t first_power = multiplicity(first_base, N);
+  static constexpr std::intmax_t remainder = remove_power(first_base, first_power, N);
 
   using type = product_t<
     magnitude<base_power<prime_base<first_base>, ratio{first_power}>>, prime_factorization_t<remainder>>;

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -103,8 +103,10 @@ namespace detail
 {
 // Helpers to perform prime factorization at compile time.
 template<std::intmax_t N>
+  requires requires { N > 0; }
 struct prime_factorization;
 template<std::intmax_t N>
+  requires requires { N > 0; }
 using prime_factorization_t = typename prime_factorization<N>::type;
 
 // A way to check whether a number is prime at compile time.
@@ -115,9 +117,8 @@ constexpr bool is_prime(std::intmax_t n);
  * @brief  A template to represent prime number bases.
  */
 template<std::intmax_t N>
-struct prime_base : std::integral_constant<std::intmax_t, N> {
-  static_assert(detail::is_prime(N));
-};
+  requires requires { detail::is_prime(N); }
+struct prime_base : std::integral_constant<std::intmax_t, N> {};
 
 /**
  * @brief  Make a Magnitude that is a rational number.
@@ -320,9 +321,8 @@ struct prime_factorization<1> { using type = magnitude<>; };
 
 // Specialization for the prime factorization of larger numbers (recursive case).
 template<std::intmax_t N>
+  requires requires { N > 0; }
 struct prime_factorization {
-  static_assert(N > 1, "Can only factor positive integers.");
-
   static constexpr std::intmax_t first_base = find_first_factor(N);
   static constexpr std::intmax_t first_power = multiplicity(first_base, N);
   static constexpr std::intmax_t remainder = remove_power(first_base, first_power, N);

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -126,11 +126,11 @@ constexpr bool operator==(T t, U u) {
 }
 
 /**
- * @brief  The (multiplicative) inverse of a BasePower.
+ * @brief  A BasePower, raised to a rational power E.
  */
-template<BasePower BP>
-constexpr auto inverse(BP bp) {
-  bp.power = -bp.power;
+template<ratio E>
+constexpr auto pow(BasePower auto bp) {
+  bp.power = bp.power * E;
   return bp;
 }
 
@@ -220,8 +220,8 @@ constexpr bool strictly_increasing(Ts&&... ts) {
 /**
  * @brief  A representation for positive real numbers which optimizes taking products and rational powers.
  *
- * Magnitudes can be treated as values.  Each type encodes exactly one value.  Users can multiply, divide, and compare
- * for equality.
+ * Magnitudes can be treated as values.  Each type encodes exactly one value.  Users can multiply, divide, raise to
+ * rational powers, and compare for equality.
  */
 template<BasePower auto... BPs>
   requires ((detail::is_valid_base_power(BPs) && ... && detail::strictly_increasing(BPs.get_base()...)))
@@ -274,10 +274,13 @@ constexpr bool operator==(magnitude<LeftBPs...>, magnitude<RightBPs...>) {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Magnitude inverse implementation.
+// Magnitude rational powers implementation.
 
-template<BasePower auto... BPs>
-constexpr auto inverse(magnitude<BPs...>) { return magnitude<inverse(BPs)...>{}; }
+template<ratio E, BasePower auto... BPs>
+constexpr auto pow(magnitude<BPs...>) {
+  if constexpr (E == 0) { return magnitude<>{}; }
+  else { return magnitude<pow<E>(BPs)...>{}; }
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Magnitude product implementation.
@@ -322,7 +325,7 @@ constexpr auto operator*(magnitude<H1, T1...>, magnitude<H2, T2...>) {
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Magnitude quotient implementation.
 
-constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * inverse(r); }
+constexpr auto operator/(Magnitude auto l, Magnitude auto r) { return l * pow<-1>(r); }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // `as_magnitude()` implementation.

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -207,6 +207,14 @@ constexpr bool strictly_increasing(Ts&&... ts) {
   return pairwise_all{std::less{}}(std::forward<Ts>(ts)...);
 }
 
+template<BasePower auto... BPs>
+static constexpr bool all_base_powers_valid = (is_valid_base_power(BPs) && ...);
+
+template<BasePower auto... BPs>
+static constexpr bool all_bases_in_order = strictly_increasing(BPs.get_base()...);
+
+template<BasePower auto... BPs>
+static constexpr bool is_base_power_pack_valid = all_base_powers_valid<BPs...> && all_bases_in_order<BPs...>;
 } // namespace detail
 
 /**
@@ -216,7 +224,7 @@ constexpr bool strictly_increasing(Ts&&... ts) {
  * rational powers, and compare for equality.
  */
 template<BasePower auto... BPs>
-  requires ((detail::is_valid_base_power(BPs) && ... && detail::strictly_increasing(BPs.get_base()...)))
+  requires (detail::is_base_power_pack_valid<BPs...>)
 struct magnitude {};
 
 // Implementation for Magnitude concept (below).

--- a/src/core/include/units/ratio.h
+++ b/src/core/include/units/ratio.h
@@ -60,6 +60,27 @@ struct ratio {
 
   [[nodiscard]] friend constexpr bool operator==(const ratio&, const ratio&) = default;
 
+  [[nodiscard]] friend constexpr ratio operator-(const ratio& r)
+  {
+    return ratio(-r.num, r.den, r.exp);
+  }
+
+  [[nodiscard]] friend constexpr ratio operator+(ratio lhs, ratio rhs)
+  {
+    // First, get the inputs into a common exponent.
+    const auto common_exp = std::min(lhs.exp, rhs.exp);
+    auto commonify = [common_exp](ratio &r) {
+      while (r.exp > common_exp) {
+        r.num *= 10;
+        --r.exp;
+      }
+    };
+    commonify(lhs);
+    commonify(rhs);
+
+    return ratio{lhs.num * rhs.den + lhs.den * rhs.num, lhs.den * rhs.den, common_exp};
+  }
+
   [[nodiscard]] friend constexpr ratio operator*(const ratio& lhs, const ratio& rhs)
   {
     const std::intmax_t gcd1 = std::gcd(lhs.num, rhs.den);

--- a/src/core/include/units/ratio.h
+++ b/src/core/include/units/ratio.h
@@ -52,7 +52,7 @@ struct ratio {
   std::intmax_t den;
   std::intmax_t exp;
 
-  constexpr explicit ratio(std::intmax_t n, std::intmax_t d = 1, std::intmax_t e = 0): num(n), den(d), exp(e)
+  constexpr explicit(false) ratio(std::intmax_t n, std::intmax_t d = 1, std::intmax_t e = 0): num(n), den(d), exp(e)
   {
     gsl_Expects(den != 0);
     detail::normalize(num, den, exp);

--- a/test/unit_test/runtime/CMakeLists.txt
+++ b/test/unit_test/runtime/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(Catch2 CONFIG REQUIRED)
 add_executable(unit_tests_runtime
     catch_main.cpp
     math_test.cpp
+    magnitude_test.cpp
     fmt_test.cpp
     fmt_units_test.cpp
     distribution_test.cpp

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -330,25 +330,33 @@ TEST_CASE("is_valid_base_power")
 
 TEST_CASE("pairwise_all evaluates all pairs")
 {
+  const auto all_pairs_return_true = pairwise_all{[](auto, auto){ return true; }};
+  const auto all_pairs_return_false = pairwise_all{[](auto, auto){ return false; }};
+  const auto all_increasing = pairwise_all{std::less{}};
+
   SECTION("always true for empty tuples")
   {
-    CHECK(pairwise_all{[](auto, auto){ return true; }}());
-    CHECK(pairwise_all{[](auto, auto){ return false; }}());
+    CHECK(all_pairs_return_true());
+    CHECK(all_pairs_return_false());
   }
 
   SECTION("always true for single-element tuples")
   {
-    CHECK(pairwise_all{[](auto, auto){ return true; }}(1));
-    CHECK(pairwise_all{[](auto, auto){ return false; }}(3.14));
-    CHECK(pairwise_all{[](auto, auto){ return true; }}('x'));
+    CHECK(all_pairs_return_true(1));
+    CHECK(all_pairs_return_false(3.14));
+    CHECK(all_pairs_return_true('x'));
   }
 
   SECTION("true for longer tuples iff true for all neighbouring pairs")
   {
-    CHECK(pairwise_all{std::less{}}(1, 1.5));
-    CHECK(pairwise_all{std::less{}}(1, 1.5, 2));
-    CHECK(!pairwise_all{std::less{}}(1, 2.0, 2));
-    CHECK(!pairwise_all{std::less{}}(1, 2.5, 2));
+    CHECK(all_increasing(1, 1.5));
+    CHECK(all_increasing(1, 1.5, 2));
+
+    CHECK(!all_increasing(1, 2.0, 2));
+    CHECK(!all_increasing(1, 2.5, 2));
+
+    CHECK(all_pairs_return_true('c', 1, 8.9, 42u));
+    CHECK(!all_pairs_return_false('c', 1, 8.9, 42u));
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -378,15 +378,15 @@ TEST_CASE("pairwise_all evaluates all pairs")
 {
   SECTION("always true for empty tuples")
   {
-    CHECK(pairwise_all(std::make_tuple(), [](auto a, auto b){ return true; }));
-    CHECK(pairwise_all(std::make_tuple(), [](auto a, auto b){ return false; }));
+    CHECK(pairwise_all(std::make_tuple(), [](auto, auto){ return true; }));
+    CHECK(pairwise_all(std::make_tuple(), [](auto, auto){ return false; }));
   }
 
   SECTION("always true for single-element tuples")
   {
-    CHECK(pairwise_all(std::make_tuple(1), [](auto a, auto b){ return true; }));
-    CHECK(pairwise_all(std::make_tuple(3.14), [](auto a, auto b){ return false; }));
-    CHECK(pairwise_all(std::make_tuple('x'), [](auto a, auto b){ return true; }));
+    CHECK(pairwise_all(std::make_tuple(1), [](auto, auto){ return true; }));
+    CHECK(pairwise_all(std::make_tuple(3.14), [](auto, auto){ return false; }));
+    CHECK(pairwise_all(std::make_tuple('x'), [](auto, auto){ return true; }));
   }
 
   SECTION("true for longer tuples iff true for all neighbouring pairs")

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -98,9 +98,9 @@ TEST_CASE("base_power")
 
   SECTION("pow() multiplies exponent")
   {
-    CHECK(pow<0>(base_power{2}) == base_power{2, 0});
-    CHECK(pow<ratio{-1, 2}>(base_power{2, 3}) == base_power{2, ratio{-3, 2}});
-    CHECK(pow<ratio{1, 3}>(base_power<pi_base>{ratio{3, 2}}) == base_power<pi_base>{ratio{1, 2}});
+    CHECK(pow(base_power{2}, 0) == base_power{2, 0});
+    CHECK(pow(base_power{2, 3}, ratio{-1, 2}) == base_power{2, ratio{-3, 2}});
+    CHECK(pow(base_power<pi_base>{ratio{3, 2}}, ratio{1, 3}) == base_power<pi_base>{ratio{1, 2}});
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -32,6 +32,8 @@ namespace units::mag
 struct noninteger_base { static constexpr long double value = 1.234L; };
 struct noncanonical_two_base { static constexpr long double value = 2.0L; };
 struct other_noncanonical_two_base { static constexpr long double value = 2.0L; };
+struct invalid_zero_base { static constexpr long double value = 0.0L; };
+struct invalid_negative_base { static constexpr long double value = -1.234L; };
 
 TEST_CASE("base_power")
 {
@@ -182,6 +184,30 @@ TEST_CASE("Division works for magnitudes")
 namespace detail
 {
 
+TEST_CASE("Prime helper functions")
+{
+  SECTION("find_first_factor()") {
+    CHECK(find_first_factor(1) == 1);
+    CHECK(find_first_factor(2) == 2);
+    CHECK(find_first_factor(4) == 2);
+    CHECK(find_first_factor(6) == 2);
+    CHECK(find_first_factor(15) == 3);
+    CHECK(find_first_factor(17) == 17);
+  }
+
+  SECTION("multiplicity") {
+    CHECK(multiplicity(2, 8) == 3);
+    CHECK(multiplicity(2, 1024) == 10);
+    CHECK(multiplicity(11, 6655) == 3);
+  }
+
+  SECTION("remove_power()") {
+    CHECK(remove_power(17, 0, 5) == 5);
+    CHECK(remove_power(2, 3, 24) == 3);
+    CHECK(remove_power(11, 3, 6655) == 5);
+  }
+}
+
 TEST_CASE("Prime factorization")
 {
   SECTION ("1 factors into the null magnitude")
@@ -233,6 +259,36 @@ TEST_CASE("is_prime detects primes")
     CHECK(!is_prime(9));
 
     CHECK(is_prime(7919));
+  }
+}
+
+TEST_CASE("is_valid_base_power")
+{
+  SECTION("0 power is invalid") {
+    REQUIRE(is_valid_base_power(base_power{2}));
+    CHECK(!is_valid_base_power(base_power{2, 0}));
+
+    REQUIRE(is_valid_base_power(base_power{41}));
+    CHECK(!is_valid_base_power(base_power{41, 0}));
+
+    REQUIRE(is_valid_base_power(base_power<pi_base>{}));
+    CHECK(!is_valid_base_power(base_power<pi_base>{0}));
+  }
+
+  SECTION("non-prime integers are invalid") {
+    CHECK(!is_valid_base_power(base_power{-8}));
+    CHECK(!is_valid_base_power(base_power{0}));
+    CHECK(!is_valid_base_power(base_power{1}));
+
+    CHECK(is_valid_base_power(base_power{2}));
+    CHECK(is_valid_base_power(base_power{3}));
+
+    CHECK(!is_valid_base_power(base_power{4}));
+  }
+
+  SECTION("non-positive floating point bases are invalid") {
+    CHECK(!is_valid_base_power(base_power<invalid_zero_base>{}));
+    CHECK(!is_valid_base_power(base_power<invalid_negative_base>{}));
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -28,6 +28,9 @@
 namespace units::mag
 {
 
+template<std::intmax_t N, std::intmax_t Num = 1, std::intmax_t Den = 1>
+using int_base_power = base_power<prime_base<N>, ratio{Num, Den}>;
+
 TEST_CASE("Magnitude is invertible")
 {
   CHECK(std::is_same_v<inverse_t<magnitude<>>, magnitude<>>);
@@ -138,12 +141,6 @@ TEST_CASE("is_base_power detects well formed base powers")
     CHECK(is_base_power_v<base_power<pi, ratio{-2, 3}>>);
   }
 
-  SECTION ("base_power disqualified by negative or zero base")
-  {
-    CHECK(!is_base_power_v<int_base_power<0>>);
-    CHECK(!is_base_power_v<int_base_power<-1>>);
-  }
-
   SECTION ("base_power disqualified by base without value")
   {
     CHECK(!is_base_power_v<base_power<int>>);
@@ -238,8 +235,8 @@ TEST_CASE("make_magnitude handles arbitrary bases")
 {
   SECTION("Equivalent to std::integral_constant for integer bases")
   {
-    CHECK(make_base_power<int_base<2>>() == make_ratio<2>());
-    CHECK(make_base_power<int_base<7>>() == make_ratio<7>());
+    CHECK(make_base_power<prime_base<2>>() == make_ratio<2>());
+    CHECK(make_base_power<prime_base<7>>() == make_ratio<7>());
   }
 
   SECTION("Handles non-integer bases")
@@ -345,6 +342,35 @@ TEST_CASE("Prime factorization")
     CHECK(std::is_same_v<
         prime_factorization_t<792>,
         magnitude<int_base_power<2, 3>, int_base_power<3, 2>, int_base_power<11>>>);
+  }
+}
+
+TEST_CASE("is_prime detects primes")
+{
+  SECTION("Non-positive numbers are not prime")
+  {
+    CHECK(!is_prime(-1328));
+    CHECK(!is_prime(-1));
+    CHECK(!is_prime(0));
+  }
+
+  SECTION("1 is not prime")
+  {
+    CHECK(!is_prime(1));
+  }
+
+  SECTION("Discriminates between primes and non-primes")
+  {
+    CHECK(is_prime(2));
+    CHECK(is_prime(3));
+    CHECK(!is_prime(4));
+    CHECK(is_prime(5));
+    CHECK(!is_prime(6));
+    CHECK(is_prime(7));
+    CHECK(!is_prime(8));
+    CHECK(!is_prime(9));
+
+    CHECK(is_prime(7919));
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -28,175 +28,6 @@
 namespace units::mag
 {
 
-// Convenience utility to create an integral base power.  For unit tests only.
-template<std::intmax_t N, std::intmax_t Num, std::intmax_t Den>
-struct IntBasePower
-{
-  // This setup is more complicated than might appear necessary in the hopes of appeasing a
-  // (possibly spurious) MSVC 14 compiler error.
-  static constexpr std::intmax_t num = Num;
-  static constexpr std::intmax_t den = Den;
-  static constexpr ratio power = ratio{num, den};
-  using type = base_power<prime_base<N>, power>;
-};
-template<std::intmax_t N, std::intmax_t Num = 1, std::intmax_t Den = 1>
-using int_base_power = typename IntBasePower<N, Num, Den>::type;
-
-TEST_CASE("Magnitude is invertible")
-{
-  CHECK(std::is_same_v<inverse_t<magnitude<>>, magnitude<>>);
-  CHECK(std::is_same_v<
-      inverse_t<magnitude<int_base_power<2>>>, magnitude<int_base_power<2, -1>>>);
-  CHECK(std::is_same_v<
-      inverse_t<magnitude<int_base_power<3, 1, 2>, int_base_power<11, -5>>>,
-      magnitude<int_base_power<3, -1, 2>, int_base_power<11, 5>>>);
-}
-
-TEST_CASE("Magnitude supports products")
-{
-  SECTION ("The nullary product gives the unit magnitude") {
-    CHECK(std::is_same_v<product_t<>, magnitude<>>);
-  }
-
-  SECTION ("The unary product is the identity operation") {
-    CHECK(std::is_same_v<
-        product_t<magnitude<int_base_power<3, 4>>>,
-        magnitude<int_base_power<3, 4>>>);
-
-    CHECK(std::is_same_v<
-        product_t<magnitude<int_base_power<2, -1, 3>, int_base_power<13, -2>>>,
-        magnitude<int_base_power<2, -1, 3>, int_base_power<13, -2>>>);
-  }
-
-  SECTION ("Binary product with null magnitude is identity") {
-    using arbitrary_mag = magnitude<int_base_power<11, 3, 2>>;
-    CHECK(std::is_same_v<product_t<magnitude<>, magnitude<>>, magnitude<>>);
-    CHECK(std::is_same_v<product_t<arbitrary_mag, magnitude<>>, arbitrary_mag>);
-    CHECK(std::is_same_v<product_t<magnitude<>, arbitrary_mag>, arbitrary_mag>);
-  }
-
-  SECTION ("Binary product with distinct bases maintains sorted order") {
-    CHECK(std::is_same_v<
-        product_t<
-          magnitude<int_base_power<2, 1, 3>, int_base_power<7, -2>>,
-          magnitude<int_base_power<3>, int_base_power<5, 5>>>,
-        magnitude<
-          int_base_power<2, 1, 3>,
-          int_base_power<3>,
-          int_base_power<5, 5>,
-          int_base_power<7, -2>>>);
-  }
-
-  SECTION ("Binary products add exponents for same bases") {
-    CHECK(std::is_same_v<
-        product_t<
-          magnitude<int_base_power<2, 3>>,
-          magnitude<int_base_power<2, -5>>>,
-        magnitude<int_base_power<2, -2>>>);
-    CHECK(std::is_same_v<
-        product_t<
-          magnitude<int_base_power<2, 3>, int_base_power<3, -1, 3>>,
-          magnitude<int_base_power<2, -5>, int_base_power<5, 4>>>,
-        magnitude<int_base_power<2, -2>, int_base_power<3, -1, 3>, int_base_power<5, 4>>>);
-  }
-
-  SECTION ("Binary products omit bases whose exponents cancel") {
-    CHECK(std::is_same_v<
-        product_t<
-          magnitude<int_base_power<2, 1, 3>>, magnitude<int_base_power<2, -1, 3>>>,
-        magnitude<>>);
-    CHECK(std::is_same_v<
-        product_t<
-          magnitude<int_base_power<2, 1, 3>, int_base_power<7, -2>>,
-          magnitude<int_base_power<2, -1, 3>, int_base_power<5, 5>>>,
-        magnitude<int_base_power<5, 5>, int_base_power<7, -2>>>);
-    CHECK(std::is_same_v<
-        product_t<
-          magnitude<int_base_power<2, 1, 3>, int_base_power<3, -2>, int_base_power<7, -2>>,
-          magnitude<int_base_power<2, -1, 3>, int_base_power<5, 5>, int_base_power<7, 2>>>,
-        magnitude<int_base_power<3, -2>, int_base_power<5, 5>>>);
-  }
-
-  SECTION ("N-ary products recurse") {
-    CHECK(std::is_same_v<
-        product_t<
-          magnitude<int_base_power<2, 1, 3>>,
-          magnitude<int_base_power<2, 2, 3>>,
-          magnitude<int_base_power<3, -4>>,
-          magnitude<int_base_power<5>>,
-          magnitude<int_base_power<2, -1>>>,
-        magnitude<int_base_power<3, -4>, int_base_power<5>>>);
-  }
-}
-
-TEST_CASE("is_base_power detects well formed base powers")
-{
-  SECTION ("Arbitrary other types are not base powers")
-  {
-    CHECK(!is_base_power_v<void>);
-    CHECK(!is_base_power_v<int>);
-    CHECK(!is_base_power_v<magnitude<int_base_power<3, 1, 4>>>);
-  }
-
-  SECTION ("int_base_power forms base powers")
-  {
-    CHECK(is_base_power_v<int_base_power<2>>);
-    CHECK(is_base_power_v<int_base_power<2, -1>>);
-    CHECK(is_base_power_v<int_base_power<2, -1, 8>>);
-  }
-
-  SECTION ("base_power forms base powers with pi and ratio")
-  {
-    CHECK(is_base_power_v<base_power<pi>>);
-    CHECK(is_base_power_v<base_power<pi, ratio{2}>>);
-    CHECK(is_base_power_v<base_power<pi, ratio{-2, 3}>>);
-  }
-
-  SECTION ("base_power disqualified by base without value")
-  {
-    CHECK(!is_base_power_v<base_power<int>>);
-    CHECK(!is_base_power_v<base_power<int, ratio{2}>>);
-    CHECK(!is_base_power_v<base_power<int, ratio{-2, 3}>>);
-  }
-}
-
-TEST_CASE("is_magnitude detects well formed magnitudes")
-{
-  SECTION ("Arbitrary other types are not magnitudes")
-  {
-    CHECK(!is_magnitude_v<void>);
-    CHECK(!is_magnitude_v<int>);
-    CHECK(!is_magnitude_v<int_base_power<3, 1, 4>>);
-  }
-
-  SECTION ("Null magnitude is magnitude")
-  {
-    CHECK(is_magnitude_v<magnitude<>>);
-  }
-
-  SECTION ("Single-base magnitude is magnitude")
-  {
-    CHECK(is_magnitude_v<magnitude<int_base_power<3, 1, 4>>>);
-  }
-
-  SECTION ("Out-of-order bases disqualify magnitudes")
-  {
-    CHECK(!is_magnitude_v<magnitude<int_base_power<3>, int_base_power<2>>>);
-  }
-
-  SECTION ("Repeated bases disqualify magnitudes")
-  {
-    CHECK(!is_magnitude_v<magnitude<int_base_power<2, 1>, int_base_power<2, 2>>>);
-  }
-
-  SECTION ("Mixed base types are magnitudes if sorted")
-  {
-    CHECK(is_magnitude_v<magnitude<int_base_power<2>, base_power<pi>>>);
-    CHECK(is_magnitude_v<magnitude<int_base_power<3>, base_power<pi>>>);
-    CHECK(!is_magnitude_v<magnitude<int_base_power<5>, base_power<pi>>>);
-  }
-}
-
 TEST_CASE("strictly_increasing")
 {
   SECTION ("Empty tuple is sorted")
@@ -219,66 +50,52 @@ TEST_CASE("strictly_increasing")
   }
 }
 
-TEST_CASE("make_ratio performs prime factorization correctly")
-{
-  SECTION("Performs prime factorization when denominator is 1")
-  {
-    CHECK(std::is_same_v<decltype(make_ratio<1>()), magnitude<>>);
-    CHECK(std::is_same_v<decltype(make_ratio<2>()), magnitude<int_base_power<2>>>);
-    CHECK(std::is_same_v<decltype(make_ratio<3>()), magnitude<int_base_power<3>>>);
-    CHECK(std::is_same_v<decltype(make_ratio<4>()), magnitude<int_base_power<2, 2>>>);
+// TEST_CASE("make_ratio performs prime factorization correctly")
+// {
+//   SECTION("Performs prime factorization when denominator is 1")
+//   {
+//     CHECK(std::is_same_v<decltype(make_ratio<1>()), magnitude<>>);
+//     CHECK(std::is_same_v<decltype(make_ratio<2>()), magnitude<base_power{2}>>);
+//     CHECK(std::is_same_v<decltype(make_ratio<3>()), magnitude<base_power{3}>>);
+//     CHECK(std::is_same_v<decltype(make_ratio<4>()), magnitude<base_power{2, 2}>>);
+// 
+//     CHECK(std::is_same_v<
+//         decltype(make_ratio<792>()),
+//         magnitude<base_power{2, 3}, base_power{3, 2}, base_power{11}>>);
+//   }
+// 
+//   SECTION("Reduces fractions to lowest terms")
+//   {
+//     CHECK(std::is_same_v<decltype(make_ratio<8, 8>()), magnitude<>>);
+//     CHECK(std::is_same_v<
+//         decltype(make_ratio<50, 80>()), magnitude<base_power{2, -3}, base_power{5}>>);
+//   }
+// }
 
-    CHECK(std::is_same_v<
-        decltype(make_ratio<792>()),
-        magnitude<int_base_power<2, 3>, int_base_power<3, 2>, int_base_power<11>>>);
-  }
+// TEST_CASE("Equality works for magnitudes")
+// {
+//   SECTION("Equivalent ratios are equal")
+//   {
+//     CHECK(make_ratio<1>() == make_ratio<1>());
+//     CHECK(make_ratio<3>() == make_ratio<3>());
+//     CHECK(make_ratio<3, 4>() == make_ratio<9, 12>());
+//   }
+// 
+//   SECTION("Different ratios are unequal")
+//   {
+//     CHECK(make_ratio<3>() != make_ratio<5>());
+//     CHECK(make_ratio<3>() != make_ratio<3, 2>());
+//   }
+// 
+//   SECTION("Supports constexpr")
+//   {
+//     constexpr auto eq = (make_ratio<4, 5>() == make_ratio<4, 3>());
+//     CHECK(!eq);
+//   }
+// }
 
-  SECTION("Reduces fractions to lowest terms")
-  {
-    CHECK(std::is_same_v<decltype(make_ratio<8, 8>()), magnitude<>>);
-    CHECK(std::is_same_v<
-        decltype(make_ratio<50, 80>()),
-        magnitude<int_base_power<2, -3>, int_base_power<5>>>);
-  }
-}
-
-TEST_CASE("make_magnitude handles arbitrary bases")
-{
-  SECTION("Equivalent to std::integral_constant for integer bases")
-  {
-    CHECK(make_base_power<prime_base<2>>() == make_ratio<2>());
-    CHECK(make_base_power<prime_base<7>>() == make_ratio<7>());
-  }
-
-  SECTION("Handles non-integer bases")
-  {
-    CHECK(make_base_power<pi>() == magnitude<base_power<pi>>{});
-    CHECK(make_base_power<pi, -3>() == magnitude<base_power<pi, ratio{-3}>>{});
-    CHECK(make_base_power<pi, -3, 7>() == magnitude<base_power<pi, ratio{-3, 7}>>{});
-  }
-}
-
-TEST_CASE("Equality works for magnitudes")
-{
-  SECTION("Equivalent ratios are equal")
-  {
-    CHECK(make_ratio<1>() == make_ratio<1>());
-    CHECK(make_ratio<3>() == make_ratio<3>());
-    CHECK(make_ratio<3, 4>() == make_ratio<9, 12>());
-  }
-
-  SECTION("Different ratios are unequal")
-  {
-    CHECK(make_ratio<3>() != make_ratio<5>());
-    CHECK(make_ratio<3>() != make_ratio<3, 2>());
-  }
-
-  SECTION("Supports constexpr")
-  {
-    constexpr auto eq = make_ratio<4, 5>() == make_ratio<4, 3>();
-    CHECK(!eq);
-  }
-}
+template<double x>
+using double_v = 2 * x;
 
 TEST_CASE("Multiplication works for magnitudes")
 {
@@ -290,15 +107,15 @@ TEST_CASE("Multiplication works for magnitudes")
   SECTION("Products work as expected")
   {
     CHECK(make_ratio<4, 5>() * make_ratio<4, 3>() == make_ratio<16, 15>());
+    CHECK(double_v<1.5> == 3.0);
   }
 
-  SECTION("Products handle pi correctly")
-  {
-    CHECK(
-        make_base_power<pi>() * make_ratio<2, 3>() * make_base_power<pi, -1, 2>() ==
-        magnitude<int_base_power<2>, int_base_power<3, -1>, base_power<pi, ratio{1, 2}>>{});
-
-  }
+  //SECTION("Products handle pi correctly")
+  //{
+  //   CHECK(
+  //       pi_to_the<1>() * make_ratio<2, 3>() * pi_to_the<ratio{-1, 2}>() ==
+  //       magnitude<base_power{2}, base_power{3, -1}, pi_power<ratio{1, 2}>()>{});
+  //}
 
   SECTION("Supports constexpr")
   {
@@ -334,25 +151,24 @@ TEST_CASE("Prime factorization")
 {
   SECTION ("1 factors into the null magnitude")
   {
-    CHECK(std::is_same_v<prime_factorization_t<1>, magnitude<>>);
+    CHECK(prime_factorization_v<1> == magnitude<>{});
   }
 
   SECTION ("Prime numbers factor into themselves")
   {
-    CHECK(std::is_same_v<prime_factorization_t<2>, magnitude<int_base_power<2>>>);
-    CHECK(std::is_same_v<prime_factorization_t<3>, magnitude<int_base_power<3>>>);
-    CHECK(std::is_same_v<prime_factorization_t<5>, magnitude<int_base_power<5>>>);
-    CHECK(std::is_same_v<prime_factorization_t<7>, magnitude<int_base_power<7>>>);
-    CHECK(std::is_same_v<prime_factorization_t<11>, magnitude<int_base_power<11>>>);
+    CHECK(prime_factorization_v<2> == magnitude<base_power{2}>{});
+    CHECK(prime_factorization_v<3> == magnitude<base_power{3}>{});
+    CHECK(prime_factorization_v<5> == magnitude<base_power{5}>{});
+    CHECK(prime_factorization_v<7> == magnitude<base_power{7}>{});
+    CHECK(prime_factorization_v<11> == magnitude<base_power{11}>{});
 
-    CHECK(std::is_same_v<prime_factorization_t<41>, magnitude<int_base_power<41>>>);
+    CHECK(prime_factorization_v<41> == magnitude<base_power{41}>{});
   }
 
   SECTION("Prime factorization finds factors and multiplicities")
   {
-    CHECK(std::is_same_v<
-        prime_factorization_t<792>,
-        magnitude<int_base_power<2, 3>, int_base_power<3, 2>, int_base_power<11>>>);
+    CHECK(prime_factorization_v<792> ==
+          magnitude<base_power{2, 3}, base_power{3, 2}, base_power{11}>{});
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -34,6 +34,9 @@ struct other_noncanonical_two_base { static constexpr long double value = 2.0L; 
 struct invalid_zero_base { static constexpr long double value = 0.0L; };
 struct invalid_negative_base { static constexpr long double value = -1.234L; };
 
+template<ratio Power>
+constexpr auto pi_to_the() { return magnitude<base_power<pi_base>{Power}>{}; }
+
 TEST_CASE("base_power")
 {
   SECTION("base rep deducible for integral base")

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -115,6 +115,43 @@ TEST_CASE("Magnitude supports products")
   }
 }
 
+TEST_CASE("is_base_power detects well formed base powers")
+{
+  SECTION ("Arbitrary other types are not base powers")
+  {
+    CHECK(!is_base_power_v<void>);
+    CHECK(!is_base_power_v<int>);
+    CHECK(!is_base_power_v<magnitude<int_base_power<3, 1, 4>>>);
+  }
+
+  SECTION ("int_base_power forms base powers")
+  {
+    CHECK(is_base_power_v<int_base_power<2>>);
+    CHECK(is_base_power_v<int_base_power<2, -1>>);
+    CHECK(is_base_power_v<int_base_power<2, -1, 8>>);
+  }
+
+  SECTION ("base_power forms base powers with pi and ratio")
+  {
+    CHECK(is_base_power_v<base_power<pi>>);
+    CHECK(is_base_power_v<base_power<pi, ratio{2}>>);
+    CHECK(is_base_power_v<base_power<pi, ratio{-2, 3}>>);
+  }
+
+  SECTION ("base_power disqualified by negative or zero base")
+  {
+    CHECK(!is_base_power_v<int_base_power<0>>);
+    CHECK(!is_base_power_v<int_base_power<-1>>);
+  }
+
+  SECTION ("base_power disqualified by base without value")
+  {
+    CHECK(!is_base_power_v<base_power<int>>);
+    CHECK(!is_base_power_v<base_power<int, ratio{2}>>);
+    CHECK(!is_base_power_v<base_power<int, ratio{-2, 3}>>);
+  }
+}
+
 TEST_CASE("is_magnitude detects well formed magnitudes")
 {
   SECTION ("Arbitrary other types are not magnitudes")

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -86,12 +86,19 @@ TEST_CASE("base_power")
   SECTION("product with inverse equals identity")
   {
     auto check_product_with_inverse_is_identity = [] (auto x) {
-      CHECK(x * inverse(x) == as_magnitude<1>());
+      CHECK(x * pow<-1>(x) == as_magnitude<1>());
     };
 
     check_product_with_inverse_is_identity(as_magnitude<3>());
     check_product_with_inverse_is_identity(as_magnitude<ratio{4, 17}>());
     check_product_with_inverse_is_identity(pi_to_the<ratio{-22, 7}>());
+  }
+
+  SECTION("pow() multiplies exponent")
+  {
+    CHECK(pow<0>(base_power{2}) == base_power{2, 0});
+    CHECK(pow<ratio{-1, 2}>(base_power{2, 3}) == base_power{2, ratio{-3, 2}});
+    CHECK(pow<ratio{1, 3}>(base_power<pi_base>{ratio{3, 2}}) == base_power<pi_base>{ratio{1, 2}});
   }
 }
 
@@ -110,6 +117,13 @@ TEST_CASE("make_ratio performs prime factorization correctly")
   SECTION("Supports fractions")
   {
     CHECK(as_magnitude<ratio{5, 8}>() == magnitude<base_power{2, -3}, base_power{5}>{});
+  }
+
+  SECTION("Supports nonzero exp")
+  {
+    constexpr ratio r{3, 1, 2};
+    REQUIRE(r.exp == 2);
+    CHECK(as_magnitude<r>() == as_magnitude<300>());
   }
 }
 
@@ -195,6 +209,10 @@ TEST_CASE("Can raise Magnitudes to rational powers")
     CHECK(pow<1>(as_magnitude<123>()) == as_magnitude<123>());
     CHECK(pow<1>(as_magnitude<ratio{3, 4}>()) == as_magnitude<ratio{3, 4}>());
     CHECK(pow<1>(pi_to_the<ratio{-1, 2}>()) == pi_to_the<ratio{-1, 2}>());
+  }
+
+  SECTION("Can raise to arbitrary rational power") {
+    CHECK(pow<ratio{-8, 3}>(pi_to_the<ratio{-1, 2}>()) == pi_to_the<ratio{4, 3}>());
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -115,6 +115,65 @@ TEST_CASE("Magnitude supports products")
   }
 }
 
+TEST_CASE("is_magnitude detects well formed magnitudes")
+{
+  SECTION ("Arbitrary other types are not magnitudes")
+  {
+    CHECK(!is_magnitude_v<void>);
+    CHECK(!is_magnitude_v<int>);
+    CHECK(!is_magnitude_v<int_base_power<3, 1, 4>>);
+  }
+
+  SECTION ("Null magnitude is magnitude")
+  {
+    CHECK(is_magnitude_v<magnitude<>>);
+  }
+
+  SECTION ("Single-base magnitude is magnitude")
+  {
+    CHECK(is_magnitude_v<magnitude<int_base_power<3, 1, 4>>>);
+  }
+
+  SECTION ("Out-of-order bases disqualify magnitudes")
+  {
+    CHECK(!is_magnitude_v<magnitude<int_base_power<3>, int_base_power<2>>>);
+  }
+
+  SECTION ("Repeated bases disqualify magnitudes")
+  {
+    CHECK(!is_magnitude_v<magnitude<int_base_power<2, 1>, int_base_power<2, 2>>>);
+  }
+
+  SECTION ("Mixed base types are magnitudes if sorted")
+  {
+    CHECK(is_magnitude_v<magnitude<int_base_power<2>, base_power<pi>>>);
+    CHECK(is_magnitude_v<magnitude<int_base_power<3>, base_power<pi>>>);
+    CHECK(!is_magnitude_v<magnitude<int_base_power<5>, base_power<pi>>>);
+  }
+}
+
+TEST_CASE("strictly_increasing")
+{
+  SECTION ("Empty tuple is sorted")
+  {
+    CHECK(strictly_increasing(std::make_tuple()));
+  }
+
+  SECTION ("Single-element tuple is sorted")
+  {
+    CHECK(strictly_increasing(std::make_tuple(3)));
+    CHECK(strictly_increasing(std::make_tuple(15.42)));
+    CHECK(strictly_increasing(std::make_tuple('c')));
+  }
+
+  SECTION ("Multi-element tuples compare correctly")
+  {
+    CHECK(strictly_increasing(std::make_tuple(3, 3.14)));
+    CHECK(!strictly_increasing(std::make_tuple(3, 3.0)));
+    CHECK(!strictly_increasing(std::make_tuple(4, 3.0)));
+  }
+}
+
 // TEST_CASE("Ratio shortcut performs prime factorization")
 // {
 //   // CHECK(std::is_same_v<ratio<>, magnitude<>>);

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -245,12 +245,12 @@ TEST_CASE("Prime helper functions")
 
 TEST_CASE("Prime factorization")
 {
-  SECTION ("1 factors into the null magnitude")
+  SECTION("1 factors into the null magnitude")
   {
     CHECK(prime_factorization_v<1> == magnitude<>{});
   }
 
-  SECTION ("Prime numbers factor into themselves")
+  SECTION("Prime numbers factor into themselves")
   {
     CHECK(prime_factorization_v<2> == magnitude<base_power{2}>{});
     CHECK(prime_factorization_v<3> == magnitude<base_power{3}>{});
@@ -353,19 +353,19 @@ TEST_CASE("pairwise_all evaluates all pairs")
 
 TEST_CASE("strictly_increasing")
 {
-  SECTION ("Empty input is sorted")
+  SECTION("Empty input is sorted")
   {
     CHECK(strictly_increasing());
   }
 
-  SECTION ("Single-element input is sorted")
+  SECTION("Single-element input is sorted")
   {
     CHECK(strictly_increasing(3));
     CHECK(strictly_increasing(15.42));
     CHECK(strictly_increasing('c'));
   }
 
-  SECTION ("Multi-value inputs compare correctly")
+  SECTION("Multi-value inputs compare correctly")
   {
     CHECK(strictly_increasing(3, 3.14));
     CHECK(!strictly_increasing(3, 3.0));

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -374,6 +374,30 @@ TEST_CASE("is_prime detects primes")
   }
 }
 
+TEST_CASE("pairwise_all evaluates all pairs")
+{
+  SECTION("always true for empty tuples")
+  {
+    CHECK(pairwise_all(std::make_tuple(), [](auto a, auto b){ return true; }));
+    CHECK(pairwise_all(std::make_tuple(), [](auto a, auto b){ return false; }));
+  }
+
+  SECTION("always true for single-element tuples")
+  {
+    CHECK(pairwise_all(std::make_tuple(1), [](auto a, auto b){ return true; }));
+    CHECK(pairwise_all(std::make_tuple(3.14), [](auto a, auto b){ return false; }));
+    CHECK(pairwise_all(std::make_tuple('x'), [](auto a, auto b){ return true; }));
+  }
+
+  SECTION("true for longer tuples iff true for all neighbouring pairs")
+  {
+    CHECK(pairwise_all(std::make_tuple(1, 1.5), std::less{}));
+    CHECK(pairwise_all(std::make_tuple(1, 1.5, 2), std::less{}));
+    CHECK(!pairwise_all(std::make_tuple(1, 2.0, 2), std::less{}));
+    CHECK(!pairwise_all(std::make_tuple(1, 2.5, 2), std::less{}));
+  }
+}
+
 } // namespace detail
 
 } // namespace units::mag

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -25,8 +25,7 @@
 #include <catch2/catch.hpp>
 #include <type_traits>
 
-namespace units::mag
-{
+namespace units {
 
 // A set of non-standard bases for testing purposes.
 struct noninteger_base { static constexpr long double value = 1.234L; };
@@ -216,8 +215,7 @@ TEST_CASE("Can raise Magnitudes to rational powers")
   }
 }
 
-namespace detail
-{
+namespace detail {
 
 TEST_CASE("Prime helper functions")
 {
@@ -375,4 +373,4 @@ TEST_CASE("strictly_increasing")
 
 } // namespace detail
 
-} // namespace units::mag
+} // namespace units

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -28,8 +28,19 @@
 namespace units::mag
 {
 
+// Convenience utility to create an integral base power.  For unit tests only.
+template<std::intmax_t N, std::intmax_t Num, std::intmax_t Den>
+struct IntBasePower
+{
+  // This setup is more complicated than might appear necessary in the hopes of appeasing a
+  // (possibly spurious) MSVC 14 compiler error.
+  static constexpr std::intmax_t num = Num;
+  static constexpr std::intmax_t den = Den;
+  static constexpr ratio power = ratio{num, den};
+  using type = base_power<prime_base<N>, power>;
+};
 template<std::intmax_t N, std::intmax_t Num = 1, std::intmax_t Den = 1>
-using int_base_power = base_power<prime_base<N>, ratio{Num, Den}>;
+using int_base_power = typename IntBasePower<N, Num, Den>::type;
 
 TEST_CASE("Magnitude is invertible")
 {

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -30,23 +30,23 @@ namespace units::mag
 
 TEST_CASE("strictly_increasing")
 {
-  SECTION ("Empty tuple is sorted")
+  SECTION ("Empty input is sorted")
   {
-    CHECK(strictly_increasing(std::make_tuple()));
+    CHECK(strictly_increasing());
   }
 
-  SECTION ("Single-element tuple is sorted")
+  SECTION ("Single-element input is sorted")
   {
-    CHECK(strictly_increasing(std::make_tuple(3)));
-    CHECK(strictly_increasing(std::make_tuple(15.42)));
-    CHECK(strictly_increasing(std::make_tuple('c')));
+    CHECK(strictly_increasing(3));
+    CHECK(strictly_increasing(15.42));
+    CHECK(strictly_increasing('c'));
   }
 
-  SECTION ("Multi-element tuples compare correctly")
+  SECTION ("Multi-value inputs compare correctly")
   {
-    CHECK(strictly_increasing(std::make_tuple(3, 3.14)));
-    CHECK(!strictly_increasing(std::make_tuple(3, 3.0)));
-    CHECK(!strictly_increasing(std::make_tuple(4, 3.0)));
+    CHECK(strictly_increasing(3, 3.14));
+    CHECK(!strictly_increasing(3, 3.0));
+    CHECK(!strictly_increasing(4, 3.0));
   }
 }
 
@@ -94,9 +94,6 @@ TEST_CASE("strictly_increasing")
 //   }
 // }
 
-template<double x>
-using double_v = 2 * x;
-
 TEST_CASE("Multiplication works for magnitudes")
 {
   SECTION("Reciprocals reduce to null magnitude")
@@ -107,7 +104,6 @@ TEST_CASE("Multiplication works for magnitudes")
   SECTION("Products work as expected")
   {
     CHECK(make_ratio<4, 5>() * make_ratio<4, 3>() == make_ratio<16, 15>());
-    CHECK(double_v<1.5> == 3.0);
   }
 
   //SECTION("Products handle pi correctly")
@@ -205,23 +201,23 @@ TEST_CASE("pairwise_all evaluates all pairs")
 {
   SECTION("always true for empty tuples")
   {
-    CHECK(pairwise_all(std::make_tuple(), [](auto, auto){ return true; }));
-    CHECK(pairwise_all(std::make_tuple(), [](auto, auto){ return false; }));
+    CHECK(pairwise_all{[](auto, auto){ return true; }}());
+    CHECK(pairwise_all{[](auto, auto){ return false; }}());
   }
 
   SECTION("always true for single-element tuples")
   {
-    CHECK(pairwise_all(std::make_tuple(1), [](auto, auto){ return true; }));
-    CHECK(pairwise_all(std::make_tuple(3.14), [](auto, auto){ return false; }));
-    CHECK(pairwise_all(std::make_tuple('x'), [](auto, auto){ return true; }));
+    CHECK(pairwise_all{[](auto, auto){ return true; }}(1));
+    CHECK(pairwise_all{[](auto, auto){ return false; }}(3.14));
+    CHECK(pairwise_all{[](auto, auto){ return true; }}('x'));
   }
 
   SECTION("true for longer tuples iff true for all neighbouring pairs")
   {
-    CHECK(pairwise_all(std::make_tuple(1, 1.5), std::less{}));
-    CHECK(pairwise_all(std::make_tuple(1, 1.5, 2), std::less{}));
-    CHECK(!pairwise_all(std::make_tuple(1, 2.0, 2), std::less{}));
-    CHECK(!pairwise_all(std::make_tuple(1, 2.5, 2), std::less{}));
+    CHECK(pairwise_all{std::less{}}(1, 1.5));
+    CHECK(pairwise_all{std::less{}}(1, 1.5, 2));
+    CHECK(!pairwise_all{std::less{}}(1, 2.0, 2));
+    CHECK(!pairwise_all{std::less{}}(1, 2.5, 2));
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -50,49 +50,46 @@ TEST_CASE("strictly_increasing")
   }
 }
 
-// TEST_CASE("make_ratio performs prime factorization correctly")
-// {
-//   SECTION("Performs prime factorization when denominator is 1")
-//   {
-//     CHECK(std::is_same_v<decltype(make_ratio<1>()), magnitude<>>);
-//     CHECK(std::is_same_v<decltype(make_ratio<2>()), magnitude<base_power{2}>>);
-//     CHECK(std::is_same_v<decltype(make_ratio<3>()), magnitude<base_power{3}>>);
-//     CHECK(std::is_same_v<decltype(make_ratio<4>()), magnitude<base_power{2, 2}>>);
-// 
-//     CHECK(std::is_same_v<
-//         decltype(make_ratio<792>()),
-//         magnitude<base_power{2, 3}, base_power{3, 2}, base_power{11}>>);
-//   }
-// 
-//   SECTION("Reduces fractions to lowest terms")
-//   {
-//     CHECK(std::is_same_v<decltype(make_ratio<8, 8>()), magnitude<>>);
-//     CHECK(std::is_same_v<
-//         decltype(make_ratio<50, 80>()), magnitude<base_power{2, -3}, base_power{5}>>);
-//   }
-// }
+TEST_CASE("make_ratio performs prime factorization correctly")
+{
+  SECTION("Performs prime factorization when denominator is 1")
+  {
+    CHECK(make_ratio<1>() == magnitude<>{});
+    CHECK(make_ratio<2>() == magnitude<base_power{2}>{});
+    CHECK(make_ratio<3>() == magnitude<base_power{3}>{});
+    CHECK(make_ratio<4>() == magnitude<base_power{2, 2}>{});
 
-// TEST_CASE("Equality works for magnitudes")
-// {
-//   SECTION("Equivalent ratios are equal")
-//   {
-//     CHECK(make_ratio<1>() == make_ratio<1>());
-//     CHECK(make_ratio<3>() == make_ratio<3>());
-//     CHECK(make_ratio<3, 4>() == make_ratio<9, 12>());
-//   }
-// 
-//   SECTION("Different ratios are unequal")
-//   {
-//     CHECK(make_ratio<3>() != make_ratio<5>());
-//     CHECK(make_ratio<3>() != make_ratio<3, 2>());
-//   }
-// 
-//   SECTION("Supports constexpr")
-//   {
-//     constexpr auto eq = (make_ratio<4, 5>() == make_ratio<4, 3>());
-//     CHECK(!eq);
-//   }
-// }
+    CHECK(make_ratio<792>() == magnitude<base_power{2, 3}, base_power{3, 2}, base_power{11}>{});
+  }
+
+  SECTION("Reduces fractions to lowest terms")
+  {
+    CHECK(make_ratio<8, 8>() == magnitude<>{});
+    CHECK(make_ratio<50, 80>() == magnitude<base_power{2, -3}, base_power{5}>{});
+  }
+}
+
+TEST_CASE("Equality works for magnitudes")
+{
+  SECTION("Equivalent ratios are equal")
+  {
+    CHECK(make_ratio<1>() == make_ratio<1>());
+    CHECK(make_ratio<3>() == make_ratio<3>());
+    CHECK(make_ratio<3, 4>() == make_ratio<9, 12>());
+  }
+
+  SECTION("Different ratios are unequal")
+  {
+    CHECK(make_ratio<3>() != make_ratio<5>());
+    CHECK(make_ratio<3>() != make_ratio<3, 2>());
+  }
+
+  SECTION("Supports constexpr")
+  {
+    constexpr auto eq = (make_ratio<4, 5>() == make_ratio<4, 3>());
+    CHECK(!eq);
+  }
+}
 
 TEST_CASE("Multiplication works for magnitudes")
 {
@@ -106,12 +103,12 @@ TEST_CASE("Multiplication works for magnitudes")
     CHECK(make_ratio<4, 5>() * make_ratio<4, 3>() == make_ratio<16, 15>());
   }
 
-  //SECTION("Products handle pi correctly")
-  //{
-  //   CHECK(
-  //       pi_to_the<1>() * make_ratio<2, 3>() * pi_to_the<ratio{-1, 2}>() ==
-  //       magnitude<base_power{2}, base_power{3, -1}, pi_power<ratio{1, 2}>()>{});
-  //}
+  SECTION("Products handle pi correctly")
+  {
+     CHECK(
+         pi_to_the<1>() * make_ratio<2, 3>() * pi_to_the<ratio{-1, 2}>() ==
+         magnitude<base_power{2}, base_power{3, -1}, base_power<pi_base>{ratio{1, 2}}>{});
+  }
 
   SECTION("Supports constexpr")
   {

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -1,0 +1,130 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2018 Mateusz Pusz
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <units/magnitude.h>
+#include <units/ratio.h>
+#include <catch2/catch.hpp>
+#include <type_traits>
+
+using namespace units;
+using namespace units::mag;
+
+TEST_CASE("Magnitude is invertible")
+{
+  CHECK(std::is_same_v<inverse_t<magnitude<>>, magnitude<>>);
+  CHECK(std::is_same_v<
+      inverse_t<magnitude<int_base_power<2>>>, magnitude<int_base_power<2, -1>>>);
+  CHECK(std::is_same_v<
+      inverse_t<magnitude<int_base_power<3, 1, 2>, int_base_power<11, -5>>>,
+      magnitude<int_base_power<3, -1, 2>, int_base_power<11, 5>>>);
+}
+
+TEST_CASE("Magnitude supports products")
+{
+  SECTION ("The nullary product gives the unit magnitude") {
+    CHECK(std::is_same_v<product_t<>, magnitude<>>);
+  }
+
+  SECTION ("The unary product is the identity operation") {
+    CHECK(std::is_same_v<
+        product_t<magnitude<int_base_power<3, 4>>>,
+        magnitude<int_base_power<3, 4>>>);
+
+    CHECK(std::is_same_v<
+        product_t<magnitude<int_base_power<2, -1, 3>, int_base_power<13, -2>>>,
+        magnitude<int_base_power<2, -1, 3>, int_base_power<13, -2>>>);
+  }
+
+  SECTION ("Binary product with null magnitude is identity") {
+    using arbitrary_mag = magnitude<int_base_power<11, 3, 2>>;
+    CHECK(std::is_same_v<product_t<magnitude<>, magnitude<>>, magnitude<>>);
+    CHECK(std::is_same_v<product_t<arbitrary_mag, magnitude<>>, arbitrary_mag>);
+    CHECK(std::is_same_v<product_t<magnitude<>, arbitrary_mag>, arbitrary_mag>);
+  }
+
+  SECTION ("Binary product with distinct bases maintains sorted order") {
+    CHECK(std::is_same_v<
+        product_t<
+          magnitude<int_base_power<2, 1, 3>, int_base_power<7, -2>>,
+          magnitude<int_base_power<3>, int_base_power<5, 5>>>,
+        magnitude<
+          int_base_power<2, 1, 3>,
+          int_base_power<3>,
+          int_base_power<5, 5>,
+          int_base_power<7, -2>>>);
+  }
+
+  SECTION ("Binary products add exponents for same bases") {
+    CHECK(std::is_same_v<
+        product_t<
+          magnitude<int_base_power<2, 3>>,
+          magnitude<int_base_power<2, -5>>>,
+        magnitude<int_base_power<2, -2>>>);
+    CHECK(std::is_same_v<
+        product_t<
+          magnitude<int_base_power<2, 3>, int_base_power<3, -1, 3>>,
+          magnitude<int_base_power<2, -5>, int_base_power<5, 4>>>,
+        magnitude<int_base_power<2, -2>, int_base_power<3, -1, 3>, int_base_power<5, 4>>>);
+  }
+
+  SECTION ("Binary products omit bases whose exponents cancel") {
+    CHECK(std::is_same_v<
+        product_t<
+          magnitude<int_base_power<2, 1, 3>>, magnitude<int_base_power<2, -1, 3>>>,
+        magnitude<>>);
+    CHECK(std::is_same_v<
+        product_t<
+          magnitude<int_base_power<2, 1, 3>, int_base_power<7, -2>>,
+          magnitude<int_base_power<2, -1, 3>, int_base_power<5, 5>>>,
+        magnitude<int_base_power<5, 5>, int_base_power<7, -2>>>);
+    CHECK(std::is_same_v<
+        product_t<
+          magnitude<int_base_power<2, 1, 3>, int_base_power<3, -2>, int_base_power<7, -2>>,
+          magnitude<int_base_power<2, -1, 3>, int_base_power<5, 5>, int_base_power<7, 2>>>,
+        magnitude<int_base_power<3, -2>, int_base_power<5, 5>>>);
+  }
+
+  SECTION ("N-ary products recurse") {
+    CHECK(std::is_same_v<
+        product_t<
+          magnitude<int_base_power<2, 1, 3>>,
+          magnitude<int_base_power<2, 2, 3>>,
+          magnitude<int_base_power<3, -4>>,
+          magnitude<int_base_power<5>>,
+          magnitude<int_base_power<2, -1>>>,
+        magnitude<int_base_power<3, -4>, int_base_power<5>>>);
+  }
+}
+
+// TEST_CASE("Ratio shortcut performs prime factorization")
+// {
+//   // CHECK(std::is_same_v<ratio<>, magnitude<>>);
+//   // CHECK(std::is_same_v<ratio<2>, magnitude<int_base_power<2>>>);
+// }
+// 
+// TEST_CASE("Equality works for ratios")
+// {
+//   CHECK(ratio<>{} == ratio<>{});
+//   CHECK(ratio<3>{} == ratio<3>{});
+// 
+//   // CHECK(ratio<3>{} != ratio<4>{});
+// }

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -32,18 +32,17 @@ TEST_CASE("make_ratio performs prime factorization correctly")
 {
   SECTION("Performs prime factorization when denominator is 1")
   {
-    CHECK(make_ratio<1>() == magnitude<>{});
-    CHECK(make_ratio<2>() == magnitude<base_power{2}>{});
-    CHECK(make_ratio<3>() == magnitude<base_power{3}>{});
-    CHECK(make_ratio<4>() == magnitude<base_power{2, 2}>{});
+    CHECK(as_magnitude<1>() == magnitude<>{});
+    CHECK(as_magnitude<2>() == magnitude<base_power{2}>{});
+    CHECK(as_magnitude<3>() == magnitude<base_power{3}>{});
+    CHECK(as_magnitude<4>() == magnitude<base_power{2, 2}>{});
 
-    CHECK(make_ratio<792>() == magnitude<base_power{2, 3}, base_power{3, 2}, base_power{11}>{});
+    CHECK(as_magnitude<792>() == magnitude<base_power{2, 3}, base_power{3, 2}, base_power{11}>{});
   }
 
-  SECTION("Reduces fractions to lowest terms")
+  SECTION("Supports fractions")
   {
-    CHECK(make_ratio<8, 8>() == magnitude<>{});
-    CHECK(make_ratio<50, 80>() == magnitude<base_power{2, -3}, base_power{5}>{});
+    CHECK(as_magnitude<ratio{5, 8}>() == magnitude<base_power{2, -3}, base_power{5}>{});
   }
 }
 
@@ -51,20 +50,20 @@ TEST_CASE("Equality works for magnitudes")
 {
   SECTION("Equivalent ratios are equal")
   {
-    CHECK(make_ratio<1>() == make_ratio<1>());
-    CHECK(make_ratio<3>() == make_ratio<3>());
-    CHECK(make_ratio<3, 4>() == make_ratio<9, 12>());
+    CHECK(as_magnitude<1>() == as_magnitude<1>());
+    CHECK(as_magnitude<3>() == as_magnitude<3>());
+    CHECK(as_magnitude<ratio{3, 4}>() == as_magnitude<ratio{9, 12}>());
   }
 
   SECTION("Different ratios are unequal")
   {
-    CHECK(make_ratio<3>() != make_ratio<5>());
-    CHECK(make_ratio<3>() != make_ratio<3, 2>());
+    CHECK(as_magnitude<3>() != as_magnitude<5>());
+    CHECK(as_magnitude<3>() != as_magnitude<ratio{3, 2}>());
   }
 
   SECTION("Supports constexpr")
   {
-    constexpr auto eq = (make_ratio<4, 5>() == make_ratio<4, 3>());
+    constexpr auto eq = (as_magnitude<ratio{4, 5}>() == as_magnitude<ratio{4, 3}>());
     CHECK(!eq);
   }
 }
@@ -73,25 +72,25 @@ TEST_CASE("Multiplication works for magnitudes")
 {
   SECTION("Reciprocals reduce to null magnitude")
   {
-    CHECK(make_ratio<3, 4>() * make_ratio<4, 3>() == make_ratio<1>());
+    CHECK(as_magnitude<ratio{3, 4}>() * as_magnitude<ratio{4, 3}>() == as_magnitude<1>());
   }
 
   SECTION("Products work as expected")
   {
-    CHECK(make_ratio<4, 5>() * make_ratio<4, 3>() == make_ratio<16, 15>());
+    CHECK(as_magnitude<ratio{4, 5}>() * as_magnitude<ratio{4, 3}>() == as_magnitude<ratio{16, 15}>());
   }
 
   SECTION("Products handle pi correctly")
   {
      CHECK(
-         pi_to_the<1>() * make_ratio<2, 3>() * pi_to_the<ratio{-1, 2}>() ==
+         pi_to_the<1>() * as_magnitude<ratio{2, 3}>() * pi_to_the<ratio{-1, 2}>() ==
          magnitude<base_power{2}, base_power{3, -1}, base_power<pi_base>{ratio{1, 2}}>{});
   }
 
   SECTION("Supports constexpr")
   {
-    constexpr auto p = make_ratio<4, 5>() * make_ratio<4, 3>();
-    CHECK(p == make_ratio<16, 15>());
+    constexpr auto p = as_magnitude<ratio{4, 5}>() * as_magnitude<ratio{4, 3}>();
+    CHECK(p == as_magnitude<ratio{16, 15}>());
   }
 }
 
@@ -99,19 +98,19 @@ TEST_CASE("Division works for magnitudes")
 {
   SECTION("Dividing anything by itself reduces to null magnitude")
   {
-    CHECK(make_ratio<3, 4>() / make_ratio<3, 4>() == make_ratio<1>());
-    CHECK(make_ratio<15>() / make_ratio<15>() == make_ratio<1>());
+    CHECK(as_magnitude<ratio{3, 4}>() / as_magnitude<ratio{3, 4}>() == as_magnitude<1>());
+    CHECK(as_magnitude<15>() / as_magnitude<15>() == as_magnitude<1>());
   }
 
   SECTION("Quotients work as expected")
   {
-    CHECK(make_ratio<4, 5>() / make_ratio<4, 3>() == make_ratio<3, 5>());
+    CHECK(as_magnitude<ratio{4, 5}>() / as_magnitude<ratio{4, 3}>() == as_magnitude<ratio{3, 5}>());
   }
 
   SECTION("Supports constexpr")
   {
-    constexpr auto q = make_ratio<4, 5>() / make_ratio<4, 3>();
-    CHECK(q == make_ratio<3, 5>());
+    constexpr auto q = as_magnitude<ratio{4, 5}>() / as_magnitude<ratio{4, 3}>();
+    CHECK(q == as_magnitude<ratio{3, 5}>());
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -248,6 +248,51 @@ TEST_CASE("Equality works for magnitudes")
     CHECK(make_ratio<3>() != make_ratio<5>());
     CHECK(make_ratio<3>() != make_ratio<3, 2>());
   }
+
+  SECTION("Supports constexpr")
+  {
+    constexpr auto eq = make_ratio<4, 5>() == make_ratio<4, 3>();
+    CHECK(!eq);
+  }
+}
+
+TEST_CASE("Multiplication works for magnitudes")
+{
+  SECTION("Reciprocals reduce to null magnitude")
+  {
+    CHECK(make_ratio<3, 4>() * make_ratio<4, 3>() == make_ratio<1>());
+  }
+
+  SECTION("Products work as expected")
+  {
+    CHECK(make_ratio<4, 5>() * make_ratio<4, 3>() == make_ratio<16, 15>());
+  }
+
+  SECTION("Supports constexpr")
+  {
+    constexpr auto p = make_ratio<4, 5>() * make_ratio<4, 3>();
+    CHECK(p == make_ratio<16, 15>());
+  }
+}
+
+TEST_CASE("Division works for magnitudes")
+{
+  SECTION("Dividing anything by itself reduces to null magnitude")
+  {
+    CHECK(make_ratio<3, 4>() / make_ratio<3, 4>() == make_ratio<1>());
+    CHECK(make_ratio<15>() / make_ratio<15>() == make_ratio<1>());
+  }
+
+  SECTION("Quotients work as expected")
+  {
+    CHECK(make_ratio<4, 5>() / make_ratio<4, 3>() == make_ratio<3, 5>());
+  }
+
+  SECTION("Supports constexpr")
+  {
+    constexpr auto q = make_ratio<4, 5>() / make_ratio<4, 3>();
+    CHECK(q == make_ratio<3, 5>());
+  }
 }
 
 namespace detail

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -181,6 +181,23 @@ TEST_CASE("Division works for magnitudes")
   }
 }
 
+TEST_CASE("Can raise Magnitudes to rational powers")
+{
+  SECTION("Anything to the 0 is 1") {
+    CHECK(pow<0>(as_magnitude<1>()) == as_magnitude<1>());
+    CHECK(pow<0>(as_magnitude<123>()) == as_magnitude<1>());
+    CHECK(pow<0>(as_magnitude<ratio{3, 4}>()) == as_magnitude<1>());
+    CHECK(pow<0>(pi_to_the<ratio{-1, 2}>()) == as_magnitude<1>());
+  }
+
+  SECTION("Anything to the 1 is itself") {
+    CHECK(pow<1>(as_magnitude<1>()) == as_magnitude<1>());
+    CHECK(pow<1>(as_magnitude<123>()) == as_magnitude<123>());
+    CHECK(pow<1>(as_magnitude<ratio{3, 4}>()) == as_magnitude<ratio{3, 4}>());
+    CHECK(pow<1>(pi_to_the<ratio{-1, 2}>()) == pi_to_the<ratio{-1, 2}>());
+  }
+}
+
 namespace detail
 {
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -28,28 +28,6 @@
 namespace units::mag
 {
 
-TEST_CASE("strictly_increasing")
-{
-  SECTION ("Empty input is sorted")
-  {
-    CHECK(strictly_increasing());
-  }
-
-  SECTION ("Single-element input is sorted")
-  {
-    CHECK(strictly_increasing(3));
-    CHECK(strictly_increasing(15.42));
-    CHECK(strictly_increasing('c'));
-  }
-
-  SECTION ("Multi-value inputs compare correctly")
-  {
-    CHECK(strictly_increasing(3, 3.14));
-    CHECK(!strictly_increasing(3, 3.0));
-    CHECK(!strictly_increasing(4, 3.0));
-  }
-}
-
 TEST_CASE("make_ratio performs prime factorization correctly")
 {
   SECTION("Performs prime factorization when denominator is 1")
@@ -215,6 +193,28 @@ TEST_CASE("pairwise_all evaluates all pairs")
     CHECK(pairwise_all{std::less{}}(1, 1.5, 2));
     CHECK(!pairwise_all{std::less{}}(1, 2.0, 2));
     CHECK(!pairwise_all{std::less{}}(1, 2.5, 2));
+  }
+}
+
+TEST_CASE("strictly_increasing")
+{
+  SECTION ("Empty input is sorted")
+  {
+    CHECK(strictly_increasing());
+  }
+
+  SECTION ("Single-element input is sorted")
+  {
+    CHECK(strictly_increasing(3));
+    CHECK(strictly_increasing(15.42));
+    CHECK(strictly_increasing('c'));
+  }
+
+  SECTION ("Multi-value inputs compare correctly")
+  {
+    CHECK(strictly_increasing(3, 3.14));
+    CHECK(!strictly_increasing(3, 3.0));
+    CHECK(!strictly_increasing(4, 3.0));
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -234,6 +234,22 @@ TEST_CASE("make_ratio performs prime factorization correctly")
   }
 }
 
+TEST_CASE("make_magnitude handles arbitrary bases")
+{
+  SECTION("Equivalent to std::integral_constant for integer bases")
+  {
+    CHECK(make_base_power<int_base<2>>() == make_ratio<2>());
+    CHECK(make_base_power<int_base<7>>() == make_ratio<7>());
+  }
+
+  SECTION("Handles non-integer bases")
+  {
+    CHECK(make_base_power<pi>() == magnitude<base_power<pi>>{});
+    CHECK(make_base_power<pi, -3>() == magnitude<base_power<pi, ratio{-3}>>{});
+    CHECK(make_base_power<pi, -3, 7>() == magnitude<base_power<pi, ratio{-3, 7}>>{});
+  }
+}
+
 TEST_CASE("Equality works for magnitudes")
 {
   SECTION("Equivalent ratios are equal")
@@ -266,6 +282,14 @@ TEST_CASE("Multiplication works for magnitudes")
   SECTION("Products work as expected")
   {
     CHECK(make_ratio<4, 5>() * make_ratio<4, 3>() == make_ratio<16, 15>());
+  }
+
+  SECTION("Products handle pi correctly")
+  {
+    CHECK(
+        make_base_power<pi>() * make_ratio<2, 3>() * make_base_power<pi, -1, 2>() ==
+        magnitude<int_base_power<2>, int_base_power<3, -1>, base_power<pi, ratio{1, 2}>>{});
+
   }
 
   SECTION("Supports constexpr")

--- a/test/unit_test/static/ratio_test.cpp
+++ b/test/unit_test/static/ratio_test.cpp
@@ -40,6 +40,13 @@ static_assert(ratio(4) * ratio(1, 2) == ratio(2));
 static_assert(ratio(1, 8) * ratio(2) == ratio(1, 4));
 static_assert(ratio(1, 2) * ratio(8) == ratio(4));
 
+// ratio negation
+static_assert(-ratio(3, 8) == ratio(-3, 8));
+
+// ratio addition
+static_assert(ratio(1, 2) + ratio(1, 3) == ratio(5, 6));
+static_assert(ratio(1, 3, 2) + ratio(11, 6) == ratio(211, 6)); // 100/3 + 11/6
+
 // multiply with exponents
 static_assert(ratio(1, 8, 2) * ratio(2, 1, 4) == ratio(1, 4, 6));
 static_assert(ratio(1, 2, -4) * ratio(8, 1, 3) == ratio(4, 1, -1));


### PR DESCRIPTION
This is the beginning of the implementation for #300, laying the first foundations.  This seems like a good point to check in and align on direction before we get too far along.  For general context:

_Things we include here:_
- Concepts for `Magnitude`, and `BasePower` (a Magnitude is made up of a canonicalized parameter pack of BasePowers).
- End user interfaces for making magnitudes:
  - `as_magnitude<ratio>()`: the main way to make a Magnitude from a rational number.  This handles the "heavy lifting" of converting to a prime factorization.
  - `base_power<T>{ratio}`: we handle irrational bases by introducing a type `T`, with a static `long double` member `value` which must be positive.
- Enhanced `ratio` functionality: addition, negation, and implicit construction.

_Work yet undone:_
- A mechanism for _applying_ a magnitude to a given value.  (We'll probably want to break out the rational and irrational parts separately, so we can give exact results as often as possible.  We'll also want to think carefully about what types we use in intermediate computations---for example, not everyone will want to use `long double`, and even `double` can be problematic for some embedded applications.)
- Actually migrating existing uses to use Magnitude instead of ratio.

Once we get to something that looks like the right direction, I can flesh out these other items.