### PR TITLE
Update isort to work around build from source bug

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: black
         language_version: python3
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: [--profile, black, --multi-line, "3"]


### PR DESCRIPTION
A Poetry update broke isort: https://github.com/PyCQA/isort/issues/2077
The bug occurs when building from source, which is what pre-commit does. 
The latest version of isort fixes this issue.