### PR TITLE
build: add options to disable part of the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,16 +62,20 @@ endif()
 # add project code
 add_subdirectory(src)
 
-# add usage example
-add_subdirectory(example)
+option(${projectPrefix}BUILD_EXAMPLES "Build examples" ON)
+if(${projectPrefix}BUILD_EXAMPLES)
+    # add usage example
+    add_subdirectory(example)
+endif()
 
 # generate project documentation
 add_subdirectory(docs)
 
-# add unit tests
 enable_testing()
-add_subdirectory(test)
-
-# tests for standalone headers
-include(TestPublicHeaders)
-add_public_header_test(test_headers mp-units::mp-units)
+if(BUILD_TESTING)
+    # add unit tests
+    add_subdirectory(test)
+    # tests for standalone headers
+    include(TestPublicHeaders)
+    add_public_header_test(test_headers mp-units::mp-units)
+endif()


### PR DESCRIPTION
Part of the build is not always useful. Make it possible only to deploy the source without testing.

We are currently using mpunit inside yocto system, and at the moment we need an extra patch to remove docs and tests. Having those options could clean up the way the recipe is built. We have to maintain a patch instead of specifying CMake options.

Do not change the current behaviour and keep the option to ON as default.