### PR TITLE
fix: constraint recursion for gcc11 on operator/

### DIFF
--- a/src/core/include/units/quantity.h
+++ b/src/core/include/units/quantity.h
@@ -392,8 +392,8 @@ public:
     return ret(v * q.number());
   }
 
-  template<typename Value>
-    requires(!Quantity<Value>) && (invoke_result_convertible_to_<rep, std::divides<>, rep, const Value&>)
+  template<Representation Value>
+    requires(invoke_result_convertible_to_<rep, std::divides<>, rep, const Value&>)
   [[nodiscard]] friend constexpr Quantity auto operator/(const quantity& q, const Value& v)
   {
     gsl_ExpectsAudit(v != quantity_values<Value>::zero());
@@ -401,8 +401,8 @@ public:
     return ret(q.number() / v);
   }
 
-  template<typename Value>
-    requires(!Quantity<Value>) && (invoke_result_convertible_to_<rep, std::divides<>, const Value&, rep>)
+  template<Representation Value>
+    requires(invoke_result_convertible_to_<rep, std::divides<>, const Value&, rep>)
   [[nodiscard]] friend constexpr Quantity auto operator/(const Value& v, const quantity& q)
   {
     return detail::make_quantity<::units::reference<dim_one, ::units::one>{} / reference>(v / q.number());


### PR DESCRIPTION
A similar fix was applied in 417f84258523d2e5f868cf080b7b837328edd501 for the operator*.

Following discussion in https://github.com/mpusz/units/issues/398, it seems appropriate to apply it for operator/.

Other operators (+, -, %) do not seem to suffer from the same problem.