### PR TITLE
Added support for use of units as subdirectory when *dependencies* are *also* subdirectories

### DIFF
--- a/src/core-fmt/CMakeLists.txt
+++ b/src/core-fmt/CMakeLists.txt
@@ -29,6 +29,8 @@ add_units_module(core-fmt DEPENDENCIES mp-units::core HEADERS include/units/form
 target_compile_definitions(mp-units-core-fmt INTERFACE ${projectPrefix}USE_LIBFMT=$<BOOL:${${projectPrefix}USE_LIBFMT}>)
 
 if(${projectPrefix}USE_LIBFMT)
-    find_package(fmt CONFIG REQUIRED)
+    if(NOT TARGET fmt::fmt)
+        find_package(fmt CONFIG REQUIRED)
+    endif()
     target_link_libraries(mp-units-core-fmt INTERFACE fmt::fmt)
 endif()

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -27,7 +27,9 @@ set(${projectPrefix}DOWNCAST_MODE ON CACHE STRING "Select downcasting mode")
 set_property(CACHE ${projectPrefix}DOWNCAST_MODE PROPERTY STRINGS AUTO ON OFF)
 
 # find dependencies
-find_package(gsl-lite CONFIG REQUIRED)
+if(NOT TARGET gsl::gsl-lite)
+    find_package(gsl-lite CONFIG REQUIRED)
+endif()
 
 # check if libc++ is being used
 include(CheckLibcxxInUse)
@@ -71,7 +73,9 @@ target_include_directories(
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     if(${projectPrefix}LIBCXX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS "14")
-        find_package(range-v3 CONFIG REQUIRED)
+        if(NOT TARGET range-v3::range-v3)
+            find_package(range-v3 CONFIG REQUIRED)
+        endif()
         target_link_libraries(mp-units-core INTERFACE range-v3::range-v3)
     endif()
 elseif(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")


### PR DESCRIPTION
Added check for gsl::gsl-lite to avoid find_package if targets already added by add_subdirectory(...) and did the same for fmt::fmt and ranges-v3, with out these changes, impossible to use library if dependencies are also subdirectories, complains about not being able to find package (when it no longer needs to)