### PR TITLE
Move the cachekey to using build information for identiciation.

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -166,11 +166,14 @@ jobs:
           cache-name: cache-conan-data
         with:
           path: ~/.conan/data
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/metadata.json') }}
+          key: build-${{ matrix.config.os }}-${{ matrix.build_type }}-${{ matrix.config.compiler.type }}-${{ matrix.config.compiler.version }}-${{ matrix.config.lib }}
           restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+            build-${{ matrix.config.os }}-${{ matrix.build_type }}-${{ matrix.config.compiler.type }}-${{ matrix.config.compiler.version }}-${{ matrix.config.lib }}
+            build-${{ matrix.config.os }}-${{ matrix.build_type }}-${{ matrix.config.compiler.type }}-${{ matrix.config.compiler.version }}-
+            build-${{ matrix.config.os }}-${{ matrix.build_type }}-${{ matrix.config.compiler.type }}-
+            build-${{ matrix.config.os }}-${{ matrix.build_type }}-
+            build-${{ matrix.config.os }}-
+                        
       - uses: hendrikmuhs/ccache-action@v1.2
         if: runner.os == 'Linux'
         with:


### PR DESCRIPTION
I'm raising this pull request based on the observation that the Conan cache is not working.  For example, during the "Create Conan Package" stage when `conan install` is run Catch2 and Fmt packaged are being built and are not found in the synced cache: https://github.com/mpusz/units/actions/runs/3841122699/jobs/6540977771

Although it might seem logical to assume that by pushing the conan data folder to the cache then eventually all build configuration would end up in it this does not appear to be what is happening.  It looks like the Conan cache is uploaded to `"${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/metadata.json') }}`.  However, I can't see any `metadata.json` in the build tree so this part drops off, resulting in a cache key such as `Linux-build-cache-conan-data`.  The first Linux build to finish uploads this folder.  When the next build completes, rather than adding to the cache its checks for its presence, see it exists and does not attempt to add to it (resulting in a subsequent cache miss for the next build of this configuration).

The solution I am proposing build the cache key out of the build configuration information to ensure key look-up is unique.  This will result in many smaller caches specific to a build configuration but should still use a similar overall memory profile (I say similar as each cache will have a copy of the source files, so will be slightly larger, but binaries were unique already so this aspect should not differ drastically).   