### PR TITLE
Pre-commit autoupdate and enable clang-format

### DIFF
--- a/.github/workflows/ci-check.yml
+++ b/.github/workflows/ci-check.yml
@@ -28,9 +28,9 @@ jobs:
   check:
     runs-on: ubuntu-20.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,13 +1,17 @@
 default_stages: [commit]
 
 repos:
+  - repo: meta
+    hooks:
+      - id: check-hooks-apply
+      - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  # - repo: https://github.com/pocc/pre-commit-hooks
-  #   rev: v1.3.5
+  # - repo: https://github.com/pre-commit/mirrors-clang-format
+  #   rev: v15.0.4
   #   hooks:
   #     - id: clang-format
   - repo: https://github.com/cheshirekow/cmake-format-precommit
@@ -19,7 +23,7 @@ repos:
       #   additional_dependencies: ["cmakelang"]
       #   exclude: "cmake/.*"
   - repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
       - id: black
         language_version: python3
@@ -29,6 +33,6 @@ repos:
       - id: isort
         args: [--profile, black, --multi-line, "3"]
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,10 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
-  # - repo: https://github.com/pre-commit/mirrors-clang-format
-  #   rev: v15.0.4
-  #   hooks:
-  #     - id: clang-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v15.0.4
+    hooks:
+      - id: clang-format
   - repo: https://github.com/cheshirekow/cmake-format-precommit
     rev: v0.6.13
     hooks:

--- a/example/include/validated_type.h
+++ b/example/include/validated_type.h
@@ -39,7 +39,7 @@ public:
 
   constexpr explicit validated_type(const T& value) noexcept(std::is_nothrow_copy_constructible_v<T>)
     requires std::copyable<T>
-  : value_(value)
+      : value_(value)
   {
     gsl_Expects(validate(value_));
   }
@@ -52,7 +52,7 @@ public:
 
   constexpr validated_type(const T& value, validated_tag) noexcept(std::is_nothrow_copy_constructible_v<T>)
     requires std::copyable<T>
-  : value_(value)
+      : value_(value)
   {
   }
 

--- a/src/core/include/units/bits/quantity_of.h
+++ b/src/core/include/units/bits/quantity_of.h
@@ -39,8 +39,8 @@ template<Exponent... Es, template<typename...> typename DimTemplate>
 inline constexpr bool same_exponents_of<unknown_dimension<Es...>, DimTemplate> =
   requires {
     typename DimTemplate<unknown_dimension<Es...>, unknown_coherent_unit<Es...>, typename Es::dimension...>;
-  }&& std::same_as<exponent_list<Es...>, typename DimTemplate<unknown_dimension<Es...>, unknown_coherent_unit<Es...>,
-                                                              typename Es::dimension...>::recipe>;
+  } && std::same_as<exponent_list<Es...>, typename DimTemplate<unknown_dimension<Es...>, unknown_coherent_unit<Es...>,
+                                                               typename Es::dimension...>::recipe>;
 
 }  // namespace detail
 

--- a/src/core/include/units/quantity_point.h
+++ b/src/core/include/units/quantity_point.h
@@ -90,7 +90,7 @@ public:
   constexpr explicit quantity_point(const QP& qp)
     requires std::is_constructible_v<quantity_type, decltype(quantity_point_like_traits<QP>::relative(qp))> &&
              equivalent<origin, typename quantity_point_like_traits<QP>::origin>
-  : q_(quantity_point_like_traits<QP>::relative(qp))
+      : q_(quantity_point_like_traits<QP>::relative(qp))
   {
   }
 

--- a/test/unit_test/static/custom_rep_test_min_expl.cpp
+++ b/test/unit_test/static/custom_rep_test_min_expl.cpp
@@ -51,7 +51,7 @@ public:
   // construction from std::int64_t
   constexpr explicit min_expl(std::intmax_t v) noexcept
     requires(Mode != 2)
-  : value_(v)
+      : value_(v)
   {
   }
 

--- a/test/unit_test/static/fps_test.cpp
+++ b/test/unit_test/static/fps_test.cpp
@@ -100,7 +100,6 @@ static_assert(1_q_ft_pdl_per_s * 10_q_s == 10_q_ft_pdl);
 static_assert(10_q_ft_pdl / 1_q_ft_pdl_per_s == 10_q_s);
 
 static_assert(detail::unit_text<dim_power, foot_poundal_per_second>() == basic_symbol_text("ft⋅pdl/s", "ft pdl/s"));
-static_assert(detail::unit_text<dim_power, foot_pound_force_per_second>() ==
-              basic_symbol_text("ft⋅lbf/s", "ft lbf/s"));
+static_assert(detail::unit_text<dim_power, foot_pound_force_per_second>() == basic_symbol_text("ft⋅lbf/s", "ft lbf/s"));
 
 }  // namespace

--- a/test/unit_test/static/test_tools.h
+++ b/test/unit_test/static/test_tools.h
@@ -124,8 +124,12 @@ constexpr bool ctad_constructible_from(Vs...)
 }
 
 constexpr auto same = []<std::equality_comparable T>(T l, T r) { return l == r; };
-constexpr auto comp = // TODO: Fix #205 to use `std::equality_comparable_with<T> U`.
-  []<typename T, typename U>(T l, U r) requires compare<T, U> { return l == r; };
+constexpr auto comp =  // TODO: Fix #205 to use `std::equality_comparable_with<T> U`.
+  []<typename T, typename U>(T l, U r)
+  requires compare<T, U>
+{
+  return l == r;
+};
 
 template<auto F>
   requires requires { F(); }


### PR DESCRIPTION
I saw that clang format 15 was released as pre-commit hook. So with this one I am updating the existing hooks and enable clang format. Running it changed a few files.