### PR TITLE
Support seamless interop between `ratio` and rational `Magnitude`

### DIFF
--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -517,16 +517,14 @@ constexpr auto numerator(magnitude<BPs...>)
 
 constexpr auto denominator(Magnitude auto m) { return numerator(pow<-1>(m)); }
 
-// Implementation of implicit conversion to ratio goes here, because it needs `numerator()` and `denominator()`.
-template<BasePower auto... BPs>
-  requires detail::is_base_power_pack_valid<BPs...>
-constexpr magnitude<BPs...>::operator ratio() const
+// Implementation of conversion to ratio goes here, because it needs `numerator()` and `denominator()`.
+constexpr ratio as_ratio(Magnitude auto m)
 {
-  static_assert(is_rational(magnitude<BPs...>{}));
+  static_assert(is_rational(m));
 
   return ratio{
-    get_value<std::intmax_t>(numerator(*this)),
-    get_value<std::intmax_t>(denominator(*this)),
+    get_value<std::intmax_t>(numerator(m)),
+    get_value<std::intmax_t>(denominator(m)),
   };
 }
 

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -519,6 +519,7 @@ constexpr auto denominator(Magnitude auto m) { return numerator(pow<-1>(m)); }
 
 // Implementation of implicit conversion to ratio goes here, because it needs `numerator()` and `denominator()`.
 template<BasePower auto... BPs>
+  requires detail::is_base_power_pack_valid<BPs...>
 constexpr magnitude<BPs...>::operator ratio() const
 {
   static_assert(is_rational(magnitude<BPs...>{}));

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -368,9 +368,6 @@ struct magnitude {
 
   // Whether this magnitude represents a rational number.
   friend constexpr bool is_rational(const magnitude&) { return (detail::is_rational(BPs) && ...); }
-
-  // Implicit conversion to ratio.
-  constexpr explicit(false) operator ratio() const;
 };
 
 // Implementation for Magnitude concept (below).
@@ -395,7 +392,7 @@ template<typename T, BasePower auto... BPs>
 constexpr T get_value(const magnitude<BPs...>&)
 {
   // Force the expression to be evaluated in a constexpr context, to catch, e.g., overflow.
-  constexpr auto result = detail::checked_static_cast<T>((detail::compute_base_power<T>(BPs) * ... * 1));
+  constexpr auto result = detail::checked_static_cast<T>((detail::compute_base_power<T>(BPs) * ... * T{1}));
 
   return result;
 }

--- a/src/core/include/units/magnitude.h
+++ b/src/core/include/units/magnitude.h
@@ -493,7 +493,7 @@ constexpr auto integer_part(magnitude<BP>)
   constexpr auto power_den = denominator(BP.power);
 
   if constexpr (std::is_integral_v<decltype(BP.get_base())> && (power_num >= power_den)) {
-    constexpr auto largest_integer_power = [power_num, power_den](BasePower auto bp) {
+    constexpr auto largest_integer_power = [=](BasePower auto bp) {
       bp.power = (power_num / power_den);  // Note: integer division intended.
       return bp;
     }(BP);  // Note: lambda is immediately invoked.
@@ -516,9 +516,8 @@ constexpr auto denominator(Magnitude auto m) { return numerator(pow<-1>(m)); }
 
 // Implementation of conversion to ratio goes here, because it needs `numerator()` and `denominator()`.
 constexpr ratio as_ratio(Magnitude auto m)
+  requires(is_rational(decltype(m){}))
 {
-  static_assert(is_rational(m));
-
   return ratio{
     get_value<std::intmax_t>(numerator(m)),
     get_value<std::intmax_t>(denominator(m)),

--- a/src/core/include/units/ratio.h
+++ b/src/core/include/units/ratio.h
@@ -87,7 +87,26 @@ struct ratio {
   }
 
   [[nodiscard]] friend constexpr ratio operator/(const ratio& lhs, const ratio& rhs) { return lhs * inverse(rhs); }
+
+  [[nodiscard]] friend constexpr std::intmax_t numerator(const ratio& r)
+  {
+    std::intmax_t num = r.num;
+    for (auto i = r.exp; i > 0; --i) {
+      num *= 10;
+    }
+    return num;
+  }
+
+  [[nodiscard]] friend constexpr std::intmax_t denominator(const ratio& r)
+  {
+    std::intmax_t den = r.den;
+    for (auto i = r.exp; i < 0; ++i) {
+      den *= 10;
+    }
+    return den;
+  }
 };
+
 
 [[nodiscard]] constexpr ratio inverse(const ratio& r) { return ratio(r.den, r.num, -r.exp); }
 

--- a/src/core/include/units/ratio.h
+++ b/src/core/include/units/ratio.h
@@ -90,23 +90,22 @@ struct ratio {
 
   [[nodiscard]] friend constexpr std::intmax_t numerator(const ratio& r)
   {
-    std::intmax_t num = r.num;
+    std::intmax_t true_num = r.num;
     for (auto i = r.exp; i > 0; --i) {
-      num *= 10;
+      true_num *= 10;
     }
-    return num;
+    return true_num;
   }
 
   [[nodiscard]] friend constexpr std::intmax_t denominator(const ratio& r)
   {
-    std::intmax_t den = r.den;
+    std::intmax_t true_den = r.den;
     for (auto i = r.exp; i < 0; ++i) {
-      den *= 10;
+      true_den *= 10;
     }
-    return den;
+    return true_den;
   }
 };
-
 
 [[nodiscard]] constexpr ratio inverse(const ratio& r) { return ratio(r.den, r.num, -r.exp); }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -168,15 +168,6 @@ TEST_CASE("make_ratio performs prime factorization correctly")
     as_magnitude<ratio(16'605'390'666'050, 10'000'000'000'000)>();
   }
 
-  SECTION("Can handle prime number which would exceed GCC iteration limit")
-  {
-    // GCC 10 has a constexpr loop iteration limit of 262144.  A naive algorithm, which performs trial division on 2 and
-    // all odd numbers up to sqrt(N), will exceed this limit for the following prime.  Thus, for this test to pass, we
-    // need to be using a more efficient algorithm.  (We could increase the limit, but we don't want users to have to
-    // mess with compiler flags just to compile the code.)
-    as_magnitude<334'524'384'739>();
-  }
-
   SECTION("Can bypass computing primes by providing known_first_factor<N>")
   {
     // Sometimes, even wheel factorization isn't enough to handle the compilers' limits on constexpr steps and/or

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -383,12 +383,10 @@ TEST_CASE("Constructing ratio from rational magnitude")
   SECTION("Irrational magnitude does not convert to ratio")
   {
     // The following code should not compile.
-    // constexpr ratio radical = pow<ratio{1, 2}>(as_magnitude<2>());
-    // (void)radical;
+    // as_ratio(pow<ratio{1, 2}>(as_magnitude<2>()));
 
     // The following code should not compile.
-    // constexpr ratio degrees_per_radian = as_magnitude<180>() / pi_to_the<1>();
-    // (void)degrees_per_radian;
+    // as_ratio(as_magnitude<180>() / pi_to_the<1>());
   }
 }
 

--- a/test/unit_test/runtime/magnitude_test.cpp
+++ b/test/unit_test/runtime/magnitude_test.cpp
@@ -374,9 +374,9 @@ TEST_CASE("Constructing ratio from rational magnitude")
     check_ratio_round_trip_is_identity<ratio{5, 8}>();
   }
 
-  SECTION("Rational magnitude implicitly converts to ratio")
+  SECTION("Rational magnitude converts to ratio")
   {
-    constexpr ratio r = as_magnitude<ratio{22, 7}>();
+    constexpr ratio r = as_ratio(as_magnitude<ratio{22, 7}>());
     CHECK(r == ratio{22, 7});
   }
 

--- a/test/unit_test/static/ratio_test.cpp
+++ b/test/unit_test/static/ratio_test.cpp
@@ -102,4 +102,10 @@ static_assert(common_ratio(ratio(100, 1), ratio(1, 10)) == ratio(1, 10));
 static_assert(common_ratio(ratio(1), ratio(1, 1, 3)) == ratio(1));
 static_assert(common_ratio(ratio(10, 1, -1), ratio(1, 1, -3)) == ratio(1, 1, -3));
 
+// numerator and denominator
+static_assert(numerator(ratio(3, 4)) == 3);
+static_assert(numerator(ratio(3, 7, 2)) == 300);
+static_assert(denominator(ratio(3, 4)) == 4);
+static_assert(denominator(ratio(3, 7, -2)) == 700);
+
 }  // namespace


### PR DESCRIPTION
We provide two new functions, `numerator(m)` and `denominator(m)`, for a
Magnitude `m`.  They fulfill the following conditions:

1. `numerator(m)` and `denominator(m)` are always integer Magnitudes.
2. If `m` is rational, then `m == numerator(m) / denominator(m)`.

If `m` is _not_ rational, then the numerator and denominator are not
especially meaningful (there is no uniquely defined "leftover irrational
part").  However, we choose a convention that matches how humans would
write a mixed number.  For example, sqrt(27/16) would have a numerator
of 3, denominator of 4, and a "leftover part" of sqrt(3), matching the
"human" way of writing this as [(3 * sqrt(3)) / 4].  This has no use
yet, but it may later be useful in printing the Magnitude of an
anonymous Unit for end users.

To further reduce friction for the upcoming migration, we provide a
conversion from a Magnitude to a `ratio`.  We restrict this operation to
rational Magnitudes, and guard this with a `static_assert`.