### PR TITLE
Work around Windows macro

### DIFF
--- a/src/systems/si/include/mp-units/systems/si/units.h
+++ b/src/systems/si/include/mp-units/systems/si/units.h
@@ -45,7 +45,16 @@ inline constexpr struct radian : named_unit<"rad", metre / metre, kind_of<isq::a
 inline constexpr struct steradian : named_unit<"sr", square<metre> / square<metre>, kind_of<isq::solid_angular_measure>> {} steradian;
 inline constexpr struct hertz : named_unit<"Hz", 1 / second, kind_of<isq::frequency>> {} hertz; 
 inline constexpr struct newton : named_unit<"N", kilogram * metre / square<second>> {} newton;
+#ifdef pascal
+#pragma push_macro("pascal")
+#undef pascal
+#define UNITS_REDEFINE_PASCAL
+#endif
 inline constexpr struct pascal : named_unit<"Pa", newton / square<metre>> {} pascal;
+#ifdef UNITS_REDEFINE_PASCAL
+#pragma pop_macro("pascal")
+#undef UNITS_REDEFINE_PASCAL
+#endif
 inline constexpr struct joule : named_unit<"J", newton * metre> {} joule;
 inline constexpr struct watt : named_unit<"W", joule / second> {} watt;
 inline constexpr struct coulomb : named_unit<"C", ampere * second> {} coulomb;


### PR DESCRIPTION
MinGW defines `pascal`: https://sourceforge.net/p/mingw-w64/mingw-w64/ci/master/tree/mingw-w64-headers/include/minwindef.h
Same as the Windows SDK: https://github.com/tpn/winsdk-10/blob/master/Include/10.0.16299.0/shared/minwindef.h#L98

This at least protects the units header from that macro, users could still face the issue, but I don't think `#undef`ing the macro globally should be done in a library header.