### PR TITLE
Fix derived_ratio calculation

### DIFF
--- a/src/core/include/units/bits/derived_unit.h
+++ b/src/core/include/units/bits/derived_unit.h
@@ -47,7 +47,7 @@ constexpr ratio inverse_if_negative(const ratio& r)
 template<Unit... Us, typename... Es>
 constexpr ratio derived_ratio(exponent_list<Es...>)
 {
-  return (... * inverse_if_negative<Es>(pow<detail::abs(Es::num)>(Us::ratio) / dimension_unit<typename Es::dimension>::ratio));
+  return (... * inverse_if_negative<Es>(pow<detail::abs(Es::num)>(Us::ratio / dimension_unit<typename Es::dimension>::ratio)));
 }
 
 template<DerivedDimension D, Unit... Us>

--- a/test/unit_test/static/fps_test.cpp
+++ b/test/unit_test/static/fps_test.cpp
@@ -59,6 +59,10 @@ static_assert(100_q_ft2 / 10_q_ft == 10_q_ft);
 
 static_assert(detail::unit_text<dim_area, square_foot>() == basic_symbol_text("ft²", "ft^2"));
 
+// volume
+static_assert(1_q_yd * 1_q_yd * 1_q_yd == 1_q_yd3);
+static_assert(cubic_yard::ratio / cubic_foot::ratio == ratio(27));
+
 /* ************** DERIVED DIMENSIONS WITH NAMED UNITS **************** */
 
 // acceleration


### PR DESCRIPTION
Fixes cases such as fps::cubic_yard where the ratio was incorrectly scaled.